### PR TITLE
fix: accept pinned Hugo build metadata

### DIFF
--- a/.github/workflows/content-release.yml
+++ b/.github/workflows/content-release.yml
@@ -104,7 +104,7 @@ jobs:
         run: |
           test "$(node --version)" = "v22.17.0"
           test "$(npm --version)" = "10.9.2"
-          test "$(hugo version | awk '{print $2}' | cut -d+ -f1)" = "v0.147.9"
+          hugo version | grep -Eq '^hugo v0\.147\.9([+-]|[[:space:]])'
 
       - name: Fail closed on unresolved production configuration
         env:


### PR DESCRIPTION
## Summary

- keep the production release gate pinned to Hugo `0.147.9`
- accept the official runner binary suffix (`v0.147.9-<commit>+extended`)
- continue rejecting any other semantic Hugo version

## Validation

- local Homebrew version string passes
- exact failed GitHub runner version string passes
- `v0.147.8` remains rejected

This fixes the first real content release failure from run 29649219883 without weakening the pinned toolchain boundary.