### PR TITLE
fix: reconcile first promotion after edge convergence

### DIFF
--- a/workers/content/broker/index.ts
+++ b/workers/content/broker/index.ts
@@ -1087,12 +1087,15 @@ async function promote(request: Request, env: Env): Promise<Response> {
             ${context.site_release_id}::uuid, ${token}, ${generation}, true,
             ${sql.json({ ...recovery, restored_site_release_id: previous.site_release_id, deployment_id: restored.id })}
           )`;
-        } else {
+        } else if (!deploymentChanged) {
           await sql`select private.finish_production_recovery_v1(
             ${context.site_release_id}::uuid, ${token}, ${generation}, true,
             ${sql.json({ production_unchanged: true })}
           )`;
         }
+        // If Pages changed during the first-ever promotion there is no prior
+        // release to restore. Keep the slot in verifying so the scheduled
+        // reconciler can commit after delayed multi-edge convergence.
       } catch {
         await sql`select private.finish_production_recovery_v1(
           ${context.site_release_id}::uuid, ${token}, ${generation}, false,


### PR DESCRIPTION
## Root cause
The exact production Pages deployment succeeded, but multi-edge verification did not converge within 60 seconds. With no previous current release to restore, the Broker closed the slot as production_unchanged even though Pages had changed, leaving the database pointer empty.

## Fix
- keep the fenced slot in verifying when the first-ever Pages deployment changed
- let the scheduled reconciler re-verify the now-converged exact deployment
- only mark production_unchanged when Pages was never changed

## Production evidence
- reconciler committed release 28004d58-15d2-4dfa-888f-713f89f7bd4e after edge convergence
- current pointer generation 1 targets Pages deployment 7cc86d6b-f4b6-4e0a-bbd9-e64ceaf100c8

## Verification
- npm test -- --run workers/content/broker/index.test.ts
- npm run content:broker:check
- git diff --check