### PR TITLE
fix: show latest published batch first

### DIFF
--- a/astro/src/components/DailyTimeline.astro
+++ b/astro/src/components/DailyTimeline.astro
@@ -3,6 +3,7 @@ import type { DailyLocale } from '../lib/daily';
 import {
 	cleanTimelineSummary,
 	formatTimelineTime,
+	orderTimelineBatches,
 	type DailyContentType,
 	type StructuredDailyReport,
 } from '../lib/structuredDaily';
@@ -29,6 +30,7 @@ const typeOrder: Array<'all' | DailyContentType> = [
 	'socialMedia',
 ];
 const overview = cleanTimelineSummary(report.overview.text);
+const orderedBatches = orderTimelineBatches(report.batches);
 ---
 
 <link rel="stylesheet" href="/css/daily-timeline.css" />
@@ -118,9 +120,9 @@ const overview = cleanTimelineSummary(report.overview.text);
 
 	<div class="timeline-batches">
 		{
-			report.batches.map((batch) => {
+			orderedBatches.map((batch) => {
 				// The producer stores each batch in ascending chronology for deterministic artifacts.
-				// The reading UI reverses that stable order so the newest item is encountered first.
+				// The reading UI keeps that source untouched while showing each batch's newest item first.
 				const items = batch.item_ids
 					.map((id) => itemById.get(id))
 					.filter((item) => item !== undefined)

--- a/astro/src/lib/structuredDaily.test.ts
+++ b/astro/src/lib/structuredDaily.test.ts
@@ -8,6 +8,8 @@ import {
 	dailyDataDirectory,
 	formatTimelineTime,
 	loadStructuredDailyReport,
+	orderTimelineBatches,
+	type StructuredDailyBatch,
 	type StructuredDailyItem,
 } from './structuredDaily';
 
@@ -98,5 +100,40 @@ describe('timeline time labels', () => {
 				'2026-07-14',
 			),
 		).toBe('—');
+	});
+});
+
+describe('timeline batch order', () => {
+	const batch = (
+		id: StructuredDailyBatch['id'],
+		status: StructuredDailyBatch['status'],
+	): StructuredDailyBatch => ({
+		id,
+		label: id,
+		status,
+		generated_at: status === 'completed' ? '2026-07-16T00:00:00.000Z' : null,
+		item_ids: [],
+	});
+
+	it('shows completed batches newest first and keeps pending batches after them', () => {
+		const batches = [
+			batch('morning', 'completed'),
+			batch('afternoon', 'pending'),
+			batch('night', 'completed'),
+			batch('lateNight', 'pending'),
+		];
+
+		expect(orderTimelineBatches(batches).map(({ id }) => id)).toEqual([
+			'night',
+			'morning',
+			'afternoon',
+			'lateNight',
+		]);
+		expect(batches.map(({ id }) => id)).toEqual([
+			'morning',
+			'afternoon',
+			'night',
+			'lateNight',
+		]);
 	});
 });

--- a/astro/src/lib/structuredDaily.ts
+++ b/astro/src/lib/structuredDaily.ts
@@ -59,6 +59,20 @@ export interface StructuredDailyReport {
 	items: StructuredDailyItem[];
 }
 
+export function orderTimelineBatches(
+	batches: readonly StructuredDailyBatch[],
+): StructuredDailyBatch[] {
+	const completed: StructuredDailyBatch[] = [];
+	const pending: StructuredDailyBatch[] = [];
+
+	for (const batch of batches) {
+		if (batch.status === 'completed') completed.push(batch);
+		else pending.push(batch);
+	}
+
+	return [...completed.reverse(), ...pending];
+}
+
 const reportCache = new Map<string, Promise<StructuredDailyReport | null>>();
 const dateKeyPattern = /^\d{4}-\d{2}-\d{2}$/;
 

--- a/layouts/partials/daily-timeline.html
+++ b/layouts/partials/daily-timeline.html
@@ -71,8 +71,18 @@
     <noscript> · {{ if $isEnglish }}Filters require JavaScript; all items remain visible.{{ else }}筛选需要 JavaScript；当前已展示全部内容。{{ end }}</noscript>
   </div>
 
+  {{- $completedBatches := where $report.batches "status" "completed" -}}
+  {{- $pendingBatches := where $report.batches "status" "ne" "completed" -}}
+  {{- $orderedBatches := slice -}}
+  {{- range (collections.Reverse $completedBatches) -}}
+    {{- $orderedBatches = $orderedBatches | append . -}}
+  {{- end -}}
+  {{- range $pendingBatches -}}
+    {{- $orderedBatches = $orderedBatches | append . -}}
+  {{- end -}}
+
   <div class="timeline-batches">
-    {{ range $report.batches }}
+    {{ range $orderedBatches }}
       {{- $batch := . -}}
       {{- $batchItems := slice -}}
       {{- range $batch.item_ids -}}


### PR DESCRIPTION
## What changed

- show completed daily batches newest first in the Astro timeline
- keep pending batches after published content in their canonical order
- mirror the same ordering in the retained Hugo renderer
- add a regression test that also proves source data is not mutated

## Why

The canonical report stores batches chronologically for deterministic publishing, but the page rendered that storage order directly. After the 23:00 batch published, readers still encountered all 157 morning items before the 120 newer items.

## Validation

- Astro tests: 47 passed
- Astro check and lint: passed
- Hugo/Astro parity: 208 daily routes
- final Astro site contract: 605 routes
- built 2026-07-16 order: night, morning, afternoon pending, lateNight pending
