### PR TITLE
Remove Astro migration placeholder copy from daily archive

### DIFF
--- a/astro/src/components/DailyArchive.astro
+++ b/astro/src/components/DailyArchive.astro
@@ -10,17 +10,11 @@ interface Props {
 
 const { entries, locale } = Astro.props;
 const heading = locale === 'en' ? 'Daily Brief' : '资讯日报';
-const description =
-	locale === 'en'
-		? 'The Astro compatibility archive currently reads the same Markdown as Hugo.'
-		: 'Astro 兼容层当前直接读取 Hugo 使用的同一批 Markdown。';
 ---
 
 <section class="page-shell">
 	<header class="page-heading">
-		<p class="eyebrow">ASTRO MIGRATION · DAY 0</p>
 		<h1>{heading}</h1>
-		<p>{description}</p>
 	</header>
 
 	<div class="archive-list">
@@ -37,7 +31,6 @@ const description =
 						<h2>
 							<a href={href}>{entry.data.title}</a>
 						</h2>
-						{entry.data.description && <p>{entry.data.description}</p>}
 					</article>
 				);
 			})


### PR DESCRIPTION
去掉日报归档页的迁移期占位文案：

- 删除硬编码的 `ASTRO MIGRATION · DAY 0` eyebrow 和 `Astro 兼容层…` 说明段落
- 删除列表卡片中的 `entry.data.description` 渲染（release-pinned 构建生成的占位 description，每条重复无信息量）

`astro check` 通过，0 errors。