### PR TITLE
fix: publish canonical daily JSON with Astro artifact

### DIFF
--- a/astro/package.json
+++ b/astro/package.json
@@ -8,7 +8,7 @@
 	},
 	"scripts": {
 		"dev": "astro dev",
-		"build": "astro build && tsx scripts/generate-redirects.ts && node scripts/build-legacy-compat.mjs && node scripts/generate-site-contract.mjs",
+		"build": "astro build && tsx scripts/publish-daily-data.ts && tsx scripts/generate-redirects.ts && node scripts/build-legacy-compat.mjs && node scripts/generate-site-contract.mjs",
 		"preview": "astro preview",
 		"astro": "astro",
 		"check": "astro check",

--- a/astro/route-ownership.json
+++ b/astro/route-ownership.json
@@ -5,6 +5,7 @@
 		"/en/",
 		"/daily/**",
 		"/en/daily/**",
+		"/data/daily/**",
 		"/search/**",
 		"/topics/**",
 		"/entities/**",

--- a/astro/scripts/publish-daily-data.ts
+++ b/astro/scripts/publish-daily-data.ts
@@ -1,0 +1,11 @@
+import { resolve } from 'node:path';
+
+import { publishDailyData } from '../src/lib/publishDailyData';
+
+const astroRoot = process.cwd();
+const names = await publishDailyData({
+	sourceDirectory: resolve(astroRoot, '..', 'data', 'daily'),
+	outputDirectory: resolve(astroRoot, 'dist', 'data', 'daily'),
+});
+
+console.log(`Published ${names.length} canonical structured daily JSON file(s).`);

--- a/astro/src/lib/publishDailyData.test.ts
+++ b/astro/src/lib/publishDailyData.test.ts
@@ -1,0 +1,52 @@
+import { mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { publishDailyData } from './publishDailyData';
+
+const temporaryRoots: string[] = [];
+
+async function directories(): Promise<{ sourceDirectory: string; outputDirectory: string }> {
+	const root = await mkdtemp(join(tmpdir(), 'bubble-publish-daily-'));
+	temporaryRoots.push(root);
+	const sourceDirectory = join(root, 'source');
+	const outputDirectory = join(root, 'dist', 'data', 'daily');
+	await mkdir(sourceDirectory, { recursive: true });
+	return { sourceDirectory, outputDirectory };
+}
+
+afterEach(async () => {
+	await Promise.all(
+		temporaryRoots.splice(0).map((root) => rm(root, { recursive: true, force: true })),
+	);
+});
+
+describe('daily JSON publisher', () => {
+	it('copies canonical reports without changing a byte', async () => {
+		const paths = await directories();
+		const source = '{\n  "date": "2026-07-16",\n  "value": "原始字节"\n}\n';
+		await writeFile(join(paths.sourceDirectory, '.gitkeep'), '');
+		await writeFile(join(paths.sourceDirectory, '2026-07-16.json'), source);
+
+		await expect(publishDailyData(paths)).resolves.toEqual(['2026-07-16.json']);
+		await expect(readFile(join(paths.outputDirectory, '2026-07-16.json'), 'utf8')).resolves.toBe(
+			source,
+		);
+	});
+
+	it('fails closed for malformed filenames and date mismatches', async () => {
+		const invalidName = await directories();
+		await writeFile(join(invalidName.sourceDirectory, 'latest.json'), '{}');
+		await expect(publishDailyData(invalidName)).rejects.toThrow(
+			'Invalid structured daily filename',
+		);
+
+		const invalidDate = await directories();
+		await writeFile(join(invalidDate.sourceDirectory, '2026-07-16.json'), '{"date":"2026-07-15"}');
+		await expect(publishDailyData(invalidDate)).rejects.toThrow(
+			'Structured daily date does not match',
+		);
+	});
+});

--- a/astro/src/lib/publishDailyData.ts
+++ b/astro/src/lib/publishDailyData.ts
@@ -1,0 +1,42 @@
+import { copyFile, mkdir, readFile, readdir, rm } from 'node:fs/promises';
+import { resolve } from 'node:path';
+
+const dateFilenamePattern = /^(\d{4}-\d{2}-\d{2})\.json$/;
+
+export async function publishDailyData(options: {
+	sourceDirectory: string;
+	outputDirectory: string;
+}): Promise<string[]> {
+	const sourceDirectory = resolve(options.sourceDirectory);
+	const outputDirectory = resolve(options.outputDirectory);
+	const names = await readdir(sourceDirectory);
+	const jsonNames = names.filter((name) => name.endsWith('.json')).sort();
+
+	for (const name of jsonNames) {
+		if (!dateFilenamePattern.test(name)) {
+			throw new Error(`Invalid structured daily filename: ${name}`);
+		}
+	}
+
+	await rm(outputDirectory, { recursive: true, force: true });
+	if (jsonNames.length === 0) return [];
+	await mkdir(outputDirectory, { recursive: true });
+
+	for (const name of jsonNames) {
+		const sourcePath = resolve(sourceDirectory, name);
+		const outputPath = resolve(outputDirectory, name);
+		const source = await readFile(sourcePath);
+		const report = JSON.parse(source.toString('utf8')) as { date?: unknown };
+		const expectedDate = dateFilenamePattern.exec(name)![1];
+		if (report.date !== expectedDate) {
+			throw new Error(`Structured daily date does not match its filename: ${name}`);
+		}
+		await copyFile(sourcePath, outputPath);
+		const output = await readFile(outputPath);
+		if (!source.equals(output)) {
+			throw new Error(`Structured daily JSON changed while publishing: ${name}`);
+		}
+	}
+
+	return jsonNames;
+}

--- a/docs/contracts/ASTRO_ROUTE_OWNERSHIP.md
+++ b/docs/contracts/ASTRO_ROUTE_OWNERSHIP.md
@@ -3,7 +3,8 @@
 Phase 4 uses an explicit build-time coexistence boundary. Cloudflare Pages publishes one artifact,
 `astro/dist`, while route ownership is split as follows:
 
-- Astro owns the homepage, both daily archives, every daily detail route, knowledge search,
+- Astro owns the homepage, both daily archives, every daily detail route, the canonical structured
+  daily JSON routes under `/data/daily/`, knowledge search,
   topic/entity routes, metadata feeds, sitemaps, robots, redirects, and the custom 404.
 - Hugo remains a build-time compatibility renderer for `about`, `ai-tools`, `curations`,
   `highlights`, `model-evals`, `my-publish`, `prompts`, and `x-trending`, including their English

--- a/scripts/verify-preview.mjs
+++ b/scripts/verify-preview.mjs
@@ -35,6 +35,7 @@ const localManifestPath =
   manifestPathArgument ??
   "astro/dist/release-manifests/site-route-manifest.json";
 const localManifestText = await readFile(localManifestPath, "utf8");
+const localDistRoot = resolve(dirname(resolve(localManifestPath)), "..");
 const localManifest = JSON.parse(localManifestText);
 const expectedSha = (
   expectedShaArgument ??
@@ -125,11 +126,7 @@ async function fetchManual(route, attempts = 3) {
         signal: AbortSignal.timeout(20_000),
         headers: { "user-agent": "bubble-preview-verifier/1.0" },
       });
-      if (
-        response.status !== 429 &&
-        response.status < 500
-      )
-        return response;
+      if (response.status !== 429 && response.status < 500) return response;
       if (attempt === attempts - 1) return response;
       await response.body?.cancel();
     } catch (error) {
@@ -241,6 +238,19 @@ async function verifyRecord(record) {
       ].includes(record.content_type)
     ) {
       await response.body?.cancel();
+      return;
+    }
+
+    if (/^\/data\/daily\/\d{4}-\d{2}-\d{2}\.json$/.test(record.route)) {
+      const deployedBytes = Buffer.from(await response.arrayBuffer());
+      const localBytes = await readFile(
+        resolve(localDistRoot, record.output_path),
+      );
+      invariant(
+        deployedBytes.equals(localBytes),
+        `${record.route}: deployed JSON bytes differ from the release artifact`,
+      );
+      JSON.parse(deployedBytes.toString("utf8"));
       return;
     }
 

--- a/scripts/verify-site.mjs
+++ b/scripts/verify-site.mjs
@@ -303,6 +303,37 @@ for (const route of requiredRoutes)
     `Missing required 200 route: ${route}`,
   );
 
+const dailyDataDirectory = resolve(repoRoot, "data", "daily");
+const dailyDataNames = (await readdir(dailyDataDirectory))
+  .filter((name) => /^\d{4}-\d{2}-\d{2}\.json$/.test(name))
+  .sort();
+const publishedDailyRecords = contract.records.filter(
+  (record) =>
+    record.status === 200 &&
+    /^\/data\/daily\/\d{4}-\d{2}-\d{2}\.json$/.test(record.route),
+);
+invariant(
+  publishedDailyRecords.length === dailyDataNames.length,
+  `Structured daily route count drifted (${publishedDailyRecords.length} routes for ${dailyDataNames.length} source files)`,
+);
+for (const name of dailyDataNames) {
+  const route = `/data/daily/${name}`;
+  const record = byRoute.get(route);
+  invariant(
+    record?.status === 200 &&
+      record.owner === "astro" &&
+      record.content_type === "application/json" &&
+      record.output_path === `data/daily/${name}`,
+    `Missing canonical structured daily route: ${route}`,
+  );
+  const source = await readFile(resolve(dailyDataDirectory, name));
+  const output = await readFile(resolve(distRoot, record.output_path));
+  invariant(
+    source.equals(output),
+    `Published structured daily JSON differs from its canonical source: ${route}`,
+  );
+}
+
 for (const [source, target] of [
   ["/index.xml", "/rss.xml"],
   ["/en/index.xml", "/en/rss.xml"],


### PR DESCRIPTION
## Summary

- publish each canonical `data/daily/*.json` file in the final Astro Pages artifact without changing bytes
- add `/data/daily/**` to route ownership and fail closed on source/artifact/route drift
- require Preview JSON bytes to match the locally verified release artifact

## Evidence

- `npm run verify --prefix astro` (45 tests, 594 routes)
- `npm test` (258 Worker tests)
- `npm run verify:renderers` (208 daily routes)
- source/dist JSON SHA-256: `e0e30a5e7218eaaca3f2e609488519c460e225ee023a86faa313ba56adca9d66`
- independent review: GO, no P0/P1

## Context

The first structured canary exposed a release-contract gap: the daily HTML was built, but the canonical structured JSON was absent from `astro/dist`, so Pages returned 404. This change closes that gap and adds regression gates.