### PR TITLE
fix: preserve strong build content etags

### DIFF
--- a/workers/content/deployer/index.test.ts
+++ b/workers/content/deployer/index.test.ts
@@ -160,7 +160,10 @@ describe("authenticated immutable build content", () => {
     );
 
     expect(response.status).toBe(200);
-    expect(response.headers.get("cache-control")).toBe("private, no-store");
+    expect(response.headers.get("cache-control")).toBe(
+      "private, no-store, no-transform",
+    );
+    expect(response.headers.get("content-encoding")).toBe("identity");
     expect(response.headers.get("etag")).toBe(`"sha256-${hash}"`);
     expect(callRpc).toHaveBeenCalledWith(
       "manifest",

--- a/workers/content/deployer/index.ts
+++ b/workers/content/deployer/index.ts
@@ -110,7 +110,8 @@ async function verifiedPrivateObject(
   return new Response(bytes, {
     headers: {
       "Content-Type": "application/json; charset=utf-8",
-      "Cache-Control": "private, no-store",
+      "Cache-Control": "private, no-store, no-transform",
+      "Content-Encoding": "identity",
       ETag: `"sha256-${expectedHash}"`,
       "X-Content-Type-Options": "nosniff",
     },


### PR DESCRIPTION
## Summary
- force identity encoding for authenticated immutable build inputs
- prevent intermediary transformations with `no-transform`
- preserve the strong SHA-bound ETag checked by pinned builds

## Evidence
Cloudflare returned `W/"sha256-..."` with gzip but retained the strong ETag for identity responses.

## Validation
- `npm test` (486 passed)
- `git diff --check`