### PR TITLE
chore: report release identity mismatches

### DIFF
--- a/.github/workflows/content-release.yml
+++ b/.github/workflows/content-release.yml
@@ -138,7 +138,41 @@ jobs:
 
       - name: Verify embedded release identity
         run: |
-          node -e "const m=require('./astro/dist/release-manifests/site-route-manifest.json');const b=m.build;if(b.code_sha!==process.env.EXACT_CODE_SHA||b.source_sha!==process.env.EXACT_CODE_SHA||b.site_release_id!==process.env.SITE_RELEASE_ID||String(b.site_release_sequence)!==process.env.CONTENT_RELEASE_SEQUENCE||b.content_sha256!==process.env.CONTENT_ROOT_SHA256||b.build_environment_version!==process.env.BUILD_ENVIRONMENT_VERSION||b.node_version!=='v22.17.0'||b.npm_version!=='10.9.2'||b.hugo_version!=='0.147.9'||b.build_timezone!=='UTC'||b.build_locale!=='C.UTF-8'||![b.content_schema_version,b.content_taxonomy_version,b.content_serializer_version,b.content_search_contract_version,b.content_source_contract_version].every(Boolean))process.exit(1)"
+          node <<'NODE'
+          const build = require('./astro/dist/release-manifests/site-route-manifest.json').build;
+          const expected = {
+            code_sha: process.env.EXACT_CODE_SHA,
+            source_sha: process.env.EXACT_CODE_SHA,
+            site_release_id: process.env.SITE_RELEASE_ID,
+            site_release_sequence: process.env.CONTENT_RELEASE_SEQUENCE,
+            content_sha256: process.env.CONTENT_ROOT_SHA256,
+            build_environment_version: process.env.BUILD_ENVIRONMENT_VERSION,
+            node_version: 'v22.17.0',
+            npm_version: '10.9.2',
+            hugo_version: '0.147.9',
+            build_timezone: 'UTC',
+            build_locale: 'C.UTF-8',
+          };
+          const mismatches = Object.entries(expected).flatMap(([field, value]) => {
+            const actual = field === 'site_release_sequence'
+              ? String(build[field])
+              : build[field];
+            return actual === value ? [] : [{ field, expected: value, actual }];
+          });
+          for (const field of [
+            'content_schema_version',
+            'content_taxonomy_version',
+            'content_serializer_version',
+            'content_search_contract_version',
+            'content_source_contract_version',
+          ]) {
+            if (!build[field]) mismatches.push({ field, expected: 'present', actual: build[field] });
+          }
+          if (mismatches.length > 0) {
+            console.error(JSON.stringify({ error: 'embedded_release_identity_mismatch', mismatches }, null, 2));
+            process.exit(1);
+          }
+          NODE
 
       - name: Create deterministic content-addressed artifact
         run: |


### PR DESCRIPTION
## Summary
- preserve every exact embedded release identity check
- report the precise expected and actual field on failure
- keep missing content contract fields fail-closed

## Validation
- workflow YAML passes Prettier parsing
- `git diff --check` passes