### PR TITLE
fix: isolate search index release identity test

### DIFF
--- a/astro/src/lib/searchIndex.test.ts
+++ b/astro/src/lib/searchIndex.test.ts
@@ -30,7 +30,9 @@ afterEach(async () => {
 describe('knowledge search index', () => {
 	it('returns an empty deterministic index when structured reports are absent', async () => {
 		const directory = await dailyDirectory();
-		await expect(buildKnowledgeSearchIndex({ directory })).resolves.toEqual({
+		await expect(
+			buildKnowledgeSearchIndex({ directory, siteReleaseId: null }),
+		).resolves.toEqual({
 			schema_version: 1,
 			taxonomy_version: 1,
 			site_release_id: null,

--- a/astro/src/lib/searchIndex.ts
+++ b/astro/src/lib/searchIndex.ts
@@ -107,7 +107,10 @@ export async function buildKnowledgeSearchIndex(
 ): Promise<KnowledgeSearchIndex> {
 	const directory = dailyDataDirectory(options.directory);
 	const locale = options.locale ?? 'zh-CN';
-	const siteReleaseId = options.siteReleaseId ?? process.env.CONTENT_RELEASE_ID ?? null;
+	const siteReleaseId =
+		options.siteReleaseId === undefined
+			? (process.env.CONTENT_RELEASE_ID ?? null)
+			: options.siteReleaseId;
 	if (
 		siteReleaseId !== null &&
 		!/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(


### PR DESCRIPTION
## Summary
- honor an explicit null search-index release identity
- isolate the empty-index unit test from production workflow environment variables

## Validation
- `CONTENT_RELEASE_ID=<production-release-id> npm test --prefix astro -- --run src/lib/searchIndex.test.ts`
- production-like `npm run check --prefix astro`
- production-like `npm run lint --prefix astro`
- production-like `npm run test --prefix astro` (67 passed)