### PR TITLE
fix: reduce broker CPU for content-addressed assets

### DIFF
--- a/workers/content/broker/index.ts
+++ b/workers/content/broker/index.ts
@@ -521,10 +521,13 @@ async function fetchContentAddressedAsset(
     throw new Error("Content-addressed artifact asset is unavailable");
   }
   const bytes = new Uint8Array(await object.arrayBuffer());
-  if (
-    (await sha256(bytes)) !== asset.sha256 ||
-    pagesAssetHash({ path: asset.path, bytes }) !== asset.pages_hash
-  ) {
+  // The immutable inventory is already verified against its database-bound
+  // fingerprint before any asset is loaded. Recomputing the Pages BLAKE3 key
+  // here base64-encodes every missing asset and can exhaust Worker CPU for a
+  // media-heavy release. The content SHA is sufficient to prove that these
+  // bytes are the exact bytes named by the verified inventory; Pages still
+  // receives the inventory's precomputed pages_hash as the upload key.
+  if ((await sha256(bytes)) !== asset.sha256) {
     throw new Error("Content-addressed artifact asset hash mismatch");
   }
   return bytes;


### PR DESCRIPTION
## Root cause
The first production promotion exceeded the Worker CPU limit while re-base64-encoding and recomputing BLAKE3 Pages keys for a 98.7 MB content-addressed release (518 files, including 59 MB of video). This left the fenced promotion slot for the reconciler.

## Fix
- keep per-object SHA-256 byte verification against the immutable inventory
- reuse the precomputed Pages asset key already bound by the inventory fingerprint
- avoid redundant base64 + BLAKE3 work inside the Broker

## Verification
- npm test -- --run workers/content/broker/index.test.ts
- npm run content:broker:check
- git diff --check