### PR TITLE
fix: resolve structured daily data during Astro builds

### DIFF
--- a/astro/src/lib/searchIndex.ts
+++ b/astro/src/lib/searchIndex.ts
@@ -1,6 +1,4 @@
 import { readdir } from 'node:fs/promises';
-import { resolve } from 'node:path';
-import { fileURLToPath } from 'node:url';
 
 import {
 	canonicalTaxonomyRecord,
@@ -12,7 +10,11 @@ import {
 	type KnowledgeLocale,
 	type TaxonomyRecord,
 } from './knowledge';
-import { loadStructuredDailyReport, type StructuredDailyItem } from './structuredDaily';
+import {
+	dailyDataDirectory,
+	loadStructuredDailyReport,
+	type StructuredDailyItem,
+} from './structuredDaily';
 
 export interface KnowledgeSearchItem {
 	key: string;
@@ -38,10 +40,6 @@ export interface KnowledgeSearchIndex {
 	item_count: number;
 	report_dates: string[];
 	items: KnowledgeSearchItem[];
-}
-
-function defaultDailyDataDirectory(): string {
-	return fileURLToPath(new URL('../../../data/daily/', import.meta.url));
 }
 
 function itemHref(date: string, id: string): string {
@@ -102,7 +100,7 @@ export async function buildKnowledgeSearchIndex(
 		locale?: KnowledgeLocale;
 	} = {},
 ): Promise<KnowledgeSearchIndex> {
-	const directory = resolve(options.directory ?? defaultDailyDataDirectory());
+	const directory = dailyDataDirectory(options.directory);
 	const locale = options.locale ?? 'zh-CN';
 	let names: string[];
 	try {

--- a/astro/src/lib/structuredDaily.test.ts
+++ b/astro/src/lib/structuredDaily.test.ts
@@ -5,6 +5,7 @@ import { join, resolve } from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
 
 import {
+	dailyDataDirectory,
 	formatTimelineTime,
 	loadStructuredDailyReport,
 	type StructuredDailyItem,
@@ -34,6 +35,10 @@ afterEach(async () => {
 });
 
 describe('structured daily report loader', () => {
+	it('resolves the canonical repository data directory independently of module bundling', () => {
+		expect(dailyDataDirectory()).toBe(resolve(process.cwd(), '..', 'data', 'daily'));
+	});
+
 	it('loads a valid report and returns null when the date is absent', async () => {
 		const directory = await dataDirectory();
 		await writeFile(join(directory, '2026-07-14.json'), JSON.stringify(await fixture()));

--- a/astro/src/lib/structuredDaily.ts
+++ b/astro/src/lib/structuredDaily.ts
@@ -1,6 +1,5 @@
 import { readFile } from 'node:fs/promises';
 import { resolve } from 'node:path';
-import { fileURLToPath } from 'node:url';
 
 import { sanitizeSummaryText } from '../../../src/daily/summary.js';
 import {
@@ -63,10 +62,10 @@ export interface StructuredDailyReport {
 const reportCache = new Map<string, Promise<StructuredDailyReport | null>>();
 const dateKeyPattern = /^\d{4}-\d{2}-\d{2}$/;
 
-function dailyDataDirectory(directory?: string): string {
+export function dailyDataDirectory(directory?: string): string {
 	if (directory) return resolve(directory);
 	if (process.env.DAILY_DATA_DIR) return resolve(process.env.DAILY_DATA_DIR);
-	return fileURLToPath(new URL('../../../data/daily/', import.meta.url));
+	return resolve(process.cwd(), '..', 'data', 'daily');
 }
 
 async function readStructuredReport(

--- a/scripts/verify-site.mjs
+++ b/scripts/verify-site.mjs
@@ -316,6 +316,13 @@ invariant(
   publishedDailyRecords.length === dailyDataNames.length,
   `Structured daily route count drifted (${publishedDailyRecords.length} routes for ${dailyDataNames.length} source files)`,
 );
+const searchIndex = JSON.parse(
+  await readFile(resolve(distRoot, "search", "index.json"), "utf8"),
+);
+const expectedSearchDates = dailyDataNames.map((name) =>
+  name.slice(0, -".json".length),
+);
+let expectedSearchItemCount = 0;
 for (const name of dailyDataNames) {
   const route = `/data/daily/${name}`;
   const record = byRoute.get(route);
@@ -332,7 +339,59 @@ for (const name of dailyDataNames) {
     source.equals(output),
     `Published structured daily JSON differs from its canonical source: ${route}`,
   );
+  const report = JSON.parse(source.toString("utf8"));
+  const date = name.slice(0, -".json".length);
+  expectedSearchItemCount += report.items.length;
+  const searchItems = searchIndex.items.filter((item) => item.date === date);
+  const expectedSearchItems = new Map(
+    report.items.map((item) => [
+      `${date}:${item.id}`,
+      `/daily/${date.slice(0, 4)}/${date.slice(5, 7)}/${date}/#news-${item.id}`,
+    ]),
+  );
+  invariant(
+    searchIndex.report_dates.includes(date) &&
+      searchItems.length === report.items.length &&
+      expectedSearchItems.size === report.items.length,
+    `Structured daily search coverage drifted: ${date}`,
+  );
+  const seenSearchKeys = new Set();
+  for (const item of searchItems) {
+    invariant(
+      !seenSearchKeys.has(item.key) &&
+        expectedSearchItems.get(item.key) === item.href,
+      `Structured daily search item drifted: ${item.key}`,
+    );
+    seenSearchKeys.add(item.key);
+  }
+  invariant(
+    seenSearchKeys.size === expectedSearchItems.size &&
+      [...expectedSearchItems.keys()].every((key) => seenSearchKeys.has(key)),
+    `Structured daily search keys drifted: ${date}`,
+  );
+  const [year, month] = date.split("-");
+  const dailyHtml = await readFile(
+    resolve(distRoot, "daily", year, month, date, "index.html"),
+    "utf8",
+  );
+  for (const item of report.items) {
+    invariant(
+      dailyHtml.includes(`id="news-${item.id}"`),
+      `Structured daily item is missing from rendered HTML: ${date}:${item.id}`,
+    );
+  }
 }
+invariant(
+  new Set(searchIndex.report_dates).size === searchIndex.report_dates.length &&
+    searchIndex.report_dates.length === expectedSearchDates.length &&
+    expectedSearchDates.every((date) => searchIndex.report_dates.includes(date)),
+  "Structured daily search report dates drifted",
+);
+invariant(
+  searchIndex.item_count === expectedSearchItemCount &&
+    searchIndex.items.length === expectedSearchItemCount,
+  `Structured daily search item count drifted (${searchIndex.items.length} items for ${expectedSearchItemCount} canonical items)`,
+);
 
 for (const [source, target] of [
   ["/index.xml", "/rss.xml"],


### PR DESCRIPTION
## Summary

- resolve canonical daily JSON from the Astro build working directory instead of bundled module URLs
- reuse the resolver when generating the knowledge search index
- fail site verification when structured items, anchors, search keys, hrefs, dates, or counts drift

## Verification

- npm run verify --prefix astro
- npm test
- npm run verify:renderers
- git diff --check
- independent review: GO, no P0/P1/P2