### PR TITLE
fix: stabilize GitHub Trending identities

### DIFF
--- a/src/daily/structuredFetch.js
+++ b/src/daily/structuredFetch.js
@@ -100,7 +100,7 @@ export async function fetchProviderPreservingData(env, foloCookie, {
         }
 
         try {
-            const transformed = entry.adapter.transform(raw, entry.contentType);
+            const transformed = entry.adapter.transform(raw, entry.contentType, { strict: true });
             if (!Array.isArray(transformed)) throw new Error('Adapter transform must return an array');
             taggedByType[entry.contentType].push(...transformed.map(item => ({
                 provider: entry.provider,

--- a/src/dataSources/github-trending.js
+++ b/src/dataSources/github-trending.js
@@ -228,13 +228,14 @@ JSON Array of Chinese Translations:`;
             };
         });
     },
-    transform: (projectsData, sourceType) => {
+    transform: (projectsData, sourceType, { strict = false } = {}) => {
         const unifiedProjects = [];
         const now = getISODate();
         if (Array.isArray(projectsData)) {
             projectsData.forEach((project, index) => {
                 unifiedProjects.push({
-                    id: index + 1, // Use project.url as ID if available
+                    // Structured runs use the stable canonical URL; legacy keeps its old index ID.
+                    id: strict ? project.url : index + 1,
                     type: sourceType,
                     url: project.url,
                     title: project.name,

--- a/tests/worker/itemIdentity.test.js
+++ b/tests/worker/itemIdentity.test.js
@@ -1,9 +1,11 @@
 import { describe, expect, it } from 'vitest';
 import { canonicalizeUrl, createIdentity } from '../../src/daily/identity.js';
+import { deduplicateSameDay } from '../../src/daily/dedupe.js';
 import { normalizeSourceItem } from '../../src/daily/normalize.js';
 import { SOURCE_REGISTRY } from '../../src/daily/sourceRegistry.js';
 import { STRUCTURED_SOURCE_ADAPTERS } from '../../src/daily/sourceAdapters.js';
 import { dataSources } from '../../src/dataFetchers.js';
+import GithubTrendingDataSource from '../../src/dataSources/github-trending.js';
 
 describe('source registry and stable identity v1', () => {
     it('freezes unique policies for all 11 registered source adapters', () => {
@@ -78,6 +80,35 @@ describe('source registry and stable identity v1', () => {
         });
         expect(first.strategy).toBe('canonical_url');
         expect(second.id).toBe(first.id);
+    });
+
+    it('does not bridge existing GitHub projects when trending order changes', async () => {
+        const alpha = {
+            owner: 'example', name: 'alpha', url: 'https://github.com/example/alpha',
+            description: 'Alpha',
+        };
+        const beta = {
+            owner: 'example', name: 'beta', url: 'https://github.com/example/beta',
+            description: 'Beta',
+        };
+        const legacy = GithubTrendingDataSource.transform([alpha, beta], 'project');
+        const structured = GithubTrendingDataSource.transform([beta, alpha], 'project', { strict: true });
+        const spoofedLegacy = GithubTrendingDataSource.transform([
+            { ...alpha, structured_source_id: 'upstream-controlled-value' },
+        ], 'project');
+        const normalize = async raw => (await normalizeSourceItem(raw, {
+            provider: 'github_trending',
+            batch: 'morning',
+            runAt: '2026-07-16T10:13:03.000Z',
+        })).item;
+        const existing = await Promise.all(legacy.map(normalize));
+        const incoming = await Promise.all(structured.map(normalize));
+
+        expect(() => deduplicateSameDay(existing, incoming)).not.toThrow();
+        expect(deduplicateSameDay(existing, incoming).items).toHaveLength(2);
+        expect(legacy.map(item => item.id)).toEqual([1, 2]);
+        expect(structured.map(item => item.id)).toEqual([beta.url, alpha.url]);
+        expect(spoofedLegacy[0].id).toBe(1);
     });
 
     it('keeps the same source ID distinct across providers', async () => {

--- a/tests/worker/structuredFetch.test.js
+++ b/tests/worker/structuredFetch.test.js
@@ -41,6 +41,7 @@ describe('provider-preserving structured fetch', () => {
             entry.adapter.fetch.mock.calls[0][2].signal instanceof AbortSignal
         ))).toBe(true);
         expect(adapters.every(entry => entry.adapter.transform.mock.calls.length === 1)).toBe(true);
+        expect(adapters.every(entry => entry.adapter.transform.mock.calls[0][2].strict === true)).toBe(true);
         expect(calls).toEqual(adapters.flatMap(entry => [
             `fetch:${entry.provider}`,
             `transform:${entry.provider}`,


### PR DESCRIPTION
## What changed

- use canonical GitHub repository URLs as structured source IDs
- preserve legacy index-based IDs outside strict structured runs
- add regression coverage for reordered Trending results and strict adapter dispatch

## Root cause

GitHub Trending order changes made index-based source claims unstable. An incoming project could inherit another project's old index claim while also carrying its own canonical URL claim, bridging two existing records and failing identity resolution closed.

## Impact

Structured runs now keep each repository identity stable across ranking changes while legacy callers retain their previous behavior.

## Validation

- `npx vitest run tests/worker/itemIdentity.test.js tests/worker/structuredFetch.test.js tests/worker/structuredSourceAdapters.test.js` — 82/82 passed
- `git diff --check` — passed
- independent review — no P0/P1/P2 findings