### PR TITLE
fix: extend structured provider timeout budget

### DIFF
--- a/src/daily/structuredFetch.js
+++ b/src/daily/structuredFetch.js
@@ -4,7 +4,8 @@ import { classifyProviderFailure } from './providerFailure.js';
 const CONTENT_TYPE_ORDER = ['news', 'project', 'paper', 'socialMedia'];
 const DEFAULT_FETCH_ATTEMPTS = 2;
 const DEFAULT_RETRY_DELAY_MS = 1000;
-const DEFAULT_FETCH_TIMEOUT_MS = 30_000;
+// Folo pagination plus the chat client's own 60-second translation deadline must fit in one attempt.
+export const DEFAULT_FETCH_TIMEOUT_MS = 90_000;
 
 function wait(milliseconds) {
     return new Promise(resolve => setTimeout(resolve, milliseconds));

--- a/tests/worker/structuredFetch.test.js
+++ b/tests/worker/structuredFetch.test.js
@@ -1,5 +1,8 @@
 import { describe, expect, it, vi } from 'vitest';
-import { fetchProviderPreservingData } from '../../src/daily/structuredFetch.js';
+import {
+    DEFAULT_FETCH_TIMEOUT_MS,
+    fetchProviderPreservingData,
+} from '../../src/daily/structuredFetch.js';
 import { classifyProviderFailure, ProviderFetchError } from '../../src/daily/providerFailure.js';
 
 function adapter(provider, contentType, items, calls) {
@@ -199,6 +202,29 @@ describe('provider-preserving structured fetch', () => {
             error_type: 'timeout',
             attempts: 2,
         }]);
+    });
+
+    it('reserves the full ninety-second budget for pagination and translation', async () => {
+        vi.useFakeTimers();
+        try {
+            expect(DEFAULT_FETCH_TIMEOUT_MS).toBe(90_000);
+            const calls = [];
+            const delayed = adapter('delayed', 'news', [], calls);
+            delayed.adapter.fetch.mockImplementation(async () => (
+                await new Promise(resolve => setTimeout(() => resolve([{
+                    id: 1,
+                    published_date: '2026-07-16',
+                }]), 75_000))
+            ));
+
+            const request = fetchProviderPreservingData({}, null, { adapters: [delayed] });
+            await vi.advanceTimersByTimeAsync(75_000);
+
+            await expect(request).resolves.toMatchObject({ errors: [] });
+            expect(delayed.adapter.fetch).toHaveBeenCalledOnce();
+        } finally {
+            vi.useRealTimers();
+        }
     });
 
     it('normalizes arbitrary provider codes and never trusts retryable metadata', () => {


### PR DESCRIPTION
## What changed

- extend the default provider attempt deadline from 30 seconds to 90 seconds
- export and directly assert the default timeout budget
- add a 75-second fake-timer success path alongside the existing timeout/retry test

## Why

The isolated Staging Cron showed that Reddit pagination completed successfully but its best-effort translation was canceled at the 30-second provider deadline. The chat client already has a 60-second internal timeout, and paginated providers need additional network and delay budget. Ninety seconds accommodates both while preserving the existing 120-second upper bound, cancellation, bounded retry, and fail-closed behavior.

## Validation

- targeted timeout/provider tests: 69 passed
- full test suite: 328 passed
- isolated Staging Worker dry-run passed
- `git diff --check`
- independent review: no P0/P1/P2