### PR TITLE
fix: tolerate transient preview edge errors

### DIFF
--- a/scripts/verify-preview.mjs
+++ b/scripts/verify-preview.mjs
@@ -104,7 +104,7 @@ function htmlMetadata(html) {
   };
 }
 
-async function fetchManual(route, attempts = 3) {
+async function fetchManual(route, attempts = 5) {
   let lastError;
   for (let attempt = 0; attempt < attempts; attempt += 1) {
     try {
@@ -121,7 +121,10 @@ async function fetchManual(route, attempts = 3) {
       if (attempt === attempts - 1) throw error;
     }
     await new Promise((resolve) =>
-      setTimeout(resolve, 250 * 2 ** attempt + Math.floor(Math.random() * 100)),
+      setTimeout(
+        resolve,
+        Math.min(4_000, 500 * 2 ** attempt) + Math.floor(Math.random() * 200),
+      ),
     );
   }
   throw lastError;


### PR DESCRIPTION
## Summary
- increase Preview transient response attempts from three to five
- use bounded exponential backoff up to four seconds
- retain exact status, header, media type, identity, and byte checks after a successful response

## Evidence
The newly deployed Preview returned 522 for one CSS asset during the contract scan, then returned 200 in five consecutive direct probes.

## Validation
- `node --check scripts/verify-preview.mjs`
- Prettier and diff checks pass
- affected Preview asset now returns 200 consistently