### PR TITLE
fix: preserve Supabase migration writer role

### DIFF
--- a/supabase/migrations/20260718000100_content_library_highlights.sql
+++ b/supabase/migrations/20260718000100_content_library_highlights.sql
@@ -296,6 +296,6 @@ grant execute on function private.create_highlight_v1(
   text, text, text, text, text, text[], text, text, uuid, jsonb, text
 ) to content_editor;
 
-reset role;
-
+-- SET LOCAL ROLE unwinds at COMMIT. RESET ROLE would also clear the Supabase
+-- migration writer's outer role before it records this migration.
 commit;

--- a/supabase/migrations/20260718000200_content_library_highlights_seed.sql
+++ b/supabase/migrations/20260718000200_content_library_highlights_seed.sql
@@ -67,6 +67,5 @@ select
 from source
 on conflict (locale, external_id) do nothing;
 
-reset role;
-
+-- Preserve the Supabase migration writer's outer role; SET LOCAL unwinds here.
 commit;


### PR DESCRIPTION
## Summary

- remove `RESET ROLE` from the two Highlight migrations
- let `SET LOCAL ROLE` unwind at each explicit `COMMIT`, matching the established content migration pattern
- preserve the Supabase CLI outer writer role so it can record migration history

## Production finding

The linked migration SQL ran to the final commit, then migration-history insertion failed because `RESET ROLE` had cleared the CLI writer role. `supabase migration list --linked` confirms neither Highlight migration is recorded remotely.

## Validation

- `bash scripts/test-supabase-local.sh`
- 228 pgTAP assertions pass before and after a second migration replay