### PR TITLE
fix: keep highlight migration under rpc owner

### DIFF
--- a/supabase/migrations/20260718000100_content_library_highlights.sql
+++ b/supabase/migrations/20260718000100_content_library_highlights.sql
@@ -274,30 +274,6 @@ begin
 end;
 $$;
 
-reset role;
-
-do $$
-declare function_name text;
-begin
-  foreach function_name in array array[
-    'list_public_highlights_v1', 'list_admin_highlights_v1',
-    'read_admin_highlights_v1', 'create_highlight_v1'
-  ] loop
-    execute format('alter function private.%I(%s) owner to content_rpc_owner',
-      function_name,
-      case function_name
-        when 'list_public_highlights_v1' then 'text,integer'
-        when 'list_admin_highlights_v1' then 'text,integer'
-        when 'read_admin_highlights_v1' then 'jsonb,jsonb,text'
-        else 'text,text,text,text,text,text[],text,text,uuid,jsonb,text'
-      end
-    );
-  end loop;
-end;
-$$;
-
-set local role content_rpc_owner;
-
 revoke all on function private.list_public_highlights_v1(text, integer)
   from public, anon, authenticated, service_role,
        content_ingestor, content_editor, content_controller, content_reader, content_deployer;


### PR DESCRIPTION
## Summary

- remove a redundant post-creation function ownership transfer
- keep table creation, function creation, and grants under the dedicated `content_rpc_owner` role
- avoid requiring the linked Supabase migration role to access the private schema after resetting roles

## Production finding

The first linked push rolled the transaction back at the redundant ownership block with `permission denied for schema private`; no migration was recorded and no partial Highlight data remained.

## Validation

- `bash scripts/test-supabase-local.sh`
- 228 pgTAP assertions pass before and after a second full migration replay