### PR TITLE
fix: harden scheduled structured source failures

### DIFF
--- a/src/chatapi.js
+++ b/src/chatapi.js
@@ -9,7 +9,7 @@
  * @returns {Promise<string>} The generated text content.
  * @throws {Error} If GEMINI_API_URL is not set, or if API call fails or returns blocked/empty content.
  */
-async function callGeminiChatAPI(env, promptText, systemPromptText = null) {
+async function callGeminiChatAPI(env, promptText, systemPromptText = null, { signal } = {}) {
     if (!env.GEMINI_API_URL) {
         throw new Error("GEMINI_API_URL environment variable is not set.");
     }
@@ -35,7 +35,8 @@ async function callGeminiChatAPI(env, promptText, systemPromptText = null) {
         const response = await fetchWithTimeout(url, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify(payload)
+            body: JSON.stringify(payload),
+            signal,
         });
 
         if (!response.ok) {
@@ -306,7 +307,7 @@ async function* callGeminiChatAPIStream(env, promptText, systemPromptText = null
  * @returns {Promise<string>} The generated text content.
  * @throws {Error} If OPENAI_API_URL or OPENAI_API_KEY is not set, or if API call fails.
  */
-async function callOpenAIChatAPI(env, promptText, systemPromptText = null) {
+async function callOpenAIChatAPI(env, promptText, systemPromptText = null, { signal } = {}) {
     if (!env.OPENAI_API_URL) {
         throw new Error("OPENAI_API_URL environment variable is not set.");
     }
@@ -337,7 +338,8 @@ async function callOpenAIChatAPI(env, promptText, systemPromptText = null) {
                 'Content-Type': 'application/json',
                 'Authorization': `Bearer ${env.OPENAI_API_KEY}`
             },
-            body: JSON.stringify(payload)
+            body: JSON.stringify(payload),
+            signal,
         });
 
         if (!response.ok) {
@@ -532,12 +534,12 @@ async function* callOpenAIChatAPIStream(env, promptText, systemPromptText = null
  * @returns {Promise<string>} The generated text content.
  * @throws {Error} If API keys/URLs are not set, or if API call fails.
  */
-export async function callChatAPI(env, promptText, systemPromptText = null) {
+export async function callChatAPI(env, promptText, systemPromptText = null, options = {}) {
     const platform = env.USE_MODEL_PLATFORM;
     if (platform.startsWith("OPEN")) {
-        return callOpenAIChatAPI(env, promptText, systemPromptText);
+        return callOpenAIChatAPI(env, promptText, systemPromptText, options);
     } else { // Default to Gemini
-        return callGeminiChatAPI(env, promptText, systemPromptText);
+        return callGeminiChatAPI(env, promptText, systemPromptText, options);
     }
 }
 
@@ -570,7 +572,15 @@ export async function* callChatAPIStream(env, promptText, systemPromptText = nul
  */
 async function fetchWithTimeout(resource, options = {}, timeout = 60000) {
   const controller = new AbortController();
-  const id = setTimeout(() => controller.abort(), timeout);
+  const externalSignal = options.signal;
+  let timedOut = false;
+  const forwardAbort = () => controller.abort(externalSignal.reason);
+  if (externalSignal?.aborted) forwardAbort();
+  else externalSignal?.addEventListener('abort', forwardAbort, { once: true });
+  const id = setTimeout(() => {
+    timedOut = true;
+    controller.abort();
+  }, timeout);
 
   try {
     const response = await fetch(resource, {
@@ -580,7 +590,7 @@ async function fetchWithTimeout(resource, options = {}, timeout = 60000) {
     return response;
   } catch (error) {
     // 当 abort() 被调用时，fetch 会抛出一个 AbortError
-    if (error.name === 'AbortError') {
+    if (error.name === 'AbortError' && timedOut) {
       throw new Error('Request timed out');
     }
     // 其他网络错误等
@@ -588,5 +598,6 @@ async function fetchWithTimeout(resource, options = {}, timeout = 60000) {
   } finally {
     // 清除计时器，防止内存泄漏
     clearTimeout(id);
+    externalSignal?.removeEventListener('abort', forwardAbort);
   }
 }

--- a/src/daily/providerFailure.js
+++ b/src/daily/providerFailure.js
@@ -1,0 +1,123 @@
+const RETRYABLE_HTTP_STATUSES = new Set([408, 429]);
+const FAILURE_POLICIES = Object.freeze({
+    missing_config: false,
+    invalid_config: false,
+    network: true,
+    timeout: true,
+    http_408: true,
+    http_429: true,
+    http_5xx: true,
+    http_4xx: false,
+    invalid_json: false,
+    invalid_shape: false,
+    provider_failure: false,
+    transform_error: false,
+});
+
+function normalizeFailureCode(code) {
+    return Object.hasOwn(FAILURE_POLICIES, code) ? code : 'provider_failure';
+}
+
+export class ProviderFetchError extends Error {
+    constructor(code, { status = null } = {}) {
+        const normalizedCode = normalizeFailureCode(code);
+        super(normalizedCode);
+        this.name = 'ProviderFetchError';
+        this.code = normalizedCode;
+        this.retryable = FAILURE_POLICIES[normalizedCode];
+        this.status = Number.isInteger(status) ? status : null;
+    }
+}
+
+export function providerConfigurationError() {
+    return new ProviderFetchError('missing_config');
+}
+
+export function providerHttpError(status) {
+    const normalizedStatus = Number.isInteger(status) ? status : null;
+    if (normalizedStatus !== null && RETRYABLE_HTTP_STATUSES.has(normalizedStatus)) {
+        return new ProviderFetchError(`http_${normalizedStatus}`, {
+            retryable: true,
+            status: normalizedStatus,
+        });
+    }
+    if (normalizedStatus !== null && normalizedStatus >= 500) {
+        return new ProviderFetchError('http_5xx', {
+            retryable: true,
+            status: normalizedStatus,
+        });
+    }
+    return new ProviderFetchError('http_4xx', { status: normalizedStatus });
+}
+
+export function providerInvalidShapeError() {
+    return new ProviderFetchError('invalid_shape');
+}
+
+export function assertProviderPositiveInteger(value) {
+    if (!Number.isInteger(value) || value < 1 || value > 100) {
+        throw new ProviderFetchError('invalid_config');
+    }
+    return value;
+}
+
+export function assertProviderPositiveIntegerSetting(value, fallback) {
+    const candidate = String(value === undefined || value === null || value === '' ? fallback : value).trim();
+    if (!/^[1-9]\d*$/.test(candidate)) throw new ProviderFetchError('invalid_config');
+    return assertProviderPositiveInteger(Number(candidate));
+}
+
+export function assertProviderUrl(value) {
+    try {
+        const url = new URL(value);
+        if (!/^https?:$/.test(url.protocol)) throw new Error('unsupported protocol');
+        return url.toString();
+    } catch {
+        throw new ProviderFetchError('invalid_config');
+    }
+}
+
+export function classifyProviderFailure(error) {
+    if (error instanceof ProviderFetchError) {
+        const code = normalizeFailureCode(error.code);
+        return {
+            code,
+            retryable: FAILURE_POLICIES[code],
+            status: error.status,
+        };
+    }
+    if (error?.name === 'AbortError') {
+        return { code: 'timeout', retryable: true, status: null };
+    }
+    if (error instanceof TypeError) {
+        return { code: 'network', retryable: true, status: null };
+    }
+    if (error instanceof SyntaxError) {
+        return { code: 'invalid_json', retryable: false, status: null };
+    }
+    return { code: 'provider_failure', retryable: false, status: null };
+}
+
+export function normalizeProviderFailure(error) {
+    if (error instanceof ProviderFetchError) return error;
+    const failure = classifyProviderFailure(error);
+    return new ProviderFetchError(failure.code, failure);
+}
+
+export function assertFoloPayload(data, { requireFeeds = false } = {}) {
+    if (!data || !Array.isArray(data.data)) throw providerInvalidShapeError();
+    for (const entry of data.data) {
+        if (!entry || typeof entry !== 'object'
+            || !entry.entries || typeof entry.entries !== 'object'
+            || !['string', 'number'].includes(typeof entry.entries.id)
+            || typeof entry.entries.publishedAt !== 'string'
+            || !entry.entries.publishedAt.trim()
+            || !Number.isFinite(Date.parse(entry.entries.publishedAt))) {
+            throw providerInvalidShapeError();
+        }
+        if (requireFeeds && (!entry.feeds || typeof entry.feeds.title !== 'string')) {
+            throw providerInvalidShapeError();
+        }
+    }
+    return data.data;
+}

--- a/src/daily/runState.js
+++ b/src/daily/runState.js
@@ -48,6 +48,11 @@ export async function triggerMarkerKey(triggerId) {
     return `structured:trigger:${await digest(String(triggerId))}`;
 }
 
+export async function failureMarkerKey(triggerId) {
+    if (!triggerId) return null;
+    return `structured:attempt-failure:${await digest(String(triggerId))}`;
+}
+
 export async function readTriggerMarker(kv, triggerId) {
     const key = await triggerMarkerKey(triggerId);
     return key ? readJson(kv, key) : null;
@@ -55,6 +60,13 @@ export async function readTriggerMarker(kv, triggerId) {
 
 export async function storeTriggerMarker(kv, triggerId, marker) {
     const key = await triggerMarkerKey(triggerId);
+    if (!key) return false;
+    await kv.put(key, JSON.stringify(marker), { expirationTtl: MARKER_TTL_SECONDS });
+    return true;
+}
+
+export async function storeFailureMarker(kv, triggerId, marker) {
+    const key = await failureMarkerKey(triggerId);
     if (!key) return false;
     await kv.put(key, JSON.stringify(marker), { expirationTtl: MARKER_TTL_SECONDS });
     return true;

--- a/src/daily/structuredFetch.js
+++ b/src/daily/structuredFetch.js
@@ -1,10 +1,53 @@
 import { STRUCTURED_SOURCE_ADAPTERS } from './sourceAdapters.js';
+import { classifyProviderFailure } from './providerFailure.js';
 
 const CONTENT_TYPE_ORDER = ['news', 'project', 'paper', 'socialMedia'];
+const DEFAULT_FETCH_ATTEMPTS = 2;
+const DEFAULT_RETRY_DELAY_MS = 1000;
+const DEFAULT_FETCH_TIMEOUT_MS = 30_000;
+
+function wait(milliseconds) {
+    return new Promise(resolve => setTimeout(resolve, milliseconds));
+}
+
+async function fetchWithDeadline(adapter, env, foloCookie, timeoutMs) {
+    const controller = new AbortController();
+    let timeoutId;
+    const timeout = new Promise((_, reject) => {
+        timeoutId = setTimeout(() => {
+            controller.abort();
+            const error = new Error('Provider attempt timed out');
+            error.name = 'AbortError';
+            reject(error);
+        }, timeoutMs);
+    });
+    try {
+        return await Promise.race([
+            adapter.fetch(env, foloCookie, { strict: true, signal: controller.signal }),
+            timeout,
+        ]);
+    } finally {
+        clearTimeout(timeoutId);
+    }
+}
 
 export async function fetchProviderPreservingData(env, foloCookie, {
     adapters = STRUCTURED_SOURCE_ADAPTERS,
+    fetchAttempts = DEFAULT_FETCH_ATTEMPTS,
+    retryDelayMs = DEFAULT_RETRY_DELAY_MS,
+    fetchTimeoutMs = DEFAULT_FETCH_TIMEOUT_MS,
+    sleep = wait,
 } = {}) {
+    if (!Number.isInteger(fetchAttempts) || fetchAttempts < 1 || fetchAttempts > 3) {
+        throw new Error('Structured fetch attempts must be between one and three');
+    }
+    if (!Number.isFinite(retryDelayMs) || retryDelayMs < 0 || retryDelayMs > 30_000) {
+        throw new Error('Structured retry delay must be between zero and thirty seconds');
+    }
+    if (!Number.isFinite(fetchTimeoutMs) || fetchTimeoutMs < 1 || fetchTimeoutMs > 120_000) {
+        throw new Error('Structured fetch timeout must be between one millisecond and two minutes');
+    }
+
     const taggedByType = Object.fromEntries(CONTENT_TYPE_ORDER.map(type => [type, []]));
     const errors = [];
 
@@ -12,8 +55,50 @@ export async function fetchProviderPreservingData(env, foloCookie, {
         if (!taggedByType[entry.contentType]) {
             throw new Error(`Unknown structured content type: ${entry.contentType}`);
         }
+
+        let raw;
+        let fetchError = null;
+        let attemptsUsed = 0;
+        for (let attempt = 1; attempt <= fetchAttempts; attempt += 1) {
+            attemptsUsed = attempt;
+            try {
+                raw = await fetchWithDeadline(
+                    entry.adapter,
+                    env,
+                    foloCookie,
+                    fetchTimeoutMs,
+                );
+                fetchError = null;
+                break;
+            } catch (error) {
+                fetchError = error;
+                const failure = classifyProviderFailure(error);
+                console.warn('[StructuredFetch] provider fetch attempt failed', {
+                    provider: entry.provider,
+                    contentType: entry.contentType,
+                    attempt,
+                    maxAttempts: fetchAttempts,
+                    errorCode: failure.code,
+                    retryable: failure.retryable,
+                });
+                if (!failure.retryable || attempt >= fetchAttempts) break;
+                await sleep(retryDelayMs * attempt);
+            }
+        }
+
+        if (fetchError) {
+            const failure = classifyProviderFailure(fetchError);
+            errors.push({
+                provider: entry.provider,
+                content_type: entry.contentType,
+                stage: 'fetch',
+                error_type: failure.code,
+                attempts: attemptsUsed,
+            });
+            continue;
+        }
+
         try {
-            const raw = await entry.adapter.fetch(env, foloCookie);
             const transformed = entry.adapter.transform(raw, entry.contentType);
             if (!Array.isArray(transformed)) throw new Error('Adapter transform must return an array');
             taggedByType[entry.contentType].push(...transformed.map(item => ({
@@ -24,7 +109,9 @@ export async function fetchProviderPreservingData(env, foloCookie, {
             errors.push({
                 provider: entry.provider,
                 content_type: entry.contentType,
-                error_type: error?.name || 'Error',
+                stage: 'transform',
+                error_type: 'transform_error',
+                attempts: 1,
             });
         }
     }

--- a/src/daily/structuredWorkflow.js
+++ b/src/daily/structuredWorkflow.js
@@ -30,6 +30,20 @@ export class StructuredRunLockedError extends Error {
     }
 }
 
+export class StructuredSourceFetchError extends Error {
+    constructor(sourceErrors) {
+        super(`Structured source fetch failed for ${sourceErrors.length} provider(s)`);
+        this.name = 'StructuredSourceFetchError';
+        this.sourceErrors = sourceErrors.map(error => ({
+            provider: error.provider,
+            content_type: error.content_type,
+            stage: error.stage || 'fetch',
+            error_type: error.error_type || 'Error',
+            attempts: Number.isInteger(error.attempts) ? error.attempts : 1,
+        }));
+    }
+}
+
 function parseReport(text, path) {
     if (text === null) return null;
     try {
@@ -211,7 +225,7 @@ export async function runStructuredDailyWorkflow(env, {
         const foloCookie = await deps.getFoloCookie(env);
         const fetched = await deps.fetchData(env, foloCookie);
         if (fetched.errors.length > 0) {
-            throw new Error(`Structured source fetch failed for ${fetched.errors.length} provider(s)`);
+            throw new StructuredSourceFetchError(fetched.errors);
         }
 
         for (let attempt = 1; attempt <= MAX_PUBLICATION_ATTEMPTS; attempt += 1) {

--- a/src/dataSources/aibase.js
+++ b/src/dataSources/aibase.js
@@ -1,16 +1,23 @@
 // src/dataSources/aibase.js
 import { getRandomUserAgent, sleep, isDateWithinLastDays, stripHtml, formatDateToChineseWithTime, escapeHtml} from '../helpers.js';
 import { getFoloDataApi, getFoloErrorMessage } from '../folo.js';
+import { assertFoloPayload, assertProviderPositiveIntegerSetting, assertProviderUrl, normalizeProviderFailure, providerConfigurationError, providerHttpError } from '../daily/providerFailure.js';
 
 const NewsDataSource = {
-    fetch: async (env, foloCookie) => { // Add sourceType
+    fetch: async (env, foloCookie, { strict = false, signal } = {}) => { // Add sourceType
         const feedId = env.AIBASE_FEED_ID;
         const fetchPages = parseInt(env.AIBASE_FETCH_PAGES || '3', 10);
         const allAibaseItems = [];
         const filterDays = parseInt(env.FOLO_FILTER_DAYS || '3', 10);
         const foloDataApi = getFoloDataApi(env);
+        if (strict) {
+            assertProviderPositiveIntegerSetting(env.AIBASE_FETCH_PAGES, '3');
+            assertProviderPositiveIntegerSetting(env.FOLO_FILTER_DAYS, '3');
+            assertProviderUrl(foloDataApi);
+        }
 
         if (!feedId) {
+            if (strict) throw providerConfigurationError();
             console.error('AIBASE_FEED_ID is not set in environment variables.');
             return {
                 version: "https://jsonfeed.org/version/1.1",
@@ -64,13 +71,16 @@ const NewsDataSource = {
                     method: 'POST',
                     headers: headers,
                     body: JSON.stringify(body),
+                    signal,
                 });
 
                 if (!response.ok) {
+                    if (strict) throw providerHttpError(response.status);
                     console.error(`Failed to fetch AI Base data, page ${i + 1}: ${await getFoloErrorMessage(response)}`);
                     break;
                 }
                 const data = await response.json();
+                if (strict) assertFoloPayload(data);
                 if (data && data.data && data.data.length > 0) {
                     const filteredItems = data.data.filter(entry => isDateWithinLastDays(entry.entries.publishedAt, filterDays));
                     allAibaseItems.push(...filteredItems.map(entry => ({
@@ -88,12 +98,13 @@ const NewsDataSource = {
                     break;
                 }
             } catch (error) {
+                if (strict) throw normalizeProviderFailure(error);
                 console.error(`Error fetching AI Base data, page ${i + 1}:`, error);
                 break;
             }
 
             // Random wait time between 0 and 5 seconds to avoid rate limiting
-            await sleep(Math.random() * 5000);
+            await sleep(Math.random() * 5000, { signal });
         }
 
         return {

--- a/src/dataSources/github-trending.js
+++ b/src/dataSources/github-trending.js
@@ -1,6 +1,7 @@
 // src/dataSources/projects.js
 import { fetchData, getISODate, removeMarkdownCodeBlock, formatDateToChineseWithTime, escapeHtml} from '../helpers.js';
 import { callChatAPI } from '../chatapi.js';
+import { normalizeProviderFailure, providerHttpError, providerInvalidShapeError } from '../daily/providerFailure.js';
 
 const GITHUB_TRENDING_URL = 'https://github.com/trending';
 
@@ -83,49 +84,85 @@ function parseGithubTrendingHtml(html) {
     }).filter(Boolean);
 }
 
-async function fetchGitHubTrendingProjects(projectsApiUrl) {
+function isExplicitGithubTrendingEmpty(html) {
+    return /there (?:aren't|are no) any trending repositories/i.test(html);
+}
+
+function hasValidProjectShape(project) {
+    if (!project || typeof project !== 'object') return false;
+    if (typeof project.owner !== 'string' || !project.owner.trim()) return false;
+    if (typeof project.name !== 'string' || !project.name.trim()) return false;
+    try {
+        const url = new URL(project.url);
+        return url.protocol === 'https:' && url.hostname === 'github.com';
+    } catch {
+        return false;
+    }
+}
+
+async function fetchGitHubTrendingProjects(projectsApiUrl, { strict = false, signal } = {}) {
     const since = getTrendingSince(projectsApiUrl);
     const response = await fetch(`${GITHUB_TRENDING_URL}?since=${encodeURIComponent(since)}`, {
         headers: {
             'Accept': 'text/html',
             'User-Agent': 'Mozilla/5.0 CloudFlare-AI-Insight-Daily'
-        }
+        },
+        signal,
     });
 
     if (!response.ok) {
+        if (strict) throw providerHttpError(response.status);
         throw new Error(`GitHub Trending fallback failed: ${response.status} ${response.statusText}`);
     }
 
     const html = await response.text();
-    return parseGithubTrendingHtml(html);
+    const projects = parseGithubTrendingHtml(html);
+    if (strict && projects.length === 0 && !isExplicitGithubTrendingEmpty(html)) {
+        throw providerInvalidShapeError();
+    }
+    return projects;
 }
 
 const ProjectsDataSource = {
-    fetch: async (env) => {
-        console.log(`Fetching projects from: ${env.PROJECTS_API_URL}`);
+    fetch: async (env, _foloCookie, { strict = false, signal } = {}) => {
+        console.log(strict
+            ? 'Fetching projects from configured primary endpoint.'
+            : `Fetching projects from: ${env.PROJECTS_API_URL}`);
         let projects = [];
         let primaryError = null;
 
         if (env.PROJECTS_API_URL) {
             try {
-                projects = await fetchData(env.PROJECTS_API_URL);
+                projects = await fetchData(env.PROJECTS_API_URL, { signal });
             } catch (error) {
                 primaryError = error;
-                console.error("Error fetching projects data:", error.message);
+                if (strict) {
+                    console.error('Configured projects endpoint failed', {
+                        errorType: normalizeProviderFailure(error).code,
+                    });
+                } else {
+                    console.error("Error fetching projects data:", error.message);
+                }
             }
         }
 
         if (!Array.isArray(projects)) {
-            console.error("Projects data is not an array:", projects);
+            if (strict) console.error('Configured projects endpoint returned an invalid shape');
+            else console.error("Projects data is not an array:", projects);
+            projects = [];
+        }
+        if (strict && projects.length > 0 && !projects.every(hasValidProjectShape)) {
+            primaryError = providerInvalidShapeError();
             projects = [];
         }
 
         if (projects.length === 0) {
             try {
                 console.log("Fetching projects from GitHub Trending fallback...");
-                projects = await fetchGitHubTrendingProjects(env.PROJECTS_API_URL);
+                projects = await fetchGitHubTrendingProjects(env.PROJECTS_API_URL, { strict, signal });
                 console.log(`Fetched ${projects.length} projects from GitHub Trending fallback.`);
             } catch (fallbackError) {
+                if (strict) throw normalizeProviderFailure(fallbackError);
                 console.error("Error fetching GitHub Trending fallback:", fallbackError.message);
                 return {
                     error: "Failed to fetch projects data",
@@ -138,6 +175,7 @@ const ProjectsDataSource = {
 
         if (projects.length === 0) {
             console.log("No projects fetched from API.");
+            if (strict) return [];
             return { items: [] };
         }
 
@@ -167,7 +205,7 @@ JSON Array of Chinese Translations:`;
         let translatedTexts = [];
         try {
             console.log(`Requesting translation for ${descriptionsToTranslate.length} project descriptions.`);
-            const chatResponse = await callChatAPI(env, promptText);
+            const chatResponse = await callChatAPI(env, promptText, null, { signal });
             const parsedTranslations = JSON.parse(removeMarkdownCodeBlock(chatResponse)); // Assuming direct JSON array response
 
             if (parsedTranslations && Array.isArray(parsedTranslations) && parsedTranslations.length === descriptionsToTranslate.length) {
@@ -177,7 +215,8 @@ JSON Array of Chinese Translations:`;
                 translatedTexts = descriptionsToTranslate.map(() => null);
             }
         } catch (translationError) {
-            console.error("Failed to translate project descriptions in batch:", translationError.message);
+            if (strict) console.error('Failed to translate project descriptions in batch');
+            else console.error("Failed to translate project descriptions in batch:", translationError.message);
             translatedTexts = descriptionsToTranslate.map(() => null);
         }
 

--- a/src/dataSources/huggingface-papers.js
+++ b/src/dataSources/huggingface-papers.js
@@ -2,16 +2,23 @@
 import { getRandomUserAgent, sleep, isDateWithinLastDays, stripHtml, removeMarkdownCodeBlock, formatDateToChineseWithTime, escapeHtml} from '../helpers.js';
 import { callChatAPI } from '../chatapi.js';
 import { getFoloDataApi, getFoloErrorMessage } from '../folo.js';
+import { assertFoloPayload, assertProviderPositiveIntegerSetting, assertProviderUrl, normalizeProviderFailure, providerConfigurationError, providerHttpError } from '../daily/providerFailure.js';
 
 const PapersDataSource = {
-    fetch: async (env, foloCookie) => {
+    fetch: async (env, foloCookie, { strict = false, signal } = {}) => {
         const feedId = env.HGPAPERS_FEED_ID;
         const fetchPages = parseInt(env.HGPAPERS_FETCH_PAGES || '3', 10);
         const allPapersItems = [];
         const filterDays = parseInt(env.FOLO_FILTER_DAYS || '3', 10);
         const foloDataApi = getFoloDataApi(env);
+        if (strict) {
+            assertProviderPositiveIntegerSetting(env.HGPAPERS_FETCH_PAGES, '3');
+            assertProviderPositiveIntegerSetting(env.FOLO_FILTER_DAYS, '3');
+            assertProviderUrl(foloDataApi);
+        }
 
         if (!feedId) {
+            if (strict) throw providerConfigurationError();
             console.error('HGPAPERS_FEED_ID is not set in environment variables.');
             return {
                 version: "https://jsonfeed.org/version/1.1",
@@ -65,13 +72,16 @@ const PapersDataSource = {
                     method: 'POST',
                     headers: headers,
                     body: JSON.stringify(body),
+                    signal,
                 });
 
                 if (!response.ok) {
+                    if (strict) throw providerHttpError(response.status);
                     console.error(`Failed to fetch Huggingface Papers data, page ${i + 1}: ${await getFoloErrorMessage(response)}`);
                     break;
                 }
                 const data = await response.json();
+                if (strict) assertFoloPayload(data);
                 if (data && data.data && data.data.length > 0) {
                     const filteredItems = data.data.filter(entry => isDateWithinLastDays(entry.entries.publishedAt, filterDays));
                     allPapersItems.push(...filteredItems.map(entry => ({
@@ -89,12 +99,13 @@ const PapersDataSource = {
                     break;
                 }
             } catch (error) {
+                if (strict) throw normalizeProviderFailure(error);
                 console.error(`Error fetching Huggingface Papers data, page ${i + 1}:`, error);
                 break;
             }
 
             // Random wait time between 0 and 5 seconds to avoid rate limiting
-            await sleep(Math.random() * 5000);
+            await sleep(Math.random() * 5000, { signal });
         }
 
         const papersData = {
@@ -144,7 +155,7 @@ Respond ONLY with the JSON array.`;
         let translatedItemsMap = new Map();
         try {
             console.log(`Requesting translation for ${itemsToTranslate.length} hgpapers titles for today.`);
-            const chatResponse = await callChatAPI(env, promptText);
+            const chatResponse = await callChatAPI(env, promptText, null, { signal });
             const parsedTranslations = JSON.parse(removeMarkdownCodeBlock(chatResponse)); // Assuming direct JSON array response
 
             if (parsedTranslations) {
@@ -156,7 +167,8 @@ Respond ONLY with the JSON array.`;
                 });
             }
         } catch (translationError) {
-            console.error("Failed to translate hgpapers titles in batch:", translationError.message);
+            if (strict) console.error('Failed to translate hgpapers titles in batch');
+            else console.error("Failed to translate hgpapers titles in batch:", translationError.message);
         }
 
         papersData.items = papersData.items.map((originalItem, index) => {

--- a/src/dataSources/jiqizhixin.js
+++ b/src/dataSources/jiqizhixin.js
@@ -1,15 +1,22 @@
 import { getRandomUserAgent, sleep, isDateWithinLastDays, stripHtml, formatDateToChineseWithTime, escapeHtml } from '../helpers.js';
 import { getFoloDataApi, getFoloErrorMessage } from '../folo.js';
+import { assertFoloPayload, assertProviderPositiveIntegerSetting, assertProviderUrl, normalizeProviderFailure, providerConfigurationError, providerHttpError } from '../daily/providerFailure.js';
 
 const JiqizhixinDataSource = {
-    fetch: async (env, foloCookie) => {
+    fetch: async (env, foloCookie, { strict = false, signal } = {}) => {
         const feedId = env.JIQIZHIXIN_FEED_ID;
         const fetchPages = parseInt(env.JIQIZHIXIN_FETCH_PAGES || '3', 10);
         const allJiqizhixinItems = [];
         const filterDays = parseInt(env.FOLO_FILTER_DAYS || '3', 10);
         const foloDataApi = getFoloDataApi(env);
+        if (strict) {
+            assertProviderPositiveIntegerSetting(env.JIQIZHIXIN_FETCH_PAGES, '3');
+            assertProviderPositiveIntegerSetting(env.FOLO_FILTER_DAYS, '3');
+            assertProviderUrl(foloDataApi);
+        }
 
         if (!feedId) {
+            if (strict) throw providerConfigurationError();
             console.error('JIQIZHIXIN_FEED_ID is not set in environment variables.');
             return {
                 version: "https://jsonfeed.org/version/1.1",
@@ -63,13 +70,16 @@ const JiqizhixinDataSource = {
                     method: 'POST',
                     headers: headers,
                     body: JSON.stringify(body),
+                    signal,
                 });
 
                 if (!response.ok) {
+                    if (strict) throw providerHttpError(response.status);
                     console.error(`Failed to fetch Jiqizhixin.AI data, page ${i + 1}: ${await getFoloErrorMessage(response)}`);
                     break;
                 }
                 const data = await response.json();
+                if (strict) assertFoloPayload(data);
                 if (data && data.data && data.data.length > 0) {
                     const filteredItems = data.data.filter(entry => isDateWithinLastDays(entry.entries.publishedAt, filterDays));
                     allJiqizhixinItems.push(...filteredItems.map(entry => ({
@@ -87,12 +97,13 @@ const JiqizhixinDataSource = {
                     break;
                 }
             } catch (error) {
+                if (strict) throw normalizeProviderFailure(error);
                 console.error(`Error fetching Jiqizhixin.AI data, page ${i + 1}:`, error);
                 break;
             }
 
             // Random wait time between 0 and 5 seconds to avoid rate limiting
-            await sleep(Math.random() * 5000);
+            await sleep(Math.random() * 5000, { signal });
         }
 
         return {

--- a/src/dataSources/openai-newsroom.js
+++ b/src/dataSources/openai-newsroom.js
@@ -1,16 +1,23 @@
 // src/dataSources/openai-newsroom.js
 import { getRandomUserAgent, sleep, isDateWithinLastDays, stripHtml, formatDateToChineseWithTime, escapeHtml} from '../helpers.js';
 import { getFoloDataApi, getFoloErrorMessage } from '../folo.js';
+import { assertFoloPayload, assertProviderPositiveIntegerSetting, assertProviderUrl, normalizeProviderFailure, providerConfigurationError, providerHttpError } from '../daily/providerFailure.js';
 
 const NewsDataSource = {
-    fetch: async (env, foloCookie) => {
+    fetch: async (env, foloCookie, { strict = false, signal } = {}) => {
         const feedId = env.OPENAI_NEWSROOM_FEED_ID;
         const fetchPages = parseInt(env.OPENAI_NEWSROOM_FETCH_PAGES || '3', 10);
         const allItems = [];
         const filterDays = parseInt(env.FOLO_FILTER_DAYS || '3', 10);
         const foloDataApi = getFoloDataApi(env);
+        if (strict) {
+            assertProviderPositiveIntegerSetting(env.OPENAI_NEWSROOM_FETCH_PAGES, '2');
+            assertProviderPositiveIntegerSetting(env.FOLO_FILTER_DAYS, '3');
+            assertProviderUrl(foloDataApi);
+        }
 
         if (!feedId) {
+            if (strict) throw providerConfigurationError();
             console.error('OPENAI_NEWSROOM_FEED_ID is not set in environment variables.');
             return {
                 version: "https://jsonfeed.org/version/1.1",
@@ -63,13 +70,16 @@ const NewsDataSource = {
                     method: 'POST',
                     headers: headers,
                     body: JSON.stringify(body),
+                    signal,
                 });
 
                 if (!response.ok) {
+                    if (strict) throw providerHttpError(response.status);
                     console.error(`Failed to fetch OpenAI NewsRoom data, page ${i + 1}: ${await getFoloErrorMessage(response)}`);
                     break;
                 }
                 const data = await response.json();
+                if (strict) assertFoloPayload(data);
                 if (data && data.data && data.data.length > 0) {
                     const filteredItems = data.data.filter(entry => isDateWithinLastDays(entry.entries.publishedAt, filterDays));
                     allItems.push(...filteredItems.map(entry => ({
@@ -87,11 +97,12 @@ const NewsDataSource = {
                     break;
                 }
             } catch (error) {
+                if (strict) throw normalizeProviderFailure(error);
                 console.error(`Error fetching OpenAI NewsRoom data, page ${i + 1}:`, error);
                 break;
             }
 
-            await sleep(Math.random() * 5000);
+            await sleep(Math.random() * 5000, { signal });
         }
 
         return {

--- a/src/dataSources/qbit.js
+++ b/src/dataSources/qbit.js
@@ -1,15 +1,22 @@
 import { getRandomUserAgent, sleep, isDateWithinLastDays, stripHtml, formatDateToChineseWithTime, escapeHtml } from '../helpers.js';
 import { getFoloDataApi, getFoloErrorMessage } from '../folo.js';
+import { assertFoloPayload, assertProviderPositiveIntegerSetting, assertProviderUrl, normalizeProviderFailure, providerConfigurationError, providerHttpError } from '../daily/providerFailure.js';
 
 const QBitDataSource = {
-    fetch: async (env, foloCookie) => {
+    fetch: async (env, foloCookie, { strict = false, signal } = {}) => {
         const feedId = env.QBIT_FEED_ID;
         const fetchPages = parseInt(env.QBIT_FETCH_PAGES || '3', 10);
         const allQBitItems = [];
         const filterDays = parseInt(env.FOLO_FILTER_DAYS || '3', 10);
         const foloDataApi = getFoloDataApi(env);
+        if (strict) {
+            assertProviderPositiveIntegerSetting(env.QBIT_FETCH_PAGES, '3');
+            assertProviderPositiveIntegerSetting(env.FOLO_FILTER_DAYS, '3');
+            assertProviderUrl(foloDataApi);
+        }
 
         if (!feedId) {
+            if (strict) throw providerConfigurationError();
             console.error('QBIT_FEED_ID is not set in environment variables.');
             return {
                 version: "https://jsonfeed.org/version/1.1",
@@ -63,13 +70,16 @@ const QBitDataSource = {
                     method: 'POST',
                     headers: headers,
                     body: JSON.stringify(body),
+                    signal,
                 });
 
                 if (!response.ok) {
+                    if (strict) throw providerHttpError(response.status);
                     console.error(`Failed to fetch QBit.AI data, page ${i + 1}: ${await getFoloErrorMessage(response)}`);
                     break;
                 }
                 const data = await response.json();
+                if (strict) assertFoloPayload(data);
                 if (data && data.data && data.data.length > 0) {
                     const filteredItems = data.data.filter(entry => isDateWithinLastDays(entry.entries.publishedAt, filterDays));
                     allQBitItems.push(...filteredItems.map(entry => ({
@@ -87,12 +97,13 @@ const QBitDataSource = {
                     break;
                 }
             } catch (error) {
+                if (strict) throw normalizeProviderFailure(error);
                 console.error(`Error fetching QBit.AI data, page ${i + 1}:`, error);
                 break;
             }
 
             // Random wait time between 0 and 5 seconds to avoid rate limiting
-            await sleep(Math.random() * 5000);
+            await sleep(Math.random() * 5000, { signal });
         }
 
         return {

--- a/src/dataSources/reddit.js
+++ b/src/dataSources/reddit.js
@@ -2,16 +2,23 @@ import { getRandomUserAgent, sleep, isDateWithinLastDays, stripHtml, formatDateT
 import { callChatAPI } from '../chatapi.js';
 import { removeMarkdownCodeBlock } from '../helpers.js';
 import { getFoloDataApi, getFoloErrorMessage } from '../folo.js';
+import { assertFoloPayload, assertProviderPositiveIntegerSetting, assertProviderUrl, normalizeProviderFailure, providerConfigurationError, providerHttpError } from '../daily/providerFailure.js';
 
 const RedditDataSource = {
-    async fetch(env, foloCookie) {
+    async fetch(env, foloCookie, { strict = false, signal } = {}) {
         const listId = env.REDDIT_LIST_ID;
         const fetchPages = parseInt(env.REDDIT_FETCH_PAGES || '3', 10);
         const allRedditItems = [];
         const filterDays = parseInt(env.FOLO_FILTER_DAYS || '3', 10);
         const foloDataApi = getFoloDataApi(env);
+        if (strict) {
+            assertProviderPositiveIntegerSetting(env.REDDIT_FETCH_PAGES, '3');
+            assertProviderPositiveIntegerSetting(env.FOLO_FILTER_DAYS, '3');
+            assertProviderUrl(foloDataApi);
+        }
 
         if (!listId) {
+            if (strict) throw providerConfigurationError();
             console.error('REDDIT_LIST_ID is not set in environment variables.');
             return {
                 version: "https://jsonfeed.org/version/1.1",
@@ -64,13 +71,16 @@ const RedditDataSource = {
                     method: 'POST',
                     headers: headers,
                     body: JSON.stringify(body),
+                    signal,
                 });
 
                 if (!response.ok) {
+                    if (strict) throw providerHttpError(response.status);
                     console.error(`Failed to fetch Reddit data, page ${i + 1}: ${await getFoloErrorMessage(response)}`);
                     break;
                 }
                 const data = await response.json();
+                if (strict) assertFoloPayload(data, { requireFeeds: true });
                 if (data && data.data && data.data.length > 0) {
                     const filteredItems = data.data.filter(entry => isDateWithinLastDays(entry.entries.publishedAt, filterDays));
                     allRedditItems.push(...filteredItems.map(entry => ({
@@ -88,11 +98,12 @@ const RedditDataSource = {
                     break;
                 }
             } catch (error) {
+                if (strict) throw normalizeProviderFailure(error);
                 console.error(`Error fetching Reddit data, page ${i + 1}:`, error);
                 break;
             }
 
-            await sleep(Math.random() * 5000);
+            await sleep(Math.random() * 5000, { signal });
         }
 
         const redditData = {
@@ -141,7 +152,7 @@ Respond ONLY with the JSON array.`;
         let translatedItemsMap = new Map();
         try {
             console.log(`Requesting translation for ${itemsToTranslate.length} reddit titles for today.`);
-            const chatResponse = await callChatAPI(env, promptText);
+            const chatResponse = await callChatAPI(env, promptText, null, { signal });
             const parsedTranslations = JSON.parse(removeMarkdownCodeBlock(chatResponse));
 
             if (parsedTranslations) {
@@ -153,7 +164,8 @@ Respond ONLY with the JSON array.`;
                 });
             }
         } catch (translationError) {
-            console.error("Failed to translate reddit titles in batch:", translationError.message);
+            if (strict) console.error('Failed to translate reddit titles in batch');
+            else console.error("Failed to translate reddit titles in batch:", translationError.message);
         }
 
         redditData.items = redditData.items.map((originalItem, index) => {

--- a/src/dataSources/twitter-extra.js
+++ b/src/dataSources/twitter-extra.js
@@ -1,15 +1,22 @@
 import { getRandomUserAgent, sleep, isDateWithinLastDays, stripHtml, formatDateToChineseWithTime, escapeHtml} from '../helpers.js';
 import { getFoloDataApi, getFoloErrorMessage } from '../folo.js';
+import { assertFoloPayload, assertProviderPositiveIntegerSetting, assertProviderUrl, normalizeProviderFailure, providerConfigurationError, providerHttpError } from '../daily/providerFailure.js';
 
 const TwitterExtraDataSource = {
-    async fetch(env, foloCookie) {
+    async fetch(env, foloCookie, { strict = false, signal } = {}) {
         const listId = env.TWITTER_EXTRA_LIST_ID;
         const fetchPages = parseInt(env.TWITTER_EXTRA_FETCH_PAGES || '3', 10);
         const allTwitterItems = [];
         const filterDays = parseInt(env.FOLO_FILTER_DAYS || '3', 10);
         const foloDataApi = getFoloDataApi(env);
+        if (strict) {
+            assertProviderPositiveIntegerSetting(env.TWITTER_EXTRA_FETCH_PAGES, '3');
+            assertProviderPositiveIntegerSetting(env.FOLO_FILTER_DAYS, '3');
+            assertProviderUrl(foloDataApi);
+        }
 
         if (!listId) {
+            if (strict) throw providerConfigurationError();
             console.error('TWITTER_EXTRA_LIST_ID is not set in environment variables.');
             return {
                 version: "https://jsonfeed.org/version/1.1",
@@ -62,13 +69,16 @@ const TwitterExtraDataSource = {
                     method: 'POST',
                     headers: headers,
                     body: JSON.stringify(body),
+                    signal,
                 });
 
                 if (!response.ok) {
+                    if (strict) throw providerHttpError(response.status);
                     console.error(`Failed to fetch Twitter Extra data, page ${i + 1}: ${await getFoloErrorMessage(response)}`);
                     break;
                 }
                 const data = await response.json();
+                if (strict) assertFoloPayload(data, { requireFeeds: true });
                 if (data && data.data && data.data.length > 0) {
                     const filteredItems = data.data.filter(entry => isDateWithinLastDays(entry.entries.publishedAt, filterDays));
                     allTwitterItems.push(...filteredItems.map(entry => ({
@@ -86,11 +96,12 @@ const TwitterExtraDataSource = {
                     break;
                 }
             } catch (error) {
+                if (strict) throw normalizeProviderFailure(error);
                 console.error(`Error fetching Twitter Extra data, page ${i + 1}:`, error);
                 break;
             }
 
-            await sleep(Math.random() * 5000);
+            await sleep(Math.random() * 5000, { signal });
         }
 
         return {

--- a/src/dataSources/twitter.js
+++ b/src/dataSources/twitter.js
@@ -1,15 +1,22 @@
 import { getRandomUserAgent, sleep, isDateWithinLastDays, stripHtml, formatDateToChineseWithTime, escapeHtml} from '../helpers.js';
 import { getFoloDataApi, getFoloErrorMessage } from '../folo.js';
+import { assertFoloPayload, assertProviderPositiveIntegerSetting, assertProviderUrl, normalizeProviderFailure, providerConfigurationError, providerHttpError } from '../daily/providerFailure.js';
 
 const TwitterDataSource = {
-    async fetch(env, foloCookie) {
+    async fetch(env, foloCookie, { strict = false, signal } = {}) {
         const listId = env.TWITTER_LIST_ID;
         const fetchPages = parseInt(env.TWITTER_FETCH_PAGES || '3', 10);
         const allTwitterItems = [];
         const filterDays = parseInt(env.FOLO_FILTER_DAYS || '3', 10);
         const foloDataApi = getFoloDataApi(env);
+        if (strict) {
+            assertProviderPositiveIntegerSetting(env.TWITTER_FETCH_PAGES, '3');
+            assertProviderPositiveIntegerSetting(env.FOLO_FILTER_DAYS, '3');
+            assertProviderUrl(foloDataApi);
+        }
 
         if (!listId) {
+            if (strict) throw providerConfigurationError();
             console.error('TWITTER_LIST_ID is not set in environment variables.');
             return {
                 version: "https://jsonfeed.org/version/1.1",
@@ -63,13 +70,16 @@ const TwitterDataSource = {
                     method: 'POST',
                     headers: headers,
                     body: JSON.stringify(body),
+                    signal,
                 });
 
                 if (!response.ok) {
+                    if (strict) throw providerHttpError(response.status);
                     console.error(`Failed to fetch Twitter data, page ${i + 1}: ${await getFoloErrorMessage(response)}`);
                     break;
                 }
                 const data = await response.json();
+                if (strict) assertFoloPayload(data, { requireFeeds: true });
                 if (data && data.data && data.data.length > 0) {
                     const filteredItems = data.data.filter(entry => isDateWithinLastDays(entry.entries.publishedAt, filterDays));
                     allTwitterItems.push(...filteredItems.map(entry => ({
@@ -87,12 +97,13 @@ const TwitterDataSource = {
                     break;
                 }
             } catch (error) {
+                if (strict) throw normalizeProviderFailure(error);
                 console.error(`Error fetching Twitter data, page ${i + 1}:`, error);
                 break;
             }
 
             // Random wait time between 0 and 5 seconds to avoid rate limiting
-            await sleep(Math.random() * 5000);
+            await sleep(Math.random() * 5000, { signal });
         }
 
         return {

--- a/src/dataSources/xiaohu.js
+++ b/src/dataSources/xiaohu.js
@@ -1,15 +1,22 @@
 import { getRandomUserAgent, sleep, isDateWithinLastDays, stripHtml, formatDateToChineseWithTime, escapeHtml } from '../helpers.js';
 import { getFoloDataApi, getFoloErrorMessage } from '../folo.js';
+import { assertFoloPayload, assertProviderPositiveIntegerSetting, assertProviderUrl, normalizeProviderFailure, providerConfigurationError, providerHttpError } from '../daily/providerFailure.js';
 
 const XiaohuDataSource = {
-    fetch: async (env, foloCookie) => {
+    fetch: async (env, foloCookie, { strict = false, signal } = {}) => {
         const feedId = env.XIAOHU_FEED_ID;
         const fetchPages = parseInt(env.XIAOHU_FETCH_PAGES || '3', 10);
         const allXiaohuItems = [];
         const filterDays = parseInt(env.FOLO_FILTER_DAYS || '3', 10);
         const foloDataApi = getFoloDataApi(env);
+        if (strict) {
+            assertProviderPositiveIntegerSetting(env.XIAOHU_FETCH_PAGES, '3');
+            assertProviderPositiveIntegerSetting(env.FOLO_FILTER_DAYS, '3');
+            assertProviderUrl(foloDataApi);
+        }
 
         if (!feedId) {
+            if (strict) throw providerConfigurationError();
             console.error('XIAOHU_FEED_ID is not set in environment variables.');
             return {
                 version: "https://jsonfeed.org/version/1.1",
@@ -63,13 +70,16 @@ const XiaohuDataSource = {
                     method: 'POST',
                     headers: headers,
                     body: JSON.stringify(body),
+                    signal,
                 });
 
                 if (!response.ok) {
+                    if (strict) throw providerHttpError(response.status);
                     console.error(`Failed to fetch Xiaohu.AI data, page ${i + 1}: ${await getFoloErrorMessage(response)}`);
                     break;
                 }
                 const data = await response.json();
+                if (strict) assertFoloPayload(data);
                 if (data && data.data && data.data.length > 0) {
                     const filteredItems = data.data.filter(entry => isDateWithinLastDays(entry.entries.publishedAt, filterDays));
                     allXiaohuItems.push(...filteredItems.map(entry => ({
@@ -87,12 +97,13 @@ const XiaohuDataSource = {
                     break;
                 }
             } catch (error) {
+                if (strict) throw normalizeProviderFailure(error);
                 console.error(`Error fetching Xiaohu.AI data, page ${i + 1}:`, error);
                 break;
             }
 
             // Random wait time between 0 and 5 seconds to avoid rate limiting
-            await sleep(Math.random() * 5000);
+            await sleep(Math.random() * 5000, { signal });
         }
 
         return {

--- a/src/dataSources/xinzhiyuan.js
+++ b/src/dataSources/xinzhiyuan.js
@@ -1,15 +1,22 @@
 import { getRandomUserAgent, sleep, isDateWithinLastDays, stripHtml, formatDateToChineseWithTime, escapeHtml } from '../helpers.js';
 import { getFoloDataApi, getFoloErrorMessage } from '../folo.js';
+import { assertFoloPayload, assertProviderPositiveIntegerSetting, assertProviderUrl, normalizeProviderFailure, providerConfigurationError, providerHttpError } from '../daily/providerFailure.js';
 
 const XinZhiYuanDataSource = {
-    fetch: async (env, foloCookie) => {
+    fetch: async (env, foloCookie, { strict = false, signal } = {}) => {
         const feedId = env.XINZHIYUAN_FEED_ID;
         const fetchPages = parseInt(env.XINZHIYUAN_FETCH_PAGES || '3', 10);
         const allXinZhiYuanItems = [];
         const filterDays = parseInt(env.FOLO_FILTER_DAYS || '3', 10);
         const foloDataApi = getFoloDataApi(env);
+        if (strict) {
+            assertProviderPositiveIntegerSetting(env.XINZHIYUAN_FETCH_PAGES, '3');
+            assertProviderPositiveIntegerSetting(env.FOLO_FILTER_DAYS, '3');
+            assertProviderUrl(foloDataApi);
+        }
 
         if (!feedId) {
+            if (strict) throw providerConfigurationError();
             console.error('XINZHIYUAN_FEED_ID is not set in environment variables.');
             return {
                 version: "https://jsonfeed.org/version/1.1",
@@ -63,13 +70,16 @@ const XinZhiYuanDataSource = {
                     method: 'POST',
                     headers: headers,
                     body: JSON.stringify(body),
+                    signal,
                 });
 
                 if (!response.ok) {
+                    if (strict) throw providerHttpError(response.status);
                     console.error(`Failed to fetch XinZhiYuan.AI data, page ${i + 1}: ${await getFoloErrorMessage(response)}`);
                     break;
                 }
                 const data = await response.json();
+                if (strict) assertFoloPayload(data);
                 if (data && data.data && data.data.length > 0) {
                     const filteredItems = data.data.filter(entry => isDateWithinLastDays(entry.entries.publishedAt, filterDays));
                     allXinZhiYuanItems.push(...filteredItems.map(entry => ({
@@ -87,12 +97,13 @@ const XinZhiYuanDataSource = {
                     break;
                 }
             } catch (error) {
+                if (strict) throw normalizeProviderFailure(error);
                 console.error(`Error fetching XinZhiYuan.AI data, page ${i + 1}:`, error);
                 break;
             }
 
             // Random wait time between 0 and 5 seconds to avoid rate limiting
-            await sleep(Math.random() * 5000);
+            await sleep(Math.random() * 5000, { signal });
         }
 
         return {

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -346,10 +346,30 @@ export function getRandomUserAgent() {
 /**
  * Pauses execution for a specified number of milliseconds.
  * @param {number} ms - The number of milliseconds to sleep.
+ * @param {{ signal?: AbortSignal }} [options] - Optional cancellation signal.
  * @returns {Promise<void>} A promise that resolves after the specified time.
  */
-export function sleep(ms) {
-    return new Promise(resolve => setTimeout(resolve, ms));
+export function sleep(ms, { signal } = {}) {
+    if (!signal) return new Promise(resolve => setTimeout(resolve, ms));
+    const abortReason = () => {
+        if (signal.reason instanceof Error) return signal.reason;
+        const error = new Error('Operation aborted');
+        error.name = 'AbortError';
+        return error;
+    };
+    if (signal.aborted) return Promise.reject(abortReason());
+    return new Promise((resolve, reject) => {
+        const timeoutId = setTimeout(() => {
+            signal.removeEventListener('abort', onAbort);
+            resolve();
+        }, ms);
+        const onAbort = () => {
+            clearTimeout(timeoutId);
+            signal.removeEventListener('abort', onAbort);
+            reject(abortReason());
+        };
+        signal.addEventListener('abort', onAbort, { once: true });
+    });
 }
 
 export function replaceImageProxy(proxy, content) {

--- a/src/index.js
+++ b/src/index.js
@@ -12,6 +12,26 @@ import { handleIncrementalDailyWorkflow, runIncrementalDailyWorkflow } from './h
 import { debugFoloCookie, storeFoloCookieToKV } from './folo.js';
 import { handleAdminRoute, isAdminRoute } from './routes/adminRoutes.js';
 import { logMissingConfig } from './logging.js';
+import { storeFailureMarker } from './daily/runState.js';
+import { SOURCE_REGISTRY } from './daily/sourceRegistry.js';
+
+const SAFE_PROVIDER_NAMES = new Set(Object.keys(SOURCE_REGISTRY));
+const SAFE_CONTENT_TYPES = new Set(['news', 'project', 'paper', 'socialMedia']);
+const SAFE_FAILURE_STAGES = new Set(['fetch', 'transform']);
+const SAFE_PROVIDER_ERROR_CODES = new Set([
+    'missing_config',
+    'invalid_config',
+    'network',
+    'timeout',
+    'http_408',
+    'http_429',
+    'http_5xx',
+    'http_4xx',
+    'invalid_json',
+    'invalid_shape',
+    'provider_failure',
+    'transform_error',
+]);
 
 function jsonResponse(value, init = {}) {
     const headers = new Headers(init.headers);
@@ -82,6 +102,51 @@ function appendSessionCookie(response, cookie) {
         statusText: response.statusText,
         headers,
     });
+}
+
+function scheduledFailureMarker(error, runAt) {
+    const sourceErrors = Array.isArray(error?.sourceErrors)
+        ? error.sourceErrors.slice(0, 16).map(sourceError => ({
+            provider: SAFE_PROVIDER_NAMES.has(sourceError?.provider)
+                ? sourceError.provider
+                : 'unknown',
+            content_type: SAFE_CONTENT_TYPES.has(sourceError?.content_type)
+                ? sourceError.content_type
+                : 'unknown',
+            stage: SAFE_FAILURE_STAGES.has(sourceError?.stage)
+                ? sourceError.stage
+                : 'unknown',
+            error_type: SAFE_PROVIDER_ERROR_CODES.has(sourceError?.error_type)
+                ? sourceError.error_type
+                : 'provider_failure',
+            attempts: Number.isInteger(sourceError?.attempts)
+                && sourceError.attempts >= 1
+                && sourceError.attempts <= 3
+                ? sourceError.attempts
+                : 1,
+        }))
+        : [];
+    return {
+        success: false,
+        status: 'failed',
+        trigger_type: 'scheduled',
+        run_at: runAt,
+        error_type: error?.name === 'StructuredSourceFetchError'
+            ? 'structured_source_fetch_failed'
+            : 'scheduled_workflow_failed',
+        ...(sourceErrors.length > 0 ? { source_errors: sourceErrors } : {}),
+    };
+}
+
+async function recordScheduledFailure(env, triggerId, marker) {
+    if (!env.DATA_KV || typeof env.DATA_KV.put !== 'function') return;
+    try {
+        await storeFailureMarker(env.DATA_KV, triggerId, marker);
+    } catch (markerError) {
+        console.warn('[Scheduled] failure marker write failed', {
+            errorType: markerError?.name || 'Error',
+        });
+    }
 }
 
 export function createWorker({
@@ -168,10 +233,28 @@ export function createWorker({
                 console.warn('[Scheduled] external writes are disabled; workflow skipped');
                 return;
             }
-            ctx.waitUntil(scheduledWorkflow(env, {
-                triggerId: `scheduled:${event.scheduledTime}`,
-                runAt: new Date(event.scheduledTime).toISOString(),
-            }));
+            const triggerId = `scheduled:${event.scheduledTime}`;
+            const runAt = new Date(event.scheduledTime).toISOString();
+            const workflow = Promise.resolve()
+                .then(() => scheduledWorkflow(env, { triggerId, runAt }))
+                .catch(async error => {
+                    const marker = scheduledFailureMarker(error, runAt);
+                    console.error('[Scheduled] workflow failed', {
+                        errorType: marker.error_type,
+                        sourceErrors: Array.isArray(marker.source_errors)
+                            ? marker.source_errors.map(sourceError => ({
+                                provider: sourceError.provider,
+                                contentType: sourceError.content_type,
+                                stage: sourceError.stage,
+                                errorType: sourceError.error_type,
+                                attempts: sourceError.attempts,
+                            }))
+                            : [],
+                    });
+                    await recordScheduledFailure(env, triggerId, marker);
+                    throw error;
+                });
+            ctx.waitUntil(workflow);
         },
     };
 }

--- a/tests/worker/providerCancellation.test.js
+++ b/tests/worker/providerCancellation.test.js
@@ -1,0 +1,45 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { callChatAPI } from '../../src/chatapi.js';
+import { sleep } from '../../src/helpers.js';
+
+afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+});
+
+describe('provider attempt cancellation', () => {
+    it('propagates the provider signal into a non-streaming chat request', async () => {
+        let requestSignal;
+        vi.stubGlobal('fetch', vi.fn(async (_url, options) => {
+            requestSignal = options.signal;
+            return await new Promise((_, reject) => {
+                requestSignal.addEventListener('abort', () => reject(requestSignal.reason), {
+                    once: true,
+                });
+            });
+        }));
+        vi.spyOn(console, 'error').mockImplementation(() => undefined);
+        const controller = new AbortController();
+        const request = callChatAPI({
+            USE_MODEL_PLATFORM: 'OPEN',
+            OPENAI_API_URL: 'https://chat.example.test',
+            OPENAI_API_KEY: 'test-key',
+            DEFAULT_OPEN_MODEL: 'test-model',
+        }, 'prompt', null, { signal: controller.signal });
+
+        await vi.waitFor(() => expect(requestSignal).toBeInstanceOf(AbortSignal));
+        controller.abort();
+
+        await expect(request).rejects.toMatchObject({ name: 'AbortError' });
+        expect(requestSignal.aborted).toBe(true);
+    });
+
+    it('cancels a pagination delay without leaving its timer alive', async () => {
+        const controller = new AbortController();
+        const delay = sleep(60_000, { signal: controller.signal });
+
+        controller.abort();
+
+        await expect(delay).rejects.toMatchObject({ name: 'AbortError' });
+    });
+});

--- a/tests/worker/runState.test.js
+++ b/tests/worker/runState.test.js
@@ -1,7 +1,9 @@
 import { describe, expect, it, vi } from 'vitest';
 import {
     acquireAdvisoryLease,
+    failureMarkerKey,
     releaseAdvisoryLease,
+    storeFailureMarker,
     storeTriggerMarker,
     triggerMarkerKey,
 } from '../../src/daily/runState.js';
@@ -37,5 +39,22 @@ describe('structured advisory run state', () => {
         expect(key).not.toContain('scheduled:123');
         await storeTriggerMarker(kv, 'scheduled:123', { commit_sha: 'abc' });
         expect(kv.put.mock.calls[0][2]).toEqual({ expirationTtl: 14 * 24 * 60 * 60 });
+    });
+
+    it('keeps failure records in a namespace separate from success markers', async () => {
+        const kv = fakeKv();
+        const triggerId = 'scheduled:123';
+        const successKey = await triggerMarkerKey(triggerId);
+        const failureKey = await failureMarkerKey(triggerId);
+
+        expect(failureKey).toMatch(/^structured:attempt-failure:[a-f0-9]{64}$/);
+        expect(failureKey).not.toBe(successKey);
+
+        await storeTriggerMarker(kv, triggerId, { success: true, commit_sha: 'abc' });
+        const successBytes = kv.values.get(successKey);
+        await storeFailureMarker(kv, triggerId, { success: false });
+
+        expect(kv.values.get(successKey)).toBe(successBytes);
+        expect(kv.values.get(failureKey)).toBe(JSON.stringify({ success: false }));
     });
 });

--- a/tests/worker/structuredFetch.test.js
+++ b/tests/worker/structuredFetch.test.js
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import { fetchProviderPreservingData } from '../../src/daily/structuredFetch.js';
+import { classifyProviderFailure, ProviderFetchError } from '../../src/daily/providerFailure.js';
 
 function adapter(provider, contentType, items, calls) {
     return {
@@ -32,6 +33,10 @@ describe('provider-preserving structured fetch', () => {
         const result = await fetchProviderPreservingData({}, 'cookie', { adapters });
 
         expect(adapters.every(entry => entry.adapter.fetch.mock.calls.length === 1)).toBe(true);
+        expect(adapters.every(entry => entry.adapter.fetch.mock.calls[0][2].strict === true)).toBe(true);
+        expect(adapters.every(entry => (
+            entry.adapter.fetch.mock.calls[0][2].signal instanceof AbortSignal
+        ))).toBe(true);
         expect(adapters.every(entry => entry.adapter.transform.mock.calls.length === 1)).toBe(true);
         expect(calls).toEqual(adapters.flatMap(entry => [
             `fetch:${entry.provider}`,
@@ -71,18 +76,140 @@ describe('provider-preserving structured fetch', () => {
     it('isolates one provider failure and continues with later providers', async () => {
         const calls = [];
         const broken = adapter('broken', 'news', [], calls);
-        broken.adapter.fetch.mockRejectedValueOnce(new TypeError('offline'));
+        broken.adapter.fetch.mockRejectedValue(new TypeError('offline'));
         const healthy = adapter('healthy', 'project', [{ id: 2, published_date: '2026-07-14' }], calls);
+        const sleep = vi.fn(async () => undefined);
 
-        const result = await fetchProviderPreservingData({}, null, { adapters: [broken, healthy] });
+        const result = await fetchProviderPreservingData({}, null, {
+            adapters: [broken, healthy],
+            retryDelayMs: 0,
+            sleep,
+        });
 
+        expect(broken.adapter.fetch).toHaveBeenCalledTimes(2);
+        expect(sleep).toHaveBeenCalledOnce();
         expect(healthy.adapter.fetch).toHaveBeenCalledOnce();
         expect(result.grouped.project).toHaveLength(1);
         expect(result.errors).toEqual([{
             provider: 'broken',
             content_type: 'news',
-            error_type: 'TypeError',
+            stage: 'fetch',
+            error_type: 'network',
+            attempts: 2,
         }]);
+    });
+
+    it('recovers one transient provider fetch without duplicating transformed items', async () => {
+        const calls = [];
+        const flaky = adapter('flaky', 'news', [{ id: 1, published_date: '2026-07-14' }], calls);
+        flaky.adapter.fetch
+            .mockRejectedValueOnce(new TypeError('temporary'))
+            .mockResolvedValueOnce([{ id: 1, published_date: '2026-07-14' }]);
+        const sleep = vi.fn(async () => undefined);
+
+        const result = await fetchProviderPreservingData({}, null, {
+            adapters: [flaky],
+            retryDelayMs: 0,
+            sleep,
+        });
+
+        expect(flaky.adapter.fetch).toHaveBeenCalledTimes(2);
+        expect(flaky.adapter.transform).toHaveBeenCalledOnce();
+        expect(sleep).toHaveBeenCalledOnce();
+        expect(result.structuredItems).toHaveLength(1);
+        expect(result.errors).toEqual([]);
+    });
+
+    it('does not retry deterministic transform failures', async () => {
+        const calls = [];
+        const broken = adapter('broken', 'news', [{ id: 1 }], calls);
+        broken.adapter.transform.mockImplementationOnce(() => {
+            throw new RangeError('invalid transform');
+        });
+        const sleep = vi.fn(async () => undefined);
+
+        const result = await fetchProviderPreservingData({}, null, {
+            adapters: [broken],
+            retryDelayMs: 0,
+            sleep,
+        });
+
+        expect(broken.adapter.fetch).toHaveBeenCalledOnce();
+        expect(broken.adapter.transform).toHaveBeenCalledOnce();
+        expect(sleep).not.toHaveBeenCalled();
+        expect(result.errors).toEqual([{
+            provider: 'broken',
+            content_type: 'news',
+            stage: 'transform',
+            error_type: 'transform_error',
+            attempts: 1,
+        }]);
+    });
+
+    it('does not retry deterministic provider failures', async () => {
+        const calls = [];
+        const denied = adapter('denied', 'news', [], calls);
+        denied.adapter.fetch.mockRejectedValue(new ProviderFetchError('http_4xx', {
+            retryable: false,
+            status: 401,
+        }));
+        const sleep = vi.fn(async () => undefined);
+
+        const result = await fetchProviderPreservingData({}, null, {
+            adapters: [denied],
+            retryDelayMs: 0,
+            sleep,
+        });
+
+        expect(denied.adapter.fetch).toHaveBeenCalledOnce();
+        expect(sleep).not.toHaveBeenCalled();
+        expect(result.errors).toEqual([{
+            provider: 'denied',
+            content_type: 'news',
+            stage: 'fetch',
+            error_type: 'http_4xx',
+            attempts: 1,
+        }]);
+    });
+
+    it('aborts and retries a provider that exceeds the per-attempt deadline', async () => {
+        const calls = [];
+        const hanging = adapter('hanging', 'news', [], calls);
+        hanging.adapter.fetch.mockImplementation((_env, _cookie, options) => {
+            calls.push(options.signal);
+            return new Promise(() => undefined);
+        });
+        const sleep = vi.fn(async () => undefined);
+
+        const result = await fetchProviderPreservingData({}, null, {
+            adapters: [hanging],
+            fetchTimeoutMs: 5,
+            retryDelayMs: 0,
+            sleep,
+        });
+
+        expect(hanging.adapter.fetch).toHaveBeenCalledTimes(2);
+        expect(calls).toHaveLength(2);
+        expect(calls.every(signal => signal.aborted)).toBe(true);
+        expect(sleep).toHaveBeenCalledOnce();
+        expect(result.errors).toEqual([{
+            provider: 'hanging',
+            content_type: 'news',
+            stage: 'fetch',
+            error_type: 'timeout',
+            attempts: 2,
+        }]);
+    });
+
+    it('normalizes arbitrary provider codes and never trusts retryable metadata', () => {
+        const error = new ProviderFetchError('secret-code', { retryable: true });
+        error.retryable = true;
+
+        expect(classifyProviderFailure(error)).toEqual({
+            code: 'provider_failure',
+            retryable: false,
+            status: null,
+        });
     });
 
     it('matches legacy stable-sort behavior for invalid, missing, and equal dates', async () => {

--- a/tests/worker/structuredSourceAdapters.test.js
+++ b/tests/worker/structuredSourceAdapters.test.js
@@ -1,0 +1,263 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import AibaseDataSource from '../../src/dataSources/aibase.js';
+import GithubTrendingDataSource from '../../src/dataSources/github-trending.js';
+import HuggingfacePapersDataSource from '../../src/dataSources/huggingface-papers.js';
+import JiqizhixinDataSource from '../../src/dataSources/jiqizhixin.js';
+import OpenAInewsroomDataSource from '../../src/dataSources/openai-newsroom.js';
+import QBitDataSource from '../../src/dataSources/qbit.js';
+import RedditDataSource from '../../src/dataSources/reddit.js';
+import TwitterDataSource from '../../src/dataSources/twitter.js';
+import TwitterExtraDataSource from '../../src/dataSources/twitter-extra.js';
+import XiaohuDataSource from '../../src/dataSources/xiaohu.js';
+import XinZhiYuanDataSource from '../../src/dataSources/xinzhiyuan.js';
+import { ProviderFetchError } from '../../src/daily/providerFailure.js';
+import { STRUCTURED_SOURCE_ADAPTERS } from '../../src/daily/sourceAdapters.js';
+
+const FOLO_ADAPTERS = [
+    ['aibase', AibaseDataSource, 'AIBASE_FEED_ID', 'AIBASE_FETCH_PAGES'],
+    ['xiaohu', XiaohuDataSource, 'XIAOHU_FEED_ID', 'XIAOHU_FETCH_PAGES'],
+    ['qbit', QBitDataSource, 'QBIT_FEED_ID', 'QBIT_FETCH_PAGES'],
+    ['xinzhiyuan', XinZhiYuanDataSource, 'XINZHIYUAN_FEED_ID', 'XINZHIYUAN_FETCH_PAGES'],
+    ['openai_newsroom', OpenAInewsroomDataSource, 'OPENAI_NEWSROOM_FEED_ID', 'OPENAI_NEWSROOM_FETCH_PAGES'],
+    ['huggingface_papers', HuggingfacePapersDataSource, 'HGPAPERS_FEED_ID', 'HGPAPERS_FETCH_PAGES'],
+    ['jiqizhixin', JiqizhixinDataSource, 'JIQIZHIXIN_FEED_ID', 'JIQIZHIXIN_FETCH_PAGES'],
+    ['twitter', TwitterDataSource, 'TWITTER_LIST_ID', 'TWITTER_FETCH_PAGES'],
+    ['twitter_extra', TwitterExtraDataSource, 'TWITTER_EXTRA_LIST_ID', 'TWITTER_EXTRA_FETCH_PAGES'],
+    ['reddit', RedditDataSource, 'REDDIT_LIST_ID', 'REDDIT_FETCH_PAGES'],
+];
+
+function envFor(idName, pagesName, overrides = {}) {
+    return {
+        FOLO_DATA_API: 'https://api.folo.example/entries',
+        FOLO_FILTER_DAYS: '3',
+        OPEN_TRANSLATE: 'false',
+        [idName]: 'source-id',
+        [pagesName]: '1',
+        ...overrides,
+    };
+}
+
+function jsonResponse(status, body) {
+    return {
+        ok: status >= 200 && status < 300,
+        status,
+        statusText: status === 200 ? 'OK' : 'Failed',
+        json: vi.fn(async () => body),
+        text: vi.fn(async () => JSON.stringify(body)),
+    };
+}
+
+function validFoloEntry() {
+    return {
+        entries: {
+            id: 'entry-1',
+            url: 'https://example.test/entry-1',
+            title: 'Example',
+            content: '<p>Example</p>',
+            publishedAt: '2026-07-16T08:00:00Z',
+            author: 'Author',
+        },
+        feeds: { title: 'Example feed' },
+    };
+}
+
+afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+});
+
+describe.each(FOLO_ADAPTERS)('%s structured strict contract', (
+    _provider,
+    adapter,
+    idName,
+    pagesName,
+) => {
+    it('rejects missing and invalid configuration without fetching', async () => {
+        const fetchMock = vi.fn();
+        vi.stubGlobal('fetch', fetchMock);
+        const missing = envFor(idName, pagesName);
+        delete missing[idName];
+
+        await expect(adapter.fetch(missing, 'cookie', { strict: true }))
+            .rejects.toMatchObject({ code: 'missing_config', retryable: false });
+        await expect(adapter.fetch(envFor(idName, pagesName, { [pagesName]: '0' }), 'cookie', {
+            strict: true,
+        })).rejects.toMatchObject({ code: 'invalid_config', retryable: false });
+        await expect(adapter.fetch(envFor(idName, pagesName, { [pagesName]: '2pages' }), 'cookie', {
+            strict: true,
+        })).rejects.toMatchObject({ code: 'invalid_config', retryable: false });
+        await expect(adapter.fetch(envFor(idName, pagesName, { FOLO_FILTER_DAYS: 'NaN' }), 'cookie', {
+            strict: true,
+        })).rejects.toMatchObject({ code: 'invalid_config', retryable: false });
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('classifies retryable and deterministic HTTP failures', async () => {
+        vi.stubGlobal('fetch', vi.fn(async () => jsonResponse(503, {})));
+        await expect(adapter.fetch(envFor(idName, pagesName), 'cookie', { strict: true }))
+            .rejects.toMatchObject({ code: 'http_5xx', retryable: true, status: 503 });
+
+        vi.stubGlobal('fetch', vi.fn(async () => jsonResponse(401, {})));
+        await expect(adapter.fetch(envFor(idName, pagesName), 'cookie', { strict: true }))
+            .rejects.toMatchObject({ code: 'http_4xx', retryable: false, status: 401 });
+    });
+
+    it('rejects network, invalid JSON, and invalid response shape', async () => {
+        vi.stubGlobal('fetch', vi.fn(async () => { throw new TypeError('secret network detail'); }));
+        await expect(adapter.fetch(envFor(idName, pagesName), 'cookie', { strict: true }))
+            .rejects.toMatchObject({ code: 'network', retryable: true });
+
+        vi.stubGlobal('fetch', vi.fn(async () => ({
+            ...jsonResponse(200, null),
+            json: vi.fn(async () => { throw new SyntaxError('secret JSON detail'); }),
+        })));
+        await expect(adapter.fetch(envFor(idName, pagesName), 'cookie', { strict: true }))
+            .rejects.toMatchObject({ code: 'invalid_json', retryable: false });
+
+        vi.stubGlobal('fetch', vi.fn(async () => jsonResponse(200, {})));
+        await expect(adapter.fetch(envFor(idName, pagesName), 'cookie', { strict: true }))
+            .rejects.toMatchObject({ code: 'invalid_shape', retryable: false });
+
+        vi.stubGlobal('fetch', vi.fn(async () => jsonResponse(200, { data: [{}] })));
+        await expect(adapter.fetch(envFor(idName, pagesName), 'cookie', { strict: true }))
+            .rejects.toMatchObject({ code: 'invalid_shape', retryable: false });
+
+        const invalidTimestamp = validFoloEntry();
+        invalidTimestamp.entries.publishedAt = 'not-a-date';
+        vi.stubGlobal('fetch', vi.fn(async () => jsonResponse(200, { data: [invalidTimestamp] })));
+        await expect(adapter.fetch(envFor(idName, pagesName), 'cookie', { strict: true }))
+            .rejects.toMatchObject({ code: 'invalid_shape', retryable: false });
+    });
+
+    it('accepts a validated empty page as a legitimate empty result', async () => {
+        const fetchMock = vi.fn(async () => jsonResponse(200, { data: [] }));
+        vi.stubGlobal('fetch', fetchMock);
+        const signal = new AbortController().signal;
+
+        await expect(adapter.fetch(envFor(idName, pagesName), 'cookie', { strict: true, signal }))
+            .resolves.toMatchObject({ items: [] });
+        expect(fetchMock.mock.calls[0][1]).toMatchObject({ signal });
+    });
+
+    it('fails closed instead of returning partial data when a later page fails', async () => {
+        vi.spyOn(Math, 'random').mockReturnValue(0);
+        const fetchMock = vi.fn()
+            .mockResolvedValueOnce(jsonResponse(200, { data: [validFoloEntry()] }))
+            .mockResolvedValueOnce(jsonResponse(503, {}));
+        vi.stubGlobal('fetch', fetchMock);
+
+        await expect(adapter.fetch(envFor(idName, pagesName, { [pagesName]: '2' }), 'cookie', {
+            strict: true,
+        })).rejects.toMatchObject({ code: 'http_5xx', retryable: true });
+        expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+});
+
+describe('github_trending structured strict contract', () => {
+    const validHtml = `
+        <article class="Box-row">
+            <h2><a href="/openai/example">openai / example</a></h2>
+            <p class="col-9">Example project</p>
+        </article>
+    `;
+
+    it('uses the validated GitHub fallback when the primary endpoint fails', async () => {
+        const fetchMock = vi.fn()
+            .mockResolvedValueOnce(jsonResponse(503, {}))
+            .mockResolvedValueOnce({ ...jsonResponse(200, null), text: vi.fn(async () => validHtml) });
+        vi.stubGlobal('fetch', fetchMock);
+
+        const result = await GithubTrendingDataSource.fetch({
+            PROJECTS_API_URL: 'https://primary.example/projects',
+            OPEN_TRANSLATE: 'false',
+        }, null, { strict: true });
+
+        expect(result).toHaveLength(1);
+        expect(result[0]).toMatchObject({ owner: 'openai', name: 'example' });
+    });
+
+    it('fails when both primary and fallback fail or fallback markup drifts', async () => {
+        vi.stubGlobal('fetch', vi.fn()
+            .mockResolvedValueOnce(jsonResponse(503, {}))
+            .mockResolvedValueOnce(jsonResponse(503, {})));
+        await expect(GithubTrendingDataSource.fetch({
+            PROJECTS_API_URL: 'https://primary.example/projects',
+        }, null, { strict: true })).rejects.toMatchObject({ code: 'http_5xx' });
+
+        vi.stubGlobal('fetch', vi.fn()
+            .mockResolvedValueOnce(jsonResponse(200, []))
+            .mockResolvedValueOnce({
+                ...jsonResponse(200, null),
+                text: vi.fn(async () => '<html>changed markup</html>'),
+            }));
+        await expect(GithubTrendingDataSource.fetch({
+            PROJECTS_API_URL: 'https://primary.example/projects',
+        }, null, { strict: true })).rejects.toMatchObject({ code: 'invalid_shape' });
+    });
+
+    it('does not accept malformed primary project data without a valid fallback', async () => {
+        vi.stubGlobal('fetch', vi.fn()
+            .mockResolvedValueOnce(jsonResponse(200, [{ owner: 'openai' }]))
+            .mockResolvedValueOnce(jsonResponse(503, {})));
+
+        await expect(GithubTrendingDataSource.fetch({
+            PROJECTS_API_URL: 'https://primary.example/projects',
+        }, null, { strict: true })).rejects.toBeInstanceOf(ProviderFetchError);
+    });
+
+    it('accepts an explicit upstream empty state', async () => {
+        vi.stubGlobal('fetch', vi.fn()
+            .mockResolvedValueOnce(jsonResponse(200, []))
+            .mockResolvedValueOnce({
+                ...jsonResponse(200, null),
+                text: vi.fn(async () => "There aren't any trending repositories."),
+            }));
+
+        await expect(GithubTrendingDataSource.fetch({
+            PROJECTS_API_URL: 'https://primary.example/projects',
+        }, null, { strict: true })).resolves.toEqual([]);
+    });
+
+    it('does not log primary URL, response body, or payload secrets in strict mode', async () => {
+        const secret = 'secret-query-and-response-token';
+        const logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+        const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+        vi.stubGlobal('fetch', vi.fn()
+            .mockResolvedValueOnce({
+                ...jsonResponse(503, null),
+                text: vi.fn(async () => secret),
+            })
+            .mockResolvedValueOnce(jsonResponse(503, {})));
+
+        await expect(GithubTrendingDataSource.fetch({
+            PROJECTS_API_URL: `https://primary.example/projects?token=${secret}`,
+        }, null, { strict: true })).rejects.toBeInstanceOf(ProviderFetchError);
+
+        vi.stubGlobal('fetch', vi.fn()
+            .mockResolvedValueOnce(jsonResponse(200, { secret }))
+            .mockResolvedValueOnce(jsonResponse(503, {})));
+        await expect(GithubTrendingDataSource.fetch({
+            PROJECTS_API_URL: 'https://primary.example/projects',
+        }, null, { strict: true })).rejects.toBeInstanceOf(ProviderFetchError);
+
+        expect(JSON.stringify(logSpy.mock.calls)).not.toContain(secret);
+        expect(JSON.stringify(errorSpy.mock.calls)).not.toContain(secret);
+    });
+});
+
+it('uses only closed provider failure fields', () => {
+    const error = new ProviderFetchError('network', { retryable: true, status: 503 });
+    expect(error).toMatchObject({
+        name: 'ProviderFetchError',
+        code: 'network',
+        retryable: true,
+        status: 503,
+    });
+});
+
+it('covers every adapter in the structured source registry', () => {
+    expect(STRUCTURED_SOURCE_ADAPTERS.map(entry => entry.provider).sort()).toEqual([
+        ...FOLO_ADAPTERS.map(([provider]) => provider),
+        'github_trending',
+    ].sort());
+});

--- a/tests/worker/structuredWorkflow.test.js
+++ b/tests/worker/structuredWorkflow.test.js
@@ -3,7 +3,10 @@ import {
     AtomicGitConflictError,
     AtomicGitUncertainError,
 } from '../../src/daily/gitAtomic.js';
-import { runStructuredDailyWorkflow } from '../../src/daily/structuredWorkflow.js';
+import {
+    runStructuredDailyWorkflow,
+    StructuredSourceFetchError,
+} from '../../src/daily/structuredWorkflow.js';
 
 const sha = character => character.repeat(40);
 const runInput = {
@@ -85,13 +88,48 @@ describe('structured publication workflow', () => {
         const deps = dependencies({
             fetchData: vi.fn(async () => ({
                 structuredItems: [],
-                errors: [{ provider: 'broken' }],
+                errors: [{
+                    provider: 'broken',
+                    content_type: 'news',
+                    stage: 'fetch',
+                    error_type: 'network',
+                    attempts: 2,
+                }],
             })),
         });
-        await expect(runStructuredDailyWorkflow(env, runInput, deps)).rejects.toThrow('source fetch failed');
+        const run = runStructuredDailyWorkflow(env, runInput, deps);
+        await expect(run).rejects.toMatchObject({
+            name: 'StructuredSourceFetchError',
+            sourceErrors: [{
+                provider: 'broken',
+                content_type: 'news',
+                stage: 'fetch',
+                error_type: 'network',
+                attempts: 2,
+            }],
+        });
+        await expect(run).rejects.toBeInstanceOf(StructuredSourceFetchError);
         expect(deps.resolveSnapshot).not.toHaveBeenCalled();
         expect(deps.commit).not.toHaveBeenCalled();
         expect(deps.releaseLease).toHaveBeenCalledOnce();
+    });
+
+    it('never treats a prior failure marker as a confirmed publication', async () => {
+        const deps = dependencies({
+            readMarker: vi.fn(async () => ({
+                success: false,
+                status: 'failed',
+                error_type: 'StructuredSourceFetchError',
+            })),
+        });
+
+        await expect(runStructuredDailyWorkflow(env, {
+            ...runInput,
+            triggerId: 'scheduled:failed',
+        }, deps)).resolves.toMatchObject({ success: true, commit_sha: sha('e') });
+
+        expect(deps.fetchData).toHaveBeenCalledOnce();
+        expect(deps.commit).toHaveBeenCalledOnce();
     });
 
     it('returns no-op only when all three artifacts match the same snapshot and head is unchanged', async () => {

--- a/tests/worker/workerRegression.test.js
+++ b/tests/worker/workerRegression.test.js
@@ -17,7 +17,118 @@ describe('worker regression guards', () => {
             triggerId: `scheduled:${Date.UTC(2026, 6, 14)}`,
             runAt: '2026-07-14T00:00:00.000Z',
         });
-        expect(waitUntil).toHaveBeenCalledWith(workflowPromise);
+        expect(waitUntil).toHaveBeenCalledOnce();
+        await expect(waitUntil.mock.calls[0][0]).resolves.toEqual({ success: true });
+    });
+
+    it('persists sanitized scheduled failures without converting them to success', async () => {
+        const error = Object.assign(new Error('secret upstream detail'), {
+            name: 'StructuredSourceFetchError',
+            sourceErrors: [{
+                provider: 'aibase',
+                content_type: 'news',
+                stage: 'fetch',
+                error_type: 'network',
+                attempts: 2,
+            }],
+        });
+        const scheduledWorkflow = vi.fn(() => { throw error; });
+        const waitUntil = vi.fn();
+        const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+        const DATA_KV = {
+            put: vi.fn(async () => undefined),
+        };
+        const worker = createWorker({ scheduledWorkflow });
+
+        await worker.scheduled(
+            { scheduledTime: Date.UTC(2026, 6, 14) },
+            { EXTERNAL_WRITES_ENABLED: 'true', DATA_KV },
+            { waitUntil },
+        );
+
+        expect(waitUntil).toHaveBeenCalledOnce();
+        await expect(waitUntil.mock.calls[0][0]).rejects.toBe(error);
+        expect(DATA_KV.put).toHaveBeenCalledOnce();
+        const [markerKey, rawMarker, options] = DATA_KV.put.mock.calls[0];
+        const marker = JSON.parse(rawMarker);
+        expect(marker).toEqual({
+            success: false,
+            status: 'failed',
+            trigger_type: 'scheduled',
+            run_at: '2026-07-14T00:00:00.000Z',
+            error_type: 'structured_source_fetch_failed',
+            source_errors: [{
+                provider: 'aibase',
+                content_type: 'news',
+                stage: 'fetch',
+                error_type: 'network',
+                attempts: 2,
+            }],
+        });
+        expect(markerKey).toMatch(/^structured:attempt-failure:[a-f0-9]{64}$/);
+        expect(options).toEqual({ expirationTtl: 14 * 24 * 60 * 60 });
+        expect(rawMarker).not.toContain('secret upstream detail');
+        expect(JSON.stringify(consoleSpy.mock.calls)).not.toContain('secret upstream detail');
+    });
+
+    it('preserves the original scheduled failure when marker persistence fails', async () => {
+        const error = new RangeError('workflow failed');
+        const scheduledWorkflow = vi.fn(async () => { throw error; });
+        const waitUntil = vi.fn();
+        const worker = createWorker({ scheduledWorkflow });
+
+        await worker.scheduled(
+            { scheduledTime: Date.UTC(2026, 6, 14) },
+            {
+                EXTERNAL_WRITES_ENABLED: 'true',
+                DATA_KV: { put: vi.fn(async () => { throw new Error('KV failed'); }) },
+            },
+            { waitUntil },
+        );
+
+        await expect(waitUntil.mock.calls[0][0]).rejects.toBe(error);
+    });
+
+    it('maps arbitrary failure metadata to closed values before logging or persistence', async () => {
+        const secret = 'secret-cookie-and-token';
+        const error = Object.assign(new Error(secret), {
+            name: secret,
+            cause: new Error(secret),
+            sourceErrors: [{
+                provider: secret,
+                content_type: secret,
+                stage: secret,
+                error_type: secret,
+                attempts: 999,
+            }],
+        });
+        const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+        const waitUntil = vi.fn();
+        const DATA_KV = { put: vi.fn(async () => undefined) };
+        const worker = createWorker({
+            scheduledWorkflow: vi.fn(async () => { throw error; }),
+        });
+
+        await worker.scheduled(
+            { scheduledTime: Date.UTC(2026, 6, 14) },
+            { EXTERNAL_WRITES_ENABLED: 'true', DATA_KV },
+            { waitUntil },
+        );
+        await expect(waitUntil.mock.calls[0][0]).rejects.toBe(error);
+
+        const marker = JSON.parse(DATA_KV.put.mock.calls[0][1]);
+        expect(marker).toMatchObject({
+            error_type: 'scheduled_workflow_failed',
+            source_errors: [{
+                provider: 'unknown',
+                content_type: 'unknown',
+                stage: 'unknown',
+                error_type: 'provider_failure',
+                attempts: 1,
+            }],
+        });
+        expect(JSON.stringify(marker)).not.toContain(secret);
+        expect(JSON.stringify(consoleSpy.mock.calls)).not.toContain(secret);
     });
 
     it('never invokes scheduled workflows when external writes are not explicitly enabled', async () => {


### PR DESCRIPTION
## What changed

- enforce strict, fail-closed contracts across all 11 structured source adapters
- retry only transient network, timeout, 408, 429, and 5xx failures
- add cancellable 30-second provider deadlines across fetches, pagination waits, and translation calls
- persist sanitized scheduled failure evidence in a namespace separate from successful trigger markers
- preserve the original scheduled rejection and legacy best-effort behavior

## Root cause

The production afternoon Cron reached the Worker but failed after source acquisition began, before Git publication. Provider adapters could previously turn malformed, partial, or failed responses into empty/partial success, while scheduled failures had insufficient safe diagnostics. Long-running subrequests also lacked an attempt-level cancellation boundary.

## Impact

Structured publication remains all-or-nothing. Transient source failures receive one bounded retry; deterministic failures stop before build or commit. Failure markers are safe to inspect without weakening successful trigger idempotency.

## Validation

- `npm test` — 327 tests passed
- targeted structured regression suite — 96 tests passed
- `npm run worker:check`
- `npm run worker:check:staging`
- `npm run verify --prefix astro` — 46 tests, 300 pages, 605 route records
- `git diff --check`
- three-round independent review — no remaining P0/P1/P2 findings