### PR TITLE
fix: isolate release workflow tests

### DIFF
--- a/.github/workflows/content-editorial-preview.yml
+++ b/.github/workflows/content-editorial-preview.yml
@@ -109,7 +109,7 @@ jobs:
           export EDITORIAL_PREVIEW_INPUT_URL="$CONTENT_DEPLOYER_ORIGIN/internal/preview-input/$DRAFT_ID/$EDITORIAL_PREVIEW_SHA256"
           npm run check --prefix astro
           npm run lint --prefix astro
-          npm run test --prefix astro
+          env -u CONTENT_RELEASE_ID npm run test --prefix astro
           npm run build --prefix astro
           npm run verify:csp --prefix astro
           npm run verify:site --prefix astro

--- a/.github/workflows/content-release.yml
+++ b/.github/workflows/content-release.yml
@@ -131,7 +131,7 @@ jobs:
         run: |
           npm run check --prefix astro
           npm run lint --prefix astro
-          npm run test --prefix astro
+          env -u CONTENT_RELEASE_ID npm run test --prefix astro
           npm run build --prefix astro
           npm run verify:csp --prefix astro
           npm run verify:site --prefix astro


### PR DESCRIPTION
## Summary
- unset `CONTENT_RELEASE_ID` only while Astro unit tests run
- preserve the immutable release identity for build and manifest verification
- apply the same isolation to production releases and editorial previews

## Validation
- reproduced the old-release environment locally
- `env -u CONTENT_RELEASE_ID npm test --prefix astro -- --run src/lib/searchIndex.test.ts`
- `git diff --check`