### PR TITLE
fix: bind pinned builds to exact code sha

### DIFF
--- a/.github/workflows/content-editorial-preview.yml
+++ b/.github/workflows/content-editorial-preview.yml
@@ -103,14 +103,13 @@ jobs:
 
       - name: Build attested draft overlay
         env:
-          GITHUB_SHA: ${{ github.event.inputs.code_sha }}
           EDITORIAL_DRAFT_ID: ${{ github.event.inputs.draft_id }}
         run: |
           export EDITORIAL_PREVIEW_INPUT_URL="$CONTENT_DEPLOYER_ORIGIN/internal/preview-input/$DRAFT_ID/$EDITORIAL_PREVIEW_SHA256"
           npm run check --prefix astro
           npm run lint --prefix astro
           env -u CONTENT_RELEASE_ID npm run test --prefix astro
-          npm run build --prefix astro
+          env -u GITHUB_SHA CF_PAGES_COMMIT_SHA="$EXACT_CODE_SHA" npm run build --prefix astro
           npm run verify:csp --prefix astro
           npm run verify:site --prefix astro
 

--- a/.github/workflows/content-release.yml
+++ b/.github/workflows/content-release.yml
@@ -126,13 +126,11 @@ jobs:
         run: npm test
 
       - name: Build pinned content release
-        env:
-          GITHUB_SHA: ${{ github.event.inputs.code_sha }}
         run: |
           npm run check --prefix astro
           npm run lint --prefix astro
           env -u CONTENT_RELEASE_ID npm run test --prefix astro
-          npm run build --prefix astro
+          env -u GITHUB_SHA CF_PAGES_COMMIT_SHA="$EXACT_CODE_SHA" npm run build --prefix astro
           npm run verify:csp --prefix astro
           npm run verify:site --prefix astro
 

--- a/astro/scripts/build-content-release.mjs
+++ b/astro/scripts/build-content-release.mjs
@@ -88,7 +88,9 @@ async function exactJson(
 }
 
 if (!releaseId) {
-	runRenderer({ SITE_DISPLAY_DATE: await latestStructuredDate(resolve(repoRoot, 'data', 'daily')) });
+	runRenderer({
+		SITE_DISPLAY_DATE: await latestStructuredDate(resolve(repoRoot, 'data', 'daily')),
+	});
 	process.exit(0);
 }
 assertPinnedToolchain(process.version, readNpmVersion());
@@ -316,7 +318,11 @@ await writeFile(
 	resolve(workspace, 'build-input.json'),
 	`${JSON.stringify(
 		{
-			code_sha: process.env.GITHUB_SHA || process.env.CF_PAGES_COMMIT_SHA || null,
+			code_sha:
+				process.env.EXACT_CODE_SHA ||
+				process.env.CF_PAGES_COMMIT_SHA ||
+				process.env.GITHUB_SHA ||
+				null,
 			site_release_id: releaseId,
 			site_release_sequence: manifest.site_release_sequence,
 			content_sha256: manifest.content_root_sha256,

--- a/astro/scripts/generate-site-contract.mjs
+++ b/astro/scripts/generate-site-contract.mjs
@@ -51,6 +51,7 @@ async function artifactFingerprint() {
 
 function sourceSha() {
 	const value =
+		process.env.EXACT_CODE_SHA ||
 		process.env.CF_PAGES_COMMIT_SHA ||
 		process.env.GITHUB_SHA ||
 		execFileSync('git', ['rev-parse', 'HEAD'], {


### PR DESCRIPTION
## Summary
- prevent GitHub reserved `GITHUB_SHA` from overriding the immutable release code SHA
- pass the exact SHA through `CF_PAGES_COMMIT_SHA` for current frozen releases
- prefer `EXACT_CODE_SHA` in future build-input and route-manifest generation
- apply the same correction to editorial Preview builds

## Root cause
On retry, the workflow head advanced to `69a3a15` while the frozen release code remained `76d8347`; GitHub preserved its workflow-head SHA inside the build process.

## Validation
- diagnostic run identified only `code_sha` and `source_sha` drift
- YAML, Node syntax, Prettier, and diff checks pass