### PR TITLE
feat: automate production code releases

### DIFF
--- a/.github/workflows/automatic-code-release.yml
+++ b/.github/workflows/automatic-code-release.yml
@@ -1,0 +1,82 @@
+name: Automatic Code Release
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      code_sha:
+        description: Exact current main SHA to bootstrap or retry
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  actions: read
+
+concurrency:
+  group: automatic-production-code-release
+  cancel-in-progress: false
+
+jobs:
+  request-code-release:
+    runs-on: ubuntu-latest
+    timeout-minutes: 105
+    environment:
+      name: content-production
+    env:
+      EXACT_CODE_SHA: ${{ github.event_name == 'workflow_dispatch' && inputs.code_sha || github.sha }}
+      CODE_RELEASE_ORIGIN: ${{ vars.CONTENT_DEPLOYER_ORIGIN }}
+      CODE_RELEASE_SECRET: ${{ secrets.CODE_RELEASE_SECRET }}
+      CONTENT_CURRENT_URLS: https://content-api.bubblenews.today/v1/current,https://content-api-origin.bubblenews.today/v1/current
+      CODE_RELEASE_WAIT_TIMEOUT_SECONDS: "2700"
+      GH_TOKEN: ${{ github.token }}
+
+    steps:
+      - name: Checkout exact main SHA
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ env.EXACT_CODE_SHA }}
+          fetch-depth: 1
+
+      - name: Verify immutable request identity
+        shell: bash
+        run: |
+          test "$(git rev-parse HEAD)" = "$EXACT_CODE_SHA"
+          [[ "$EXACT_CODE_SHA" =~ ^[0-9a-f]{40}$ ]]
+          test -n "$CODE_RELEASE_ORIGIN"
+          test -n "$CODE_RELEASE_SECRET"
+
+      - name: Require a manual bootstrap SHA to be current main
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        shell: bash
+        run: |
+          current_main_sha="$(gh api "repos/$GITHUB_REPOSITORY/git/ref/heads/main" --jq '.object.sha')"
+          test "$current_main_sha" = "$EXACT_CODE_SHA"
+
+      - name: Fail closed on automatic release configuration
+        run: node scripts/validate-content-production-config.mjs workflow-code-release
+
+      - name: Wait for successful main build verification
+        shell: bash
+        run: |
+          for attempt in $(seq 1 100); do
+            run_json="$(gh run list \
+              --workflow build-and-deploy.yml \
+              --commit "$EXACT_CODE_SHA" \
+              --event push \
+              --limit 1 \
+              --json status,conclusion,databaseId)"
+            status="$(jq -r '.[0].status // ""' <<<"$run_json")"
+            conclusion="$(jq -r '.[0].conclusion // ""' <<<"$run_json")"
+            if [[ "$status" == "completed" ]]; then
+              test "$conclusion" = "success"
+              exit 0
+            fi
+            sleep 15
+          done
+          echo "Timed out waiting for Build and Verify Site" >&2
+          exit 1
+
+      - name: Request and verify production code release
+        run: node scripts/request-code-release.mjs

--- a/scripts/check-content-observability.mjs
+++ b/scripts/check-content-observability.mjs
@@ -194,6 +194,8 @@ function currentIdentity(value) {
     code_sha: String(value?.code_sha || ""),
     content_sha256: String(value?.content_sha256 || ""),
     manifest_sha256: String(value?.manifest_sha256 || ""),
+    content_base_release_id: String(value?.content_base_release_id || ""),
+    release_kind: String(value?.release_kind || "content"),
     site_release_id: String(value?.site_release_id || ""),
     site_release_sequence: Number(value?.site_release_sequence),
   };

--- a/scripts/check-content-observation-window.mjs
+++ b/scripts/check-content-observation-window.mjs
@@ -110,7 +110,12 @@ function checkCoversSlot(check, slot, expected, upperBound) {
     Number.isFinite(lowerBound) &&
     checkedAt >= lowerBound &&
     checkedAt < upperBound &&
-    identityMatches(check.current, slot) &&
+    (identityMatches(check.current, slot) ||
+      (check.current?.release_kind === "code" &&
+        UUID.test(String(check.current?.site_release_id || "")) &&
+        Number(check.current?.site_release_sequence) >
+          Number(slot.site_release_sequence) &&
+        check.current?.content_sha256 === slot.site_content_sha256)) &&
     Array.isArray(check.due_batches) &&
     check.due_batches.some(
       (batch) =>

--- a/scripts/request-code-release.mjs
+++ b/scripts/request-code-release.mjs
@@ -1,0 +1,263 @@
+import { createHmac } from "node:crypto";
+import { pathToFileURL } from "node:url";
+
+const UUID =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const SHA1 = /^[a-f0-9]{40}$/;
+
+function positiveInteger(value, fallback, label) {
+  const normalized = value === undefined ? fallback : Number(value);
+  if (!Number.isInteger(normalized) || normalized <= 0)
+    throw new Error(`${label} must be a positive integer`);
+  return normalized;
+}
+
+function codeReleaseConfiguration(env) {
+  const origin = env.CODE_RELEASE_ORIGIN?.trim();
+  const secret = env.CODE_RELEASE_SECRET?.trim();
+  const codeSha = env.EXACT_CODE_SHA?.trim().toLowerCase();
+  if (!origin || !secret || !SHA1.test(codeSha || ""))
+    throw new Error("Automatic code release configuration is incomplete");
+
+  const requestUrl = new URL("/internal/code-release", origin);
+  if (requestUrl.protocol !== "https:")
+    throw new Error("Code release origin must use HTTPS");
+  const currentUrls = String(env.CONTENT_CURRENT_URLS || "")
+    .split(",")
+    .map((value) => value.trim())
+    .filter(Boolean)
+    .map((value) => new URL(value));
+  if (
+    currentUrls.length < 2 ||
+    new Set(currentUrls.map((url) => url.origin)).size < 2 ||
+    currentUrls.some(
+      (url) =>
+        url.protocol !== "https:" ||
+        url.pathname !== "/v1/current" ||
+        url.search ||
+        url.hash ||
+        url.username ||
+        url.password,
+    )
+  ) {
+    throw new Error(
+      "CONTENT_CURRENT_URLS must contain at least two distinct exact HTTPS /v1/current origins",
+    );
+  }
+  return {
+    codeSha,
+    currentUrls,
+    requestUrl,
+    secret,
+    requestAttempts: positiveInteger(
+      env.CODE_RELEASE_REQUEST_MAX_ATTEMPTS,
+      60,
+      "CODE_RELEASE_REQUEST_MAX_ATTEMPTS",
+    ),
+    requestDelayMs: positiveInteger(
+      env.CODE_RELEASE_REQUEST_DELAY_MS,
+      30_000,
+      "CODE_RELEASE_REQUEST_DELAY_MS",
+    ),
+    pollDelayMs: positiveInteger(
+      env.CODE_RELEASE_POLL_DELAY_MS,
+      15_000,
+      "CODE_RELEASE_POLL_DELAY_MS",
+    ),
+    waitTimeoutMs:
+      positiveInteger(
+        env.CODE_RELEASE_WAIT_TIMEOUT_SECONDS,
+        2700,
+        "CODE_RELEASE_WAIT_TIMEOUT_SECONDS",
+      ) * 1000,
+  };
+}
+
+async function responseJson(response) {
+  const text = await response.text();
+  try {
+    return JSON.parse(text);
+  } catch {
+    return { raw: text.slice(0, 500) };
+  }
+}
+
+async function requestRelease(configuration, dependencies) {
+  const body = JSON.stringify({ code_sha: configuration.codeSha });
+  const signature = createHmac("sha256", configuration.secret)
+    .update(body)
+    .digest("hex");
+  for (
+    let attempt = 1;
+    attempt <= configuration.requestAttempts;
+    attempt += 1
+  ) {
+    const response = await dependencies.fetch(configuration.requestUrl, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Code-Release-Signature": signature,
+      },
+      body,
+    });
+    const result = await responseJson(response);
+
+    if (response.ok) {
+      if (result?.status === "no_changes") {
+        dependencies.log(
+          JSON.stringify({
+            outcome: "no_op",
+            code_sha: configuration.codeSha,
+            changed_file_count: result.changed_file_count || 0,
+          }),
+        );
+        return { outcome: "no_op" };
+      }
+      if (result?.status === "already_current")
+        return { outcome: "already_current", siteReleaseId: null };
+      if (
+        result?.status === "queued" &&
+        UUID.test(String(result.site_release_id || "")) &&
+        String(result.code_sha || "") === configuration.codeSha
+      ) {
+        dependencies.log(
+          JSON.stringify({
+            outcome: "queued",
+            site_release_id: result.site_release_id,
+            code_sha: configuration.codeSha,
+          }),
+        );
+        return {
+          outcome: "queued",
+          siteReleaseId: String(result.site_release_id),
+        };
+      }
+      throw new Error(
+        `Automatic code release returned an unexpected success: ${JSON.stringify(result)}`,
+      );
+    }
+
+    if (
+      response.status === 409 &&
+      result?.error === "code_release_target_superseded" &&
+      SHA1.test(String(result.current_main_sha || ""))
+    ) {
+      dependencies.log(
+        JSON.stringify({
+          outcome: "superseded",
+          requested_code_sha: configuration.codeSha,
+          current_main_sha: result.current_main_sha,
+        }),
+      );
+      return { outcome: "superseded" };
+    }
+    if (![409, 503].includes(response.status) || result?.retryable !== true) {
+      throw new Error(
+        `Automatic code release was rejected (${response.status}): ${JSON.stringify(result)}`,
+      );
+    }
+    if (attempt === configuration.requestAttempts) {
+      throw new Error(
+        `Automatic code release remained unavailable after ${configuration.requestAttempts} attempts`,
+      );
+    }
+    dependencies.log(
+      `Code release request is waiting for a safe production head (${attempt}/${configuration.requestAttempts})`,
+    );
+    await dependencies.sleep(configuration.requestDelayMs);
+  }
+  throw new Error("Automatic code release request exhausted unexpectedly");
+}
+
+function pointerMatches(pointer, codeSha, siteReleaseId) {
+  return (
+    pointer &&
+    typeof pointer === "object" &&
+    String(pointer.code_sha || "") === codeSha &&
+    (!siteReleaseId || String(pointer.site_release_id || "") === siteReleaseId)
+  );
+}
+
+async function waitForCurrentPointer(
+  configuration,
+  siteReleaseId,
+  dependencies,
+) {
+  const startedAt = dependencies.now();
+  let lastObserved = [];
+  while (dependencies.now() - startedAt < configuration.waitTimeoutMs) {
+    const observations = await Promise.all(
+      configuration.currentUrls.map(async (url) => {
+        try {
+          const response = await dependencies.fetch(url, {
+            headers: {
+              Accept: "application/json",
+              "Cache-Control": "no-cache",
+            },
+          });
+          const body = await responseJson(response);
+          return {
+            url: url.origin,
+            ok: response.ok,
+            site_release_id: body?.site_release_id || null,
+            code_sha: body?.code_sha || null,
+            matches:
+              response.ok &&
+              pointerMatches(body, configuration.codeSha, siteReleaseId),
+          };
+        } catch (error) {
+          return {
+            url: url.origin,
+            ok: false,
+            error: error instanceof Error ? error.name : "Error",
+            matches: false,
+          };
+        }
+      }),
+    );
+    lastObserved = observations;
+    if (observations.every((value) => value.matches)) {
+      dependencies.log(
+        JSON.stringify({
+          outcome: "deployed",
+          site_release_id: siteReleaseId || observations[0].site_release_id,
+          code_sha: configuration.codeSha,
+          verified_current_origins: observations.map((value) => value.url),
+        }),
+      );
+      return {
+        outcome: "deployed",
+        siteReleaseId: siteReleaseId || observations[0].site_release_id,
+      };
+    }
+    await dependencies.sleep(configuration.pollDelayMs);
+  }
+  throw new Error(
+    `Automatic code release did not become the verified current pointer before timeout: ${JSON.stringify(lastObserved)}`,
+  );
+}
+
+export async function runCodeRelease(env = process.env, overrides = {}) {
+  const dependencies = {
+    fetch: overrides.fetch || globalThis.fetch,
+    log: overrides.log || console.log,
+    now: overrides.now || Date.now,
+    sleep:
+      overrides.sleep ||
+      ((milliseconds) =>
+        new Promise((resolve) => setTimeout(resolve, milliseconds))),
+  };
+  if (typeof dependencies.fetch !== "function")
+    throw new Error("Fetch is unavailable");
+  const configuration = codeReleaseConfiguration(env);
+  const request = await requestRelease(configuration, dependencies);
+  if (["no_op", "superseded"].includes(request.outcome)) return request;
+  return waitForCurrentPointer(
+    configuration,
+    request.siteReleaseId,
+    dependencies,
+  );
+}
+
+const invokedPath = process.argv[1] ? pathToFileURL(process.argv[1]).href : "";
+if (import.meta.url === invokedPath) await runCodeRelease();

--- a/scripts/test-content-failure-matrix-local.mjs
+++ b/scripts/test-content-failure-matrix-local.mjs
@@ -847,7 +847,22 @@ try {
   );
   const claimFixtures = [];
   for (let index = 0; index < 12; index += 1) {
-    claimFixtures.push(await createRelease(snapshotA, `claim-${index}`));
+    const dispatchId = randomUUID();
+    const payload = {
+      dispatch_id: dispatchId,
+      site_release_id: releaseA.site_release_id,
+      site_release_sequence: releaseA.site_release_sequence,
+      expected_predecessor_id: releaseA.expected_predecessor_id,
+      expected_content_sha: releaseA.contentSha256,
+      code_sha: sha256(`code:claim-${index}`).slice(0, 40),
+      build_environment_version: BUILD_ENV,
+      mode: "shadow",
+    };
+    await admin`
+      insert into private.content_outbox(site_release_id, dispatch_id, payload)
+      values (${releaseA.site_release_id}::uuid, ${dispatchId}::uuid, ${admin.json(payload)})
+    `;
+    claimFixtures.push({ ...releaseA, dispatchId, label: `claim-${index}` });
   }
   const claimResults = await Promise.all(
     Array.from({ length: 50 }, (_, index) =>
@@ -869,7 +884,7 @@ try {
     "Outbox claim was duplicated",
   );
   const reclaimTarget = claimed.find(
-    (claim) => claim.site_release_id !== releaseA.site_release_id,
+    (claim) => claim.dispatch_id !== releaseA.dispatchId,
   );
   await admin`
 		update private.content_outbox set lease_expires_at = clock_timestamp() - interval '1 second'

--- a/scripts/validate-content-production-config.mjs
+++ b/scripts/validate-content-production-config.mjs
@@ -612,6 +612,37 @@ function validateRuntimePreflightEnvironment(env) {
   return { profile: "workflow-runtime-preflight" };
 }
 
+function validateCodeReleaseEnvironment(env) {
+  matches("EXACT_CODE_SHA", env.EXACT_CODE_SHA, SHA1);
+  httpsUrl("CODE_RELEASE_ORIGIN", env.CODE_RELEASE_ORIGIN, {
+    originOnly: true,
+  });
+  secret("CODE_RELEASE_SECRET", env.CODE_RELEASE_SECRET, 32);
+  const currentUrls = required("CONTENT_CURRENT_URLS", env.CONTENT_CURRENT_URLS)
+    .split(",")
+    .map((value) => httpsUrl("CONTENT_CURRENT_URLS", value.trim()));
+  if (currentUrls.length < 2)
+    fail("CONTENT_CURRENT_URLS must contain at least two verifier origins");
+  if (new Set(currentUrls.map((url) => url.origin)).size < 2)
+    fail("CONTENT_CURRENT_URLS must contain distinct verifier origins");
+  if (
+    currentUrls.some(
+      (url) => url.pathname !== "/v1/current" || url.search || url.hash,
+    )
+  ) {
+    fail("CONTENT_CURRENT_URLS must contain exact /v1/current endpoints");
+  }
+  const waitTimeout = Number(
+    required(
+      "CODE_RELEASE_WAIT_TIMEOUT_SECONDS",
+      env.CODE_RELEASE_WAIT_TIMEOUT_SECONDS,
+    ),
+  );
+  if (!Number.isInteger(waitTimeout) || waitTimeout < 60 || waitTimeout > 7200)
+    fail("CODE_RELEASE_WAIT_TIMEOUT_SECONDS must be between 60 and 7200");
+  return { profile: "workflow-code-release" };
+}
+
 export function validateWorkflowEnvironment(profile, env) {
   if (profile === "workflow-release") return validateReleaseEnvironment(env);
   if (profile === "workflow-editorial-preview")
@@ -624,6 +655,9 @@ export function validateWorkflowEnvironment(profile, env) {
   }
   if (profile === "workflow-runtime-preflight") {
     return validateRuntimePreflightEnvironment(env);
+  }
+  if (profile === "workflow-code-release") {
+    return validateCodeReleaseEnvironment(env);
   }
   if (profile === "workflow-observability") {
     return validateObservabilityEnvironment(env);

--- a/supabase/migrations/20260719000100_automatic_code_releases.sql
+++ b/supabase/migrations/20260719000100_automatic_code_releases.sql
@@ -1,0 +1,955 @@
+begin;
+
+alter table private.site_release_reservations
+  alter column report_snapshot_id drop not null,
+  add column if not exists release_kind text not null default 'content',
+  add column if not exists idempotency_key uuid,
+  add column if not exists requested_code_sha text,
+  add column if not exists requested_base_code_sha text,
+  add column if not exists requested_build_environment_version text,
+  add column if not exists source_change_set_sha256 text;
+
+alter table private.site_release_reservations
+  drop constraint if exists site_release_reservations_release_kind_check;
+alter table private.site_release_reservations
+  add constraint site_release_reservations_release_kind_check
+  check (release_kind in ('content', 'code'));
+
+alter table private.site_release_reservations
+  drop constraint if exists site_release_reservations_shape_check;
+alter table private.site_release_reservations
+  add constraint site_release_reservations_shape_check check (
+    (
+      release_kind = 'content'
+      and report_snapshot_id is not null
+      and idempotency_key is null
+      and requested_code_sha is null
+      and requested_base_code_sha is null
+      and requested_build_environment_version is null
+      and source_change_set_sha256 is null
+    )
+    or
+    (
+      release_kind = 'code'
+      and report_snapshot_id is null
+      and idempotency_key is not null
+      and requested_code_sha ~ '^[a-f0-9]{40}$'
+      and requested_base_code_sha ~ '^[a-f0-9]{40}$'
+      and requested_code_sha <> requested_base_code_sha
+      and nullif(btrim(requested_build_environment_version), '') is not null
+      and source_change_set_sha256 ~ '^[a-f0-9]{64}$'
+    )
+  );
+
+create unique index if not exists site_release_reservations_code_idempotency_idx
+  on private.site_release_reservations(idempotency_key)
+  where idempotency_key is not null;
+
+create unique index if not exists site_release_reservations_code_semantic_idx
+  on private.site_release_reservations(
+    expected_predecessor_id,
+    requested_code_sha,
+    requested_build_environment_version
+  )
+  where release_kind = 'code';
+
+alter table private.site_releases
+  add column if not exists release_kind text not null default 'content',
+  add column if not exists content_base_release_id uuid references private.site_releases(id),
+  add column if not exists requested_code_sha text,
+  add column if not exists source_change_set_sha256 text;
+
+alter table private.site_releases
+  drop constraint if exists site_releases_release_kind_check;
+alter table private.site_releases
+  add constraint site_releases_release_kind_check
+  check (release_kind in ('content', 'code'));
+
+alter table private.site_releases
+  drop constraint if exists site_releases_code_shape_check;
+alter table private.site_releases
+  add constraint site_releases_code_shape_check check (
+    (
+      release_kind = 'content'
+      and content_base_release_id is null
+      and requested_code_sha is null
+      and source_change_set_sha256 is null
+    )
+    or
+    (
+      release_kind = 'code'
+      and content_base_release_id is not null
+      and requested_code_sha ~ '^[a-f0-9]{40}$'
+      and source_change_set_sha256 ~ '^[a-f0-9]{64}$'
+    )
+  );
+
+alter table private.content_settings
+  drop constraint if exists content_settings_setting_key_check;
+alter table private.content_settings
+  add constraint content_settings_setting_key_check check (setting_key in (
+    'database_mirror', 'shadow_build', 'publication', 'admin_draft',
+    'admin_preview', 'admin_publish', 'global_suppression', 'code_release'
+  ));
+insert into private.content_settings(setting_key, enabled, updated_by)
+values ('code_release', false, 'migration:automatic-code-release')
+on conflict (setting_key) do nothing;
+
+create table if not exists private.release_head_claims (
+  predecessor_id uuid primary key references private.site_releases(id),
+  reservation_id uuid not null unique references private.site_release_reservations(id),
+  release_kind text not null check (release_kind in ('content', 'code')),
+  expires_at timestamptz,
+  inserted_at timestamptz not null default clock_timestamp()
+);
+
+alter table private.release_head_claims enable row level security;
+alter table private.release_head_claims force row level security;
+drop policy if exists content_rpc_owner_all on private.release_head_claims;
+create policy content_rpc_owner_all on private.release_head_claims
+  for all to content_rpc_owner using (true) with check (true);
+revoke all on private.release_head_claims
+  from public, anon, authenticated, service_role,
+       content_ingestor, content_editor, content_controller,
+       content_reader, content_deployer;
+grant select, insert, update, delete on private.release_head_claims to content_rpc_owner;
+grant select on private.release_head_claims to content_backup;
+
+set local role content_rpc_owner;
+
+create or replace function private.claim_release_head_v1()
+returns trigger
+language plpgsql
+volatile
+security definer
+set search_path = ''
+as $$
+begin
+  if new.expected_predecessor_id is null then return new; end if;
+
+  delete from private.release_head_claims claim
+  using private.site_release_reservations reservation
+  where claim.predecessor_id = new.expected_predecessor_id
+    and reservation.id = claim.reservation_id
+    and (
+      reservation.status = 'abandoned'
+      or (reservation.status = 'reserved' and reservation.expires_at <= clock_timestamp())
+    );
+
+  begin
+    insert into private.release_head_claims(
+      predecessor_id, reservation_id, release_kind, expires_at
+    ) values (
+      new.expected_predecessor_id, new.id, new.release_kind, new.expires_at
+    );
+  exception when unique_violation then
+    raise exception using
+      errcode = '55P03',
+      message = 'Release head is busy; retry from the latest production pointer';
+  end;
+  return new;
+end;
+$$;
+
+set local role postgres;
+do $$
+begin
+  if not exists (
+    select 1 from pg_catalog.pg_trigger
+    where tgname = 'site_release_reservation_claim_head'
+      and tgrelid = 'private.site_release_reservations'::regclass
+      and not tgisinternal
+  ) then
+    create trigger site_release_reservation_claim_head
+    after insert on private.site_release_reservations
+    for each row execute function private.claim_release_head_v1();
+  end if;
+end;
+$$;
+set local role content_rpc_owner;
+
+create or replace function private.release_abandoned_head_v1()
+returns trigger
+language plpgsql
+volatile
+security definer
+set search_path = ''
+as $$
+begin
+  if new.status = 'abandoned' and old.status is distinct from new.status then
+    delete from private.release_head_claims where reservation_id = new.id;
+  elsif new.status = 'finalized' and old.status is distinct from new.status then
+    update private.release_head_claims
+    set expires_at = null
+    where reservation_id = new.id;
+  end if;
+  return new;
+end;
+$$;
+
+set local role postgres;
+do $$
+begin
+  if not exists (
+    select 1 from pg_catalog.pg_trigger
+    where tgname = 'site_release_reservation_release_head'
+      and tgrelid = 'private.site_release_reservations'::regclass
+      and not tgisinternal
+  ) then
+    create trigger site_release_reservation_release_head
+    after update of status on private.site_release_reservations
+    for each row execute function private.release_abandoned_head_v1();
+  end if;
+end;
+$$;
+set local role content_rpc_owner;
+
+create or replace function private.release_terminal_head_v1()
+returns trigger
+language plpgsql
+volatile
+security definer
+set search_path = ''
+as $$
+begin
+  if new.status = 'deployed'
+    or (new.status = 'preview_verified' and new.payload ->> 'mode' = 'shadow')
+    or (
+      new.status = 'dead_letter'
+      and not exists (
+        select 1
+        from private.content_outbox sibling
+        where sibling.site_release_id = new.site_release_id
+          and sibling.id <> new.id
+          and sibling.status not in ('deployed', 'dead_letter')
+          and not (
+            sibling.status = 'preview_verified'
+            and sibling.payload ->> 'mode' = 'shadow'
+          )
+      )
+    ) then
+    delete from private.release_head_claims where reservation_id = new.site_release_id;
+  end if;
+  return new;
+end;
+$$;
+
+set local role postgres;
+do $$
+begin
+  if not exists (
+    select 1 from pg_catalog.pg_trigger
+    where tgname = 'content_outbox_release_terminal_head'
+      and tgrelid = 'private.content_outbox'::regclass
+      and not tgisinternal
+  ) then
+    create trigger content_outbox_release_terminal_head
+    after insert or update on private.content_outbox
+    for each row execute function private.release_terminal_head_v1();
+  end if;
+end;
+$$;
+set local role content_rpc_owner;
+
+revoke all on function private.claim_release_head_v1()
+  from public, anon, authenticated, service_role, content_backup,
+       content_ingestor, content_editor, content_controller,
+       content_reader, content_deployer;
+revoke all on function private.release_abandoned_head_v1()
+  from public, anon, authenticated, service_role, content_backup,
+       content_ingestor, content_editor, content_controller,
+       content_reader, content_deployer;
+revoke all on function private.release_terminal_head_v1()
+  from public, anon, authenticated, service_role, content_backup,
+       content_ingestor, content_editor, content_controller,
+       content_reader, content_deployer;
+
+do $$
+declare
+  current_release_id uuid;
+  active_count integer;
+begin
+  select target_site_release_id into current_release_id
+  from private.release_current_pointer where singleton;
+  if current_release_id is null then return; end if;
+
+  select count(*) into active_count
+  from private.site_release_reservations reservation
+  where reservation.expected_predecessor_id = current_release_id
+    and (
+      (reservation.status = 'reserved' and reservation.expires_at > clock_timestamp())
+      or (
+        reservation.status = 'finalized'
+        and exists (
+          select 1 from private.content_outbox outbox
+          where outbox.site_release_id = reservation.id
+            and outbox.status not in ('deployed', 'dead_letter')
+            and not (
+              outbox.status = 'preview_verified'
+              and outbox.payload ->> 'mode' = 'shadow'
+            )
+        )
+      )
+    );
+  if active_count > 1 then
+    raise exception 'Multiple active children already exist for the production release';
+  end if;
+
+  insert into private.release_head_claims(
+    predecessor_id, reservation_id, release_kind, expires_at
+  )
+  select current_release_id, reservation.id, reservation.release_kind,
+    case when reservation.status = 'reserved' then reservation.expires_at else null end
+  from private.site_release_reservations reservation
+  where reservation.expected_predecessor_id = current_release_id
+    and (
+      (reservation.status = 'reserved' and reservation.expires_at > clock_timestamp())
+      or (
+        reservation.status = 'finalized'
+        and exists (
+          select 1 from private.content_outbox outbox
+          where outbox.site_release_id = reservation.id
+            and outbox.status not in ('deployed', 'dead_letter')
+            and not (
+              outbox.status = 'preview_verified'
+              and outbox.payload ->> 'mode' = 'shadow'
+            )
+        )
+      )
+    )
+  on conflict (predecessor_id) do nothing;
+end;
+$$;
+
+create or replace function private.get_code_release_base_v1()
+returns jsonb
+language sql
+stable
+security definer
+set search_path = ''
+as $$
+  select jsonb_build_object(
+    'site_release_id', release.id,
+    'site_release_sequence', release.sequence,
+    'manifest_object_key', release.manifest_object_key,
+    'manifest_byte_length', release.manifest_byte_length,
+    'manifest_sha256', release.manifest_sha256,
+    'content_root_sha256', release.content_root_sha256,
+    'structured_cutover_date', release.structured_cutover_date,
+    'code_sha', artifact.code_sha,
+    'build_environment_version', artifact.build_environment_version,
+    'pointer_generation', pointer.generation
+  )
+  from private.release_current_pointer pointer
+  join private.site_releases release on release.id = pointer.target_site_release_id
+  join private.release_artifacts artifact on artifact.site_release_id = release.id
+  where pointer.singleton
+$$;
+
+create or replace function private.get_current_release_v1()
+returns jsonb
+language sql
+stable
+security definer
+set search_path = ''
+as $$
+  select jsonb_build_object(
+    'site_release_id', pointer.target_site_release_id,
+    'site_release_sequence', pointer.target_release_sequence,
+    'generation', pointer.generation,
+    'pages_deployment_id', pointer.pages_deployment_id,
+    'manifest_sha256', pointer.manifest_sha256,
+    'content_sha256', release.content_root_sha256,
+    'artifact_sha256', pointer.artifact_sha256,
+    'artifact_fingerprint_sha256', artifact.artifact_fingerprint_sha256,
+    'code_sha', artifact.code_sha,
+    'build_environment_version', pointer.build_environment_version,
+    'release_kind', release.release_kind,
+    'content_base_release_id', release.content_base_release_id
+  )
+  from private.release_current_pointer pointer
+  join private.site_releases release on release.id = pointer.target_site_release_id
+  join private.release_artifacts artifact on artifact.site_release_id = pointer.target_site_release_id
+  where pointer.singleton
+$$;
+
+create or replace function private.list_admin_releases_v1(page_size integer default 50)
+returns jsonb
+language sql
+stable
+security definer
+set search_path = ''
+as $$
+  select coalesce(jsonb_agg(to_jsonb(page) order by sequence desc), '[]'::jsonb)
+  from (
+    select r.id, r.sequence, r.expected_predecessor_id, r.content_root_sha256,
+      r.manifest_sha256, r.inserted_at, r.release_kind,
+      r.content_base_release_id, r.requested_code_sha, r.source_change_set_sha256,
+      (p.target_site_release_id = r.id) as is_current,
+      a.artifact_sha256, a.production_verified_at,
+      (select d.event_type from private.release_deployment_attempts d
+        where d.site_release_id = r.id order by d.id desc limit 1) as latest_event
+    from private.site_releases r
+    left join private.release_current_pointer p on p.singleton
+    left join private.release_artifacts a on a.site_release_id = r.id
+    order by r.sequence desc
+    limit least(greatest(page_size, 1), 100)
+  ) page
+$$;
+
+create or replace function private.reserve_code_release_v1(
+  requested_idempotency_key uuid,
+  code_sha text,
+  base_code_sha text,
+  build_environment_version text,
+  change_set_sha256 text
+)
+returns jsonb
+language plpgsql
+volatile
+security definer
+set search_path = ''
+as $$
+declare
+  reservation private.site_release_reservations%rowtype;
+  base_release private.site_releases%rowtype;
+  base_artifact private.release_artifacts%rowtype;
+  current_release_id uuid;
+  was_idempotent boolean := false;
+begin
+  perform private.require_setting_v1('publication');
+  perform private.require_setting_v1('code_release');
+  if requested_idempotency_key is null
+    or code_sha is null
+    or code_sha !~ '^[a-f0-9]{40}$'
+    or base_code_sha is null
+    or base_code_sha !~ '^[a-f0-9]{40}$'
+    or code_sha = base_code_sha
+    or nullif(btrim(build_environment_version), '') is null
+    or change_set_sha256 is null
+    or change_set_sha256 !~ '^[a-f0-9]{64}$' then
+    raise exception using errcode = '22023', message = 'Invalid code release request';
+  end if;
+
+  perform pg_advisory_xact_lock(42002);
+  select * into reservation
+  from private.site_release_reservations
+  where idempotency_key = requested_idempotency_key
+  for update;
+  if found then
+    was_idempotent := true;
+    if reservation.release_kind <> 'code'
+      or reservation.requested_code_sha <> code_sha
+      or reservation.requested_base_code_sha <> base_code_sha
+      or reservation.requested_build_environment_version <> build_environment_version
+      or reservation.source_change_set_sha256 <> change_set_sha256 then
+      raise exception using errcode = '23505', message = 'Code release idempotency collision';
+    end if;
+    if reservation.status = 'reserved'
+      and reservation.expires_at <= clock_timestamp() then
+      select target_site_release_id into current_release_id
+      from private.release_current_pointer where singleton;
+      if current_release_id is distinct from reservation.expected_predecessor_id then
+        raise exception using errcode = '40001', message = 'Code release base is no longer current';
+      end if;
+      delete from private.release_head_claims claim
+      using private.site_release_reservations stale
+      where claim.predecessor_id = reservation.expected_predecessor_id
+        and stale.id = claim.reservation_id
+        and stale.status = 'reserved'
+        and stale.expires_at <= clock_timestamp();
+      begin
+        insert into private.release_head_claims(
+          predecessor_id, reservation_id, release_kind, expires_at
+        ) values (
+          reservation.expected_predecessor_id, reservation.id,
+          reservation.release_kind, clock_timestamp() + interval '15 minutes'
+        );
+      exception when unique_violation then
+        raise exception using
+          errcode = '55P03',
+          message = 'Release head is busy; retry from the latest production pointer';
+      end;
+      update private.site_release_reservations
+      set expires_at = clock_timestamp() + interval '15 minutes'
+      where id = reservation.id
+      returning * into reservation;
+    end if;
+  else
+    select target_site_release_id into current_release_id
+    from private.release_current_pointer where singleton;
+    select * into base_release from private.site_releases where id = current_release_id;
+    select * into base_artifact from private.release_artifacts where site_release_id = current_release_id;
+    if base_release.id is null or base_artifact.site_release_id is null
+      or base_artifact.code_sha <> base_code_sha then
+      raise exception using errcode = '40001', message = 'Code release base is no longer current';
+    end if;
+
+    insert into private.site_release_reservations(
+      expected_predecessor_id, report_snapshot_id, release_kind,
+      idempotency_key, requested_code_sha, requested_base_code_sha,
+      requested_build_environment_version, source_change_set_sha256
+    ) values (
+      base_release.id, null, 'code', requested_idempotency_key,
+      code_sha, base_code_sha, build_environment_version, change_set_sha256
+    ) returning * into reservation;
+
+    insert into private.site_release_reservation_reports(
+      reservation_id, report_date, report_snapshot_id, byte_sha256
+    )
+    select reservation.id, report_date, report_snapshot_id, byte_sha256
+    from private.site_release_reports
+    where site_release_id = base_release.id;
+  end if;
+
+  select * into base_release
+  from private.site_releases where id = reservation.expected_predecessor_id;
+  return jsonb_build_object(
+    'reservation_id', reservation.id,
+    'site_release_id', reservation.id,
+    'site_release_sequence', reservation.sequence,
+    'expected_predecessor_id', reservation.expected_predecessor_id,
+    'expires_at', reservation.expires_at,
+    'status', reservation.status,
+    'dispatch_id', reservation.idempotency_key,
+    'base_manifest', jsonb_build_object(
+      'object_key', base_release.manifest_object_key,
+      'byte_length', base_release.manifest_byte_length,
+      'sha256', base_release.manifest_sha256
+    ),
+    'content_root_sha256', base_release.content_root_sha256,
+    'idempotent', was_idempotent
+  );
+end;
+$$;
+
+create or replace function private.finalize_code_release_v1(
+  reservation_id uuid,
+  manifest_object_key text,
+  manifest_byte_length bigint,
+  manifest_sha256 text,
+  dispatch_id uuid,
+  dispatch_payload jsonb
+)
+returns jsonb
+language plpgsql
+volatile
+security definer
+set search_path = ''
+as $$
+declare
+  reservation private.site_release_reservations%rowtype;
+  base_release private.site_releases%rowtype;
+  existing_release private.site_releases%rowtype;
+  existing_outbox private.content_outbox%rowtype;
+begin
+  perform private.require_setting_v1('publication');
+  perform private.require_setting_v1('code_release');
+  perform pg_advisory_xact_lock(42002);
+  select * into reservation
+  from private.site_release_reservations
+  where id = reservation_id
+  for update;
+  if not found or reservation.release_kind <> 'code' then
+    raise exception 'Unknown code release reservation';
+  end if;
+
+  if reservation.status = 'finalized' then
+    select * into existing_release from private.site_releases where id = reservation.id;
+    select * into existing_outbox
+    from private.content_outbox
+    where site_release_id = reservation.id
+      and private.content_outbox.dispatch_id = reservation.idempotency_key;
+    if existing_release.id is null
+      or existing_outbox.id is null
+      or existing_release.manifest_object_key is distinct from manifest_object_key
+      or existing_release.manifest_byte_length is distinct from manifest_byte_length
+      or existing_release.manifest_sha256 is distinct from manifest_sha256
+      or existing_release.content_root_sha256 is distinct from (
+        select content_root_sha256 from private.site_releases
+        where id = reservation.expected_predecessor_id
+      )
+      or existing_outbox.dispatch_id is distinct from dispatch_id
+      or existing_outbox.payload is distinct from dispatch_payload then
+      raise exception using errcode = '23505', message = 'Code release finalize idempotency collision';
+    end if;
+    return jsonb_build_object(
+      'site_release_id', existing_release.id,
+      'site_release_sequence', existing_release.sequence,
+      'expected_predecessor_id', existing_release.expected_predecessor_id,
+      'dispatch_id', existing_outbox.dispatch_id,
+      'idempotent', true
+    );
+  end if;
+
+  if dispatch_id is distinct from reservation.idempotency_key then
+    raise exception using errcode = '22023', message = 'Code release dispatch identity mismatch';
+  end if;
+
+  select * into base_release
+  from private.site_releases where id = reservation.expected_predecessor_id;
+  if reservation.status <> 'reserved'
+    or reservation.expires_at <= clock_timestamp()
+    or reservation.expected_predecessor_id is distinct from (
+      select target_site_release_id from private.release_current_pointer where singleton
+    ) then
+    raise exception using errcode = '40001', message = 'Code release predecessor changed';
+  end if;
+  if dispatch_payload is null
+    or jsonb_typeof(dispatch_payload) is distinct from 'object'
+    or dispatch_payload ->> 'mode' is distinct from 'production'
+    or dispatch_payload ->> 'dispatch_id' is distinct from dispatch_id::text
+    or dispatch_payload ->> 'site_release_id' is distinct from reservation.id::text
+    or coalesce(dispatch_payload ->> 'site_release_sequence', '') !~ '^[0-9]+$'
+    or (dispatch_payload ->> 'site_release_sequence')::bigint is distinct from reservation.sequence
+    or dispatch_payload ->> 'expected_predecessor_id'
+      is distinct from reservation.expected_predecessor_id::text
+    or dispatch_payload ->> 'expected_content_sha' is distinct from base_release.content_root_sha256
+    or dispatch_payload ->> 'code_sha' is distinct from reservation.requested_code_sha
+    or dispatch_payload ->> 'build_environment_version'
+      is distinct from reservation.requested_build_environment_version then
+    raise exception using errcode = '22023', message = 'Code release dispatch identity mismatch';
+  end if;
+  if manifest_sha256 is null
+    or manifest_sha256 !~ '^[a-f0-9]{64}$'
+    or manifest_object_key is distinct from 'site-manifests/sha256/' || manifest_sha256 || '.json'
+    or manifest_byte_length is null
+    or manifest_byte_length <= 0
+    or not exists (
+      select 1 from private.site_release_reservation_reports refs
+      where refs.reservation_id = reservation.id
+    )
+    or exists (
+      (select report_date, report_snapshot_id, byte_sha256
+       from private.site_release_reservation_reports
+       where private.site_release_reservation_reports.reservation_id = reservation.id)
+      except
+      (select report_date, report_snapshot_id, byte_sha256
+       from private.site_release_reports
+       where site_release_id = base_release.id)
+    )
+    or exists (
+      (select report_date, report_snapshot_id, byte_sha256
+       from private.site_release_reports
+       where site_release_id = base_release.id)
+      except
+      (select report_date, report_snapshot_id, byte_sha256
+       from private.site_release_reservation_reports
+       where private.site_release_reservation_reports.reservation_id = reservation.id)
+    ) then
+    raise exception 'Code release content clone mismatch';
+  end if;
+
+  insert into private.site_releases(
+    id, sequence, expected_predecessor_id, manifest_object_key,
+    manifest_byte_length, manifest_sha256, content_root_sha256,
+    schema_version, taxonomy_version, serializer_version,
+    search_contract_version, source_contract_version,
+    structured_cutover_date, no_report_days, release_kind,
+    content_base_release_id, requested_code_sha, source_change_set_sha256
+  ) values (
+    reservation.id, reservation.sequence, reservation.expected_predecessor_id,
+    manifest_object_key, manifest_byte_length, manifest_sha256,
+    base_release.content_root_sha256, base_release.schema_version,
+    base_release.taxonomy_version, base_release.serializer_version,
+    base_release.search_contract_version, base_release.source_contract_version,
+    base_release.structured_cutover_date, base_release.no_report_days, 'code',
+    coalesce(base_release.content_base_release_id, base_release.id),
+    reservation.requested_code_sha,
+    reservation.source_change_set_sha256
+  );
+  insert into private.site_release_reports(
+    site_release_id, report_date, report_snapshot_id, byte_sha256
+  )
+  select reservation.id, report_date, report_snapshot_id, byte_sha256
+  from private.site_release_reservation_reports
+  where private.site_release_reservation_reports.reservation_id = reservation.id;
+  insert into private.content_outbox(site_release_id, dispatch_id, payload)
+  values (reservation.id, dispatch_id, dispatch_payload);
+  insert into private.release_deployment_attempts(site_release_id, dispatch_id, event_type)
+  values (reservation.id, dispatch_id, 'queued');
+  update private.site_release_reservations
+  set status = 'finalized'
+  where id = reservation.id;
+
+  return jsonb_build_object(
+    'site_release_id', reservation.id,
+    'site_release_sequence', reservation.sequence,
+    'expected_predecessor_id', reservation.expected_predecessor_id,
+    'dispatch_id', dispatch_id,
+    'idempotent', false
+  );
+end;
+$$;
+
+create or replace function private.defer_editorial_publish_request_v1(
+  publish_request_id uuid,
+  worker_id text,
+  error_code text
+)
+returns void
+language plpgsql
+volatile
+security definer
+set search_path = ''
+as $$
+declare request private.editorial_publish_requests%rowtype;
+begin
+  if error_code is null or error_code not in ('55P03', '40001') then
+    raise exception using errcode = '22023', message = 'Editorial deferral requires a transient release-head conflict';
+  end if;
+  select * into request
+  from private.editorial_publish_requests
+  where id = publish_request_id
+  for update;
+  if request.id is null
+    or request.status <> 'claimed'
+    or request.locked_by is distinct from worker_id then
+    raise exception 'Editorial publish deferral ownership conflict';
+  end if;
+
+  update private.site_release_reservations
+  set status = 'abandoned'
+  where id = request.reservation_id and status = 'reserved';
+  update private.editorial_overrides value
+  set status = 'cleared'
+  where value.status = 'staged'
+    and exists (
+      select 1
+      from private.editorial_staged_overrides staged
+      where staged.publish_request_id = request.id
+        and staged.override_id = value.id
+    );
+  delete from private.editorial_staged_overrides staged
+  where staged.publish_request_id = request.id;
+  update private.editorial_publish_requests value
+  set status = 'queued',
+      locked_by = null,
+      lease_expires_at = null,
+      reservation_id = null,
+      error_code = left(defer_editorial_publish_request_v1.error_code, 200),
+      updated_at = clock_timestamp()
+  where value.id = request.id;
+end;
+$$;
+
+create or replace function private.defer_global_suppression_request_v1(
+  suppression_request_id uuid,
+  worker_id text,
+  error_code text
+)
+returns void
+language plpgsql
+volatile
+security definer
+set search_path = ''
+as $$
+declare request private.global_suppression_requests%rowtype;
+begin
+  if error_code is null or error_code not in ('55P03', '40001') then
+    raise exception using errcode = '22023', message = 'Global suppression deferral requires a transient release-head conflict';
+  end if;
+  select * into request
+  from private.global_suppression_requests
+  where id = suppression_request_id
+  for update;
+  if request.id is null
+    or request.status <> 'claimed'
+    or request.locked_by is distinct from worker_id then
+    raise exception 'Global suppression deferral ownership conflict';
+  end if;
+
+  update private.site_release_reservations
+  set status = 'abandoned'
+  where id = request.reservation_id and status = 'reserved';
+  update private.global_suppression_requests value
+  set status = 'queued',
+      locked_by = null,
+      lease_expires_at = null,
+      reservation_id = null,
+      error_code = left(defer_global_suppression_request_v1.error_code, 200),
+      updated_at = clock_timestamp()
+  where value.id = request.id;
+end;
+$$;
+
+create or replace function private.rebuild_content_release_v1(
+  site_release_id uuid,
+  reason text,
+  typed_confirmation text,
+  idempotency_key uuid,
+  assertion jsonb,
+  body_sha256 text
+)
+returns jsonb
+language plpgsql
+volatile
+security definer
+set search_path = ''
+as $$
+declare
+  actor record;
+  existing jsonb;
+  release_row private.site_releases%rowtype;
+  source_outbox private.content_outbox%rowtype;
+  new_outbox private.content_outbox%rowtype;
+  current_release_id uuid;
+  claimed_predecessor_id uuid;
+  new_dispatch_id uuid := gen_random_uuid();
+  result jsonb;
+begin
+  select * into actor from private.consume_attestation_v1(
+    assertion, 'content-control', 'operations.rebuild', body_sha256, array['Owner']
+  );
+  existing := private.reserve_admin_idempotency_v1(
+    'content-control', 'operations.rebuild', idempotency_key, actor.actor_sub, body_sha256
+  );
+  if existing is not null then return existing; end if;
+  if coalesce(char_length(btrim(reason)), 0) < 8
+    or typed_confirmation is distinct from 'REBUILD ' || rebuild_content_release_v1.site_release_id::text then
+    raise exception 'Invalid rebuild confirmation';
+  end if;
+
+  perform pg_advisory_xact_lock(42002);
+  select * into release_row
+  from private.site_releases value
+  where value.id = rebuild_content_release_v1.site_release_id;
+  if release_row.id is null then raise exception 'Unknown site release'; end if;
+  select target_site_release_id into current_release_id
+  from private.release_current_pointer
+  where singleton;
+
+  select * into source_outbox
+  from private.content_outbox value
+  where value.site_release_id = rebuild_content_release_v1.site_release_id
+  order by value.inserted_at desc, value.id desc
+  limit 1;
+  if source_outbox.id is null then raise exception 'Release has no dispatch identity'; end if;
+  if source_outbox.status not in ('failed', 'dead_letter') then
+    raise exception 'Release latest dispatch is not rebuildable';
+  end if;
+  if exists (
+    select 1
+    from private.content_outbox sibling
+    where sibling.site_release_id = rebuild_content_release_v1.site_release_id
+      and sibling.id <> source_outbox.id
+      and sibling.status not in ('deployed', 'dead_letter')
+      and not (
+        sibling.status = 'preview_verified'
+        and sibling.payload ->> 'mode' = 'shadow'
+      )
+  ) then
+    raise exception using
+      errcode = '55P03',
+      message = 'Release already has actionable dispatch work';
+  end if;
+  if source_outbox.payload ->> 'mode' = 'production' then
+    perform private.require_setting_v1('publication');
+  elsif source_outbox.payload ->> 'mode' = 'shadow' then
+    perform private.require_setting_v1('shadow_build');
+  else
+    raise exception 'Release outbox has an invalid mode';
+  end if;
+
+  if source_outbox.payload ->> 'mode' = 'production'
+    and release_row.id is distinct from current_release_id then
+    if release_row.expected_predecessor_id is distinct from current_release_id then
+      raise exception using errcode = '40001', message = 'Rebuild predecessor is no longer current';
+    end if;
+    if not exists (
+      select 1
+      from private.site_release_reservations reservation
+      where reservation.id = release_row.id
+        and reservation.status = 'finalized'
+    ) then
+      raise exception 'Release reservation is unavailable for rebuild';
+    end if;
+    insert into private.release_head_claims(
+      predecessor_id, reservation_id, release_kind, expires_at
+    ) values (
+      release_row.expected_predecessor_id, release_row.id,
+      release_row.release_kind, null
+    )
+    on conflict (predecessor_id) do update set
+      reservation_id = excluded.reservation_id,
+      release_kind = excluded.release_kind,
+      expires_at = null
+    where private.release_head_claims.reservation_id = excluded.reservation_id
+    returning predecessor_id into claimed_predecessor_id;
+    if claimed_predecessor_id is null then
+      raise exception using
+        errcode = '55P03',
+        message = 'Release head is busy; retry from the latest production pointer';
+    end if;
+  end if;
+
+  insert into private.content_outbox(site_release_id, dispatch_id, payload)
+  values (
+    rebuild_content_release_v1.site_release_id,
+    new_dispatch_id,
+    source_outbox.payload || jsonb_build_object('dispatch_id', new_dispatch_id::text)
+  )
+  returning * into new_outbox;
+  insert into private.release_deployment_attempts(
+    site_release_id, dispatch_id, event_type, evidence
+  ) values (
+    rebuild_content_release_v1.site_release_id, new_dispatch_id, 'queued',
+    jsonb_build_object(
+      'kind', 'manual_rebuild',
+      'requested_by', actor.actor_sub,
+      'source_dispatch_id', source_outbox.dispatch_id
+    )
+  );
+  result := jsonb_build_object(
+    'outbox_id', new_outbox.id,
+    'site_release_id', new_outbox.site_release_id,
+    'dispatch_id', new_outbox.dispatch_id,
+    'source_dispatch_id', source_outbox.dispatch_id,
+    'status', new_outbox.status
+  );
+  insert into private.content_audit_log(
+    actor_sub, actor_email, actor_role, action, reason, request_id,
+    idempotency_key, target, result
+  ) values (
+    actor.actor_sub, actor.actor_email, actor.actor_role, 'operations.rebuild', reason,
+    actor.assertion_jti::text, idempotency_key::text,
+    jsonb_build_object(
+      'site_release_id', rebuild_content_release_v1.site_release_id,
+      'source_dispatch_id', source_outbox.dispatch_id,
+      'dispatch_id', new_dispatch_id
+    ),
+    'queued'
+  );
+  perform private.complete_admin_idempotency_v1(
+    'content-control', 'operations.rebuild', idempotency_key, result
+  );
+  return result;
+end;
+$$;
+
+revoke all on function private.get_code_release_base_v1()
+  from public, anon, authenticated, service_role, content_backup,
+       content_ingestor, content_editor, content_controller, content_reader;
+revoke all on function private.reserve_code_release_v1(uuid, text, text, text, text)
+  from public, anon, authenticated, service_role, content_backup,
+       content_ingestor, content_editor, content_controller, content_reader;
+revoke all on function private.finalize_code_release_v1(uuid, text, bigint, text, uuid, jsonb)
+  from public, anon, authenticated, service_role, content_backup,
+       content_ingestor, content_editor, content_controller, content_reader;
+revoke all on function private.defer_editorial_publish_request_v1(uuid, text, text)
+  from public, anon, authenticated, service_role, content_backup,
+       content_editor, content_controller, content_reader, content_deployer;
+revoke all on function private.defer_global_suppression_request_v1(uuid, text, text)
+  from public, anon, authenticated, service_role, content_backup,
+       content_editor, content_controller, content_reader, content_deployer;
+grant execute on function private.get_code_release_base_v1() to content_deployer;
+grant execute on function private.reserve_code_release_v1(uuid, text, text, text, text)
+  to content_deployer;
+grant execute on function private.finalize_code_release_v1(uuid, text, bigint, text, uuid, jsonb)
+  to content_deployer;
+grant execute on function private.defer_editorial_publish_request_v1(uuid, text, text)
+  to content_ingestor;
+grant execute on function private.defer_global_suppression_request_v1(uuid, text, text)
+  to content_ingestor;
+
+commit;

--- a/supabase/tests/database/automatic_code_release.test.sql
+++ b/supabase/tests/database/automatic_code_release.test.sql
@@ -1,0 +1,485 @@
+begin;
+
+create extension if not exists pgtap with schema extensions;
+select plan(30);
+
+select ok(
+  has_function_privilege(
+    'content_deployer',
+    'private.reserve_code_release_v1(uuid,text,text,text,text)',
+    'execute'
+  ),
+  'deployer can reserve automatic code releases'
+);
+select ok(
+  has_function_privilege(
+    'content_deployer',
+    'private.finalize_code_release_v1(uuid,text,bigint,text,uuid,jsonb)',
+    'execute'
+  ),
+  'deployer can finalize automatic code releases'
+);
+select ok(
+  not has_function_privilege(
+    'content_controller',
+    'private.reserve_code_release_v1(uuid,text,text,text,text)',
+    'execute'
+  ),
+  'interactive controllers cannot bypass automatic code release validation'
+);
+select ok(
+  has_table_privilege('content_backup', 'private.release_head_claims', 'select')
+    and not has_table_privilege('content_backup', 'private.release_head_claims', 'insert'),
+  'backup role can read but cannot mutate release head claims'
+);
+select ok(
+  has_function_privilege(
+    'content_ingestor',
+    'private.defer_editorial_publish_request_v1(uuid,text,text)',
+    'execute'
+  ) and has_function_privilege(
+    'content_ingestor',
+    'private.defer_global_suppression_request_v1(uuid,text,text)',
+    'execute'
+  ),
+  'ingestor can defer transient editorial and suppression head conflicts'
+);
+select ok(
+  not has_function_privilege(
+    'content_editor',
+    'private.defer_editorial_publish_request_v1(uuid,text,text)',
+    'execute'
+  ) and not has_function_privilege(
+    'content_controller',
+    'private.defer_global_suppression_request_v1(uuid,text,text)',
+    'execute'
+  ) and not has_function_privilege(
+    'content_deployer',
+    'private.defer_editorial_publish_request_v1(uuid,text,text)',
+    'execute'
+  ),
+  'non-ingestor runtime roles cannot defer publication requests'
+);
+
+create temporary table code_reservation(result jsonb);
+create temporary table finalized_code_release(result jsonb);
+create temporary table rebuild_result(result jsonb);
+create temporary table second_code_reservation(result jsonb);
+create temporary table second_code_release(result jsonb);
+grant all on code_reservation, finalized_code_release, rebuild_result,
+  second_code_reservation, second_code_release to content_rpc_owner;
+
+set local role content_rpc_owner;
+select is(
+  (select enabled from private.content_settings where setting_key = 'code_release'),
+  false,
+  'automatic code releases remain disabled until explicitly enabled after bootstrap'
+);
+update private.content_settings set enabled = true
+where setting_key in ('publication', 'code_release');
+
+insert into private.report_snapshots(
+  id, report_date, report_version, parsed_document, object_key,
+  byte_length, byte_sha256, serializer_version
+) values (
+  '10000000-0000-4000-8000-000000000001', '2026-07-19', 1,
+  '{"date":"2026-07-19","items":[],"batches":[]}'::jsonb,
+  'report-snapshots/sha256/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.json',
+  42, repeat('a', 64), 'daily-json-c14n-v1'
+);
+insert into private.site_releases(
+  id, sequence, expected_predecessor_id, manifest_object_key,
+  manifest_byte_length, manifest_sha256, content_root_sha256,
+  schema_version, taxonomy_version, serializer_version,
+  search_contract_version, source_contract_version,
+  structured_cutover_date, no_report_days
+) values (
+  '20000000-0000-4000-8000-000000000001', 9001, null,
+  'site-manifests/sha256/bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb.json',
+  100, repeat('b', 64), repeat('c', 64), 1, 1,
+  'daily-json-c14n-v1', 'search-v1', 'daily-source-v1', '2026-07-16', '{}'
+);
+insert into private.site_release_reports(
+  site_release_id, report_date, report_snapshot_id, byte_sha256
+) values (
+  '20000000-0000-4000-8000-000000000001', '2026-07-19',
+  '10000000-0000-4000-8000-000000000001', repeat('a', 64)
+);
+insert into private.release_artifacts(
+  site_release_id, object_key, byte_length, artifact_sha256,
+  artifact_fingerprint_sha256, hash_algorithm, code_sha,
+  build_environment_version, production_verified_at
+) values (
+  '20000000-0000-4000-8000-000000000001',
+  'artifacts/sha256/dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd.json',
+  100, repeat('d', 64), repeat('e', 64),
+  'sha256-content-addressed-pages-v1', repeat('3', 40),
+  'node22.17-astro7-hugo0.147.9-v1', clock_timestamp()
+);
+insert into private.release_current_pointer(
+  singleton, target_site_release_id, target_release_sequence, generation,
+  pages_deployment_id, manifest_sha256, artifact_sha256,
+  build_environment_version
+) values (
+  true, '20000000-0000-4000-8000-000000000001', 9001, 1,
+  'base-pages-deployment', repeat('b', 64), repeat('d', 64),
+  'node22.17-astro7-hugo0.147.9-v1'
+);
+
+insert into code_reservation(result)
+select private.reserve_code_release_v1(
+  '30000000-0000-4000-8000-000000000001', repeat('4', 40), repeat('3', 40),
+  'node22.17-astro7-hugo0.147.9-v1', repeat('f', 64)
+) as result;
+
+select is(
+  (select result ->> 'expected_predecessor_id' from code_reservation),
+  '20000000-0000-4000-8000-000000000001',
+  'code release is based on the current production release'
+);
+select is(
+  (select result ->> 'content_root_sha256' from code_reservation),
+  repeat('c', 64),
+  'code release preserves the current content root'
+);
+select is(
+  (select count(*) from private.site_release_reservation_reports
+   where reservation_id = (select (result ->> 'reservation_id')::uuid from code_reservation)),
+  1::bigint,
+  'code release clones every current report reference'
+);
+select is(
+  (select result ->> 'dispatch_id' from code_reservation),
+  '30000000-0000-4000-8000-000000000001',
+  'reservation returns a deterministic dispatch identity bound to its idempotency key'
+);
+select throws_ok(
+  $$select private.reserve_site_release_v1('10000000-0000-4000-8000-000000000001')$$,
+  '55P03',
+  'Release head is busy; retry from the latest production pointer',
+  'content and code releases cannot form sibling children'
+);
+
+insert into finalized_code_release(result)
+select private.finalize_code_release_v1(
+  (select (result ->> 'reservation_id')::uuid from code_reservation),
+  'site-manifests/sha256/1111111111111111111111111111111111111111111111111111111111111111.json',
+  101, repeat('1', 64),
+  '30000000-0000-4000-8000-000000000001',
+  jsonb_build_object(
+    'dispatch_id', '30000000-0000-4000-8000-000000000001',
+    'site_release_id', (select result ->> 'site_release_id' from code_reservation),
+    'site_release_sequence', (select (result ->> 'site_release_sequence')::bigint from code_reservation),
+    'expected_predecessor_id', '20000000-0000-4000-8000-000000000001',
+    'expected_content_sha', repeat('c', 64),
+    'code_sha', repeat('4', 40),
+    'build_environment_version', 'node22.17-astro7-hugo0.147.9-v1',
+    'mode', 'production'
+  )
+) as result;
+
+select is(
+  (select release_kind from private.site_releases
+   where id = (select (result ->> 'site_release_id')::uuid from finalized_code_release)),
+  'code',
+  'finalized release records its code-only lineage'
+);
+select is(
+  (select content_root_sha256 from private.site_releases
+   where id = (select (result ->> 'site_release_id')::uuid from finalized_code_release)),
+  repeat('c', 64),
+  'finalized code release keeps content byte-identical'
+);
+select is(
+  (select payload ->> 'code_sha' from private.content_outbox
+   where site_release_id = (select (result ->> 'site_release_id')::uuid from finalized_code_release)),
+  repeat('4', 40),
+  'outbox pins the requested main code SHA'
+);
+select is(
+  (select content_base_release_id::text from private.site_releases
+   where id = (select (result ->> 'site_release_id')::uuid from finalized_code_release)),
+  '20000000-0000-4000-8000-000000000001',
+  'first code release records the canonical content-bearing base release'
+);
+select is(
+  (
+    select private.finalize_code_release_v1(
+      (select (result ->> 'reservation_id')::uuid from code_reservation),
+      'site-manifests/sha256/1111111111111111111111111111111111111111111111111111111111111111.json',
+      101, repeat('1', 64),
+      '30000000-0000-4000-8000-000000000001',
+      jsonb_build_object(
+        'dispatch_id', '30000000-0000-4000-8000-000000000001',
+        'site_release_id', (select result ->> 'site_release_id' from code_reservation),
+        'site_release_sequence', (select (result ->> 'site_release_sequence')::bigint from code_reservation),
+        'expected_predecessor_id', '20000000-0000-4000-8000-000000000001',
+        'expected_content_sha', repeat('c', 64),
+        'code_sha', repeat('4', 40),
+        'build_environment_version', 'node22.17-astro7-hugo0.147.9-v1',
+        'mode', 'production'
+      )
+    ) ->> 'idempotent'
+  ),
+  'true',
+  'finalize replays the exact deterministic tuple idempotently'
+);
+select is(
+  (select count(*) from private.content_outbox
+   where site_release_id = (select (result ->> 'site_release_id')::uuid from finalized_code_release)),
+  1::bigint,
+  'deterministic finalize replay creates no duplicate outbox work'
+);
+select throws_ok(
+  $$select private.reserve_site_release_v1('10000000-0000-4000-8000-000000000001')$$,
+  '55P03',
+  'Release head is busy; retry from the latest production pointer',
+  'finalized but unpromoted release continues to own the production head'
+);
+select throws_ok(
+  format(
+    $$select private.finalize_code_release_v1(%L::uuid, %L, 101, %L, %L::uuid, %L::jsonb)$$,
+    (select result ->> 'site_release_id' from finalized_code_release),
+    'site-manifests/sha256/1111111111111111111111111111111111111111111111111111111111111111.json',
+    repeat('1', 64),
+    '40000000-0000-4000-8000-000000000002',
+    jsonb_build_object('different', true)::text
+  ),
+  '23505',
+  'Code release finalize idempotency collision',
+  'finalize rejects the same reservation with a different dispatch tuple'
+);
+
+insert into private.content_outbox(site_release_id, dispatch_id, payload)
+select site_release_id,
+  '40000000-0000-4000-8000-000000000003',
+  payload || jsonb_build_object('dispatch_id', '40000000-0000-4000-8000-000000000003')
+from private.content_outbox
+where dispatch_id = '30000000-0000-4000-8000-000000000001';
+update private.content_outbox set status = 'dead_letter'
+where dispatch_id = '30000000-0000-4000-8000-000000000001';
+select is(
+  (select count(*) from private.release_head_claims),
+  1::bigint,
+  'one dead-lettered outbox does not release a head still owned by actionable rebuild work'
+);
+update private.content_outbox set status = 'dead_letter'
+where dispatch_id = '40000000-0000-4000-8000-000000000003';
+insert into private.content_outbox(site_release_id, dispatch_id, payload, inserted_at)
+select site_release_id,
+  '40000000-0000-4000-8000-000000000004',
+  payload || jsonb_build_object('dispatch_id', '40000000-0000-4000-8000-000000000004'),
+  inserted_at - interval '1 day'
+from private.content_outbox
+where dispatch_id = '30000000-0000-4000-8000-000000000001';
+
+create or replace function private.consume_attestation_v1(
+  assertion jsonb,
+  expected_audience text,
+  expected_action text,
+  expected_body_sha256 text,
+  required_roles text[]
+)
+returns table(actor_sub text, actor_email text, actor_role text, assertion_jti uuid)
+language sql
+volatile
+security definer
+set search_path = ''
+as $$
+  select 'automatic-code-release-owner'::text,
+    'owner@example.test'::text,
+    'Owner'::text,
+    '60000000-0000-4000-8000-000000000001'::uuid
+$$;
+
+select throws_ok(
+  format(
+    $$select private.rebuild_content_release_v1(%L::uuid, %L, %L, %L::uuid, '{}'::jsonb, %L)$$,
+    (select result ->> 'site_release_id' from finalized_code_release),
+    'retry while sibling dispatch remains actionable',
+    'REBUILD ' || (select result ->> 'site_release_id' from finalized_code_release),
+    '50000000-0000-4000-8000-000000000000',
+    repeat('9', 64)
+  ),
+  '55P03',
+  'Release already has actionable dispatch work',
+  'manual rebuild rejects duplicate dispatch while sibling outbox work remains actionable'
+);
+update private.content_outbox set status = 'dead_letter'
+where dispatch_id = '40000000-0000-4000-8000-000000000004';
+
+insert into rebuild_result(result)
+select private.rebuild_content_release_v1(
+  (select (result ->> 'site_release_id')::uuid from finalized_code_release),
+  'retry after dead letter',
+  'REBUILD ' || (select result ->> 'site_release_id' from finalized_code_release),
+  '50000000-0000-4000-8000-000000000001',
+  '{}'::jsonb,
+  repeat('9', 64)
+);
+select is(
+  (select count(*) from private.release_head_claims),
+  1::bigint,
+  'manual rebuild atomically reacquires the current predecessor head'
+);
+select is(
+  (select result ->> 'status' from rebuild_result),
+  'queued',
+  'manual rebuild queues a new outbox only after reacquiring the head'
+);
+update private.content_outbox set status = 'dead_letter'
+where id = (select (result ->> 'outbox_id')::uuid from rebuild_result);
+
+insert into private.release_artifacts(
+  site_release_id, object_key, byte_length, artifact_sha256,
+  artifact_fingerprint_sha256, hash_algorithm, code_sha,
+  build_environment_version, production_verified_at
+)
+select (result ->> 'site_release_id')::uuid,
+  'artifacts/sha256/6666666666666666666666666666666666666666666666666666666666666666.json',
+  100, repeat('6', 64), repeat('7', 64),
+  'sha256-content-addressed-pages-v1', repeat('4', 40),
+  'node22.17-astro7-hugo0.147.9-v1', clock_timestamp()
+from finalized_code_release;
+update private.release_current_pointer pointer set
+  target_site_release_id = (select (result ->> 'site_release_id')::uuid from finalized_code_release),
+  target_release_sequence = (select (result ->> 'site_release_sequence')::bigint from finalized_code_release),
+  generation = 2,
+  pages_deployment_id = 'code-pages-deployment',
+  manifest_sha256 = repeat('1', 64),
+  artifact_sha256 = repeat('6', 64)
+where pointer.singleton;
+
+insert into second_code_reservation(result)
+select private.reserve_code_release_v1(
+  '30000000-0000-4000-8000-000000000002', repeat('5', 40), repeat('4', 40),
+  'node22.17-astro7-hugo0.147.9-v1', repeat('8', 64)
+);
+insert into second_code_release(result)
+select private.finalize_code_release_v1(
+  (select (result ->> 'reservation_id')::uuid from second_code_reservation),
+  'site-manifests/sha256/2222222222222222222222222222222222222222222222222222222222222222.json',
+  102, repeat('2', 64),
+  '30000000-0000-4000-8000-000000000002',
+  jsonb_build_object(
+    'dispatch_id', '30000000-0000-4000-8000-000000000002',
+    'site_release_id', (select result ->> 'site_release_id' from second_code_reservation),
+    'site_release_sequence', (select (result ->> 'site_release_sequence')::bigint from second_code_reservation),
+    'expected_predecessor_id', (select result ->> 'site_release_id' from finalized_code_release),
+    'expected_content_sha', repeat('c', 64),
+    'code_sha', repeat('5', 40),
+    'build_environment_version', 'node22.17-astro7-hugo0.147.9-v1',
+    'mode', 'production'
+  )
+);
+select is(
+  (select release.content_base_release_id::text
+   from private.site_releases release
+   where release.id = (select (result ->> 'site_release_id')::uuid from second_code_release)),
+  '20000000-0000-4000-8000-000000000001',
+  'code-on-code release retains the canonical content-bearing base instead of the prior code release'
+);
+update private.content_outbox set status = 'deployed'
+where site_release_id = (select (result ->> 'site_release_id')::uuid from second_code_release);
+select lives_ok(
+  $$select private.reserve_site_release_v1('10000000-0000-4000-8000-000000000001')$$,
+  'content publication can continue after the code release reaches a terminal state'
+);
+
+insert into private.editorial_drafts(
+  id, base_site_release_id, owner_sub, status
+) values (
+  '70000000-0000-4000-8000-000000000001',
+  (select (result ->> 'site_release_id')::uuid from finalized_code_release),
+  'automatic-code-release-owner', 'publishing'
+);
+insert into private.preview_builds(
+  id, draft_id, base_site_release_id, preview_sha256,
+  artifact_sha256, pages_preview_url, verifier_evidence
+) values (
+  '71000000-0000-4000-8000-000000000001',
+  '70000000-0000-4000-8000-000000000001',
+  (select (result ->> 'site_release_id')::uuid from finalized_code_release),
+  repeat('a', 64), repeat('b', 64),
+  'https://editorial-preview.example.test', '{"verified":true}'::jsonb
+);
+insert into private.editorial_publish_requests(
+  id, draft_id, preview_build_id, requested_by, reason, idempotency_key,
+  status, locked_by, lease_expires_at
+) values (
+  '72000000-0000-4000-8000-000000000001',
+  '70000000-0000-4000-8000-000000000001',
+  '71000000-0000-4000-8000-000000000001',
+  'automatic-code-release-owner', 'publish after active release',
+  '73000000-0000-4000-8000-000000000001',
+  'claimed', 'editorial-transient-worker', clock_timestamp() + interval '5 minutes'
+);
+select throws_ok(
+  $$select private.defer_editorial_publish_request_v1(
+    '72000000-0000-4000-8000-000000000001',
+    'editorial-transient-worker', 'XX000'
+  )$$,
+  '22023',
+  'Editorial deferral requires a transient release-head conflict',
+  'editorial deferral rejects non-transient failures'
+);
+
+insert into private.content_items(
+  id, event_id, identity_version, source_type, content_type,
+  source_name, time_precision, provenance_kind
+) values (
+  'n_' || repeat('1', 64), 'e_' || repeat('2', 64), 1,
+  'test', 'article', 'automatic-code-release-test', 'exact', 'live_ingestion'
+);
+insert into private.global_suppressions(
+  id, item_id, reason, created_by, assertion_jti, active
+) values (
+  '74000000-0000-4000-8000-000000000001', 'n_' || repeat('1', 64),
+  'transient suppression test', 'automatic-code-release-owner',
+  '75000000-0000-4000-8000-000000000001', false
+);
+insert into private.global_suppression_requests(
+  id, suppression_id, item_id, base_site_release_id,
+  requested_by, requested_role, request_jti, reason, idempotency_key,
+  status, locked_by, lease_expires_at
+) values (
+  '76000000-0000-4000-8000-000000000001',
+  '74000000-0000-4000-8000-000000000001', 'n_' || repeat('1', 64),
+  (select (result ->> 'site_release_id')::uuid from finalized_code_release),
+  'automatic-code-release-owner', 'Owner',
+  '77000000-0000-4000-8000-000000000001',
+  'suppress after active release', '78000000-0000-4000-8000-000000000001',
+  'claimed', 'suppression-transient-worker', clock_timestamp() + interval '5 minutes'
+);
+
+select private.defer_editorial_publish_request_v1(
+  '72000000-0000-4000-8000-000000000001',
+  'editorial-transient-worker', '55P03'
+);
+select private.defer_global_suppression_request_v1(
+  '76000000-0000-4000-8000-000000000001',
+  'suppression-transient-worker', '40001'
+);
+select ok(
+  (select status = 'queued' and locked_by is null and lease_expires_at is null
+     and reservation_id is null and error_code = '55P03'
+   from private.editorial_publish_requests
+   where id = '72000000-0000-4000-8000-000000000001'),
+  'editorial transient deferral requeues the claimed request and clears its lease'
+);
+select is(
+  (select status from private.editorial_drafts
+   where id = '70000000-0000-4000-8000-000000000001'),
+  'publishing',
+  'editorial transient deferral does not mark the draft failed'
+);
+select ok(
+  (select status = 'queued' and locked_by is null and lease_expires_at is null
+     and reservation_id is null and error_code = '40001'
+   from private.global_suppression_requests
+   where id = '76000000-0000-4000-8000-000000000001'),
+  'global suppression transient deferral requeues the claimed request without failing it'
+);
+
+select * from finish();
+rollback;

--- a/supabase/tests/database/content_database_security.test.sql
+++ b/supabase/tests/database/content_database_security.test.sql
@@ -8,8 +8,12 @@ select cmp_ok(
   '>=', 12::bigint,
   'content and release tables are installed in the private schema'
 );
-select is((select count(*) from private.content_settings), 7::bigint, 'all capability switches exist');
-select is((select count(*) from private.content_settings where enabled), 0::bigint, 'all capability switches fail closed');
+select is((select count(*) from private.content_settings), 8::bigint, 'all capability switches exist');
+select is(
+  (select count(*) from private.content_settings where enabled),
+  0::bigint,
+  'all production mutation capabilities start fail-closed'
+);
 select ok(
   (select bool_and(rolcanlogin) from pg_roles where rolname in (
     'content_ingestor', 'content_editor', 'content_controller', 'content_reader', 'content_deployer'

--- a/tests/worker/contentMirror.test.js
+++ b/tests/worker/contentMirror.test.js
@@ -31,7 +31,11 @@ function bucket() {
     };
 }
 
-function database({ loseFirstFinalizeResponse = false, rejectFinalize = false } = {}) {
+function database({
+    loseFirstFinalizeResponse = false,
+    rejectFinalize = false,
+    reserveError = null,
+} = {}) {
     const calls = [];
     let finalized = false;
     let attemptStatus = 'started';
@@ -65,6 +69,7 @@ function database({ loseFirstFinalizeResponse = false, rejectFinalize = false } 
             ];
         }
         if (query.includes('reserve_ingestion_site_release_v1')) {
+            if (reserveError) throw reserveError;
             return [{ result: { ...reservation, idempotent: finalized } }];
         }
         if (query.includes('finalize_site_release_v1')) {
@@ -244,4 +249,26 @@ describe('structured content database mirror', () => {
         ]);
         expect(db.sql.end).toHaveBeenCalledWith({ timeout: 2 });
     });
+
+    it.each(['55P03', '40001'])(
+        'does not permanently fail a publication attempt for transient database contention %s',
+        async (code) => {
+            const env = enabledEnv();
+            const contention = Object.assign(new Error('Release head is busy'), {
+                code,
+            });
+            const db = database({ reserveError: contention });
+
+            await expect(
+                mirrorStructuredReport(env, input(), {
+                    openDatabase: vi.fn(() => db.sql),
+                }),
+            ).rejects.toBe(contention);
+
+            expect(
+                db.calls.some((call) => call.query.includes('fail_ingestion_publication_attempt_v1')),
+            ).toBe(false);
+            expect(db.sql.end).toHaveBeenCalledWith({ timeout: 2 });
+        },
+    );
 });

--- a/tests/worker/contentObservability.test.js
+++ b/tests/worker/contentObservability.test.js
@@ -332,6 +332,23 @@ describe("two-day production observation gate", () => {
     );
   });
 
+  it("accepts a healthy code release that preserves a slot's content root", () => {
+    const input = healthyWindowInput();
+    input.checks[0].current = {
+      ...input.checks[0].current,
+      artifact_fingerprint_sha256: "9".repeat(64),
+      artifact_sha256: "8".repeat(64),
+      code_sha: "7".repeat(40),
+      manifest_sha256: "6".repeat(64),
+      release_kind: "code",
+      site_release_id: "99999999-9999-4999-8999-999999999999",
+      site_release_sequence: input.slots[0].site_release_sequence + 1,
+    };
+    const result = evaluateContentObservationWindow(input, WINDOW_NOW);
+    expect(result.measurable_gate_passed).toBe(true);
+    expect(result.reasons).toEqual([]);
+  });
+
   it("fails on manual repair, noncanonical trigger, rollback or missing edge evidence", () => {
     const input = healthyWindowInput();
     input.publication_attempts[0].trigger_kind = "manual:repair";

--- a/tests/worker/contentProductionConfig.test.js
+++ b/tests/worker/contentProductionConfig.test.js
@@ -193,6 +193,46 @@ describe("content production preflight", () => {
     ).toThrow(/CLOUDFLARE_R2_LOCK_READ_TOKEN is too short/);
   });
 
+  it("requires an exact SHA, HTTPS origin, and dedicated code release secret", () => {
+    const environment = {
+      EXACT_CODE_SHA: "a".repeat(40),
+      CODE_RELEASE_ORIGIN: "https://content-deployer.bubblenews.today",
+      CODE_RELEASE_SECRET: "b".repeat(32),
+      CONTENT_CURRENT_URLS:
+        "https://content-api.example.com/v1/current,https://content-api-origin.example.com/v1/current",
+      CODE_RELEASE_WAIT_TIMEOUT_SECONDS: "2700",
+    };
+    expect(
+      validateWorkflowEnvironment("workflow-code-release", environment),
+    ).toEqual({ profile: "workflow-code-release" });
+    expect(() =>
+      validateWorkflowEnvironment("workflow-code-release", {
+        ...environment,
+        CODE_RELEASE_ORIGIN: "http://content-deployer.example.com",
+      }),
+    ).toThrow(/CODE_RELEASE_ORIGIN must be a credential-free HTTPS origin/);
+    expect(() =>
+      validateWorkflowEnvironment("workflow-code-release", {
+        ...environment,
+        CONTENT_CURRENT_URLS: "https://content-api.example.com/v1/current",
+      }),
+    ).toThrow(/at least two verifier origins/);
+    expect(() =>
+      validateWorkflowEnvironment("workflow-code-release", {
+        ...environment,
+        CONTENT_CURRENT_URLS:
+          "https://content-api.example.com/v1/current,https://content-api.example.com/v1/current",
+      }),
+    ).toThrow(/distinct verifier origins/);
+    expect(() =>
+      validateWorkflowEnvironment("workflow-code-release", {
+        ...environment,
+        CONTENT_CURRENT_URLS:
+          "https://content-api.example.com/v1/current?cached=true,https://content-api-origin.example.com/v1/current",
+      }),
+    ).toThrow(/exact \/v1\/current endpoints/);
+  });
+
   it("requires a topology-approved deployer-only observability environment", () => {
     const environment = {
       CONTENT_OBSERVABILITY_DATABASE_URL:

--- a/tests/worker/requestCodeRelease.test.js
+++ b/tests/worker/requestCodeRelease.test.js
@@ -1,0 +1,162 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { runCodeRelease } from "../../scripts/request-code-release.mjs";
+
+const CODE_SHA = "a".repeat(40);
+const RELEASE_ID = "11111111-1111-4111-8111-111111111111";
+
+function environment(overrides = {}) {
+  return {
+    CODE_RELEASE_ORIGIN: "https://deployer.example.test",
+    CODE_RELEASE_SECRET: "s".repeat(32),
+    EXACT_CODE_SHA: CODE_SHA,
+    CONTENT_CURRENT_URLS:
+      "https://api-one.example.test/v1/current,https://api-two.example.test/v1/current",
+    CODE_RELEASE_REQUEST_MAX_ATTEMPTS: "2",
+    CODE_RELEASE_REQUEST_DELAY_MS: "1",
+    CODE_RELEASE_POLL_DELAY_MS: "1",
+    CODE_RELEASE_WAIT_TIMEOUT_SECONDS: "30",
+    ...overrides,
+  };
+}
+
+function json(body, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("automatic code release request and deployment wait", () => {
+  it("does not treat a queued response as success before every current pointer converges", async () => {
+    let now = 0;
+    let pointerRound = 0;
+    const fetch = vi.fn(async (input) => {
+      const url = new URL(String(input));
+      if (url.pathname === "/internal/code-release") {
+        return json(
+          { status: "queued", site_release_id: RELEASE_ID, code_sha: CODE_SHA },
+          202,
+        );
+      }
+      pointerRound += 1;
+      if (pointerRound <= 2) {
+        return json({ site_release_id: "old", code_sha: "b".repeat(40) });
+      }
+      return json({ site_release_id: RELEASE_ID, code_sha: CODE_SHA });
+    });
+    const sleep = vi.fn(async (milliseconds) => {
+      now += milliseconds;
+    });
+
+    await expect(
+      runCodeRelease(environment(), {
+        fetch,
+        sleep,
+        now: () => now,
+        log: vi.fn(),
+      }),
+    ).resolves.toEqual({ outcome: "deployed", siteReleaseId: RELEASE_ID });
+    expect(fetch).toHaveBeenCalledTimes(5);
+    expect(sleep).toHaveBeenCalledOnce();
+  });
+
+  it("reports a non-UI change set as an explicit safe no-op", async () => {
+    const log = vi.fn();
+    const fetch = vi.fn(async () =>
+      json({ status: "no_changes", code_sha: CODE_SHA }),
+    );
+
+    await expect(
+      runCodeRelease(environment(), { fetch, log, sleep: vi.fn() }),
+    ).resolves.toEqual({ outcome: "no_op" });
+    expect(fetch).toHaveBeenCalledOnce();
+    expect(log.mock.calls.flat().join(" ")).toContain('"outcome":"no_op"');
+  });
+
+  it("records a superseded push and leaves the latest main run to aggregate it", async () => {
+    const log = vi.fn();
+    const fetch = vi.fn(async () =>
+      json(
+        {
+          error: "code_release_target_superseded",
+          retryable: true,
+          current_main_sha: "b".repeat(40),
+        },
+        409,
+      ),
+    );
+
+    await expect(
+      runCodeRelease(environment(), { fetch, log, sleep: vi.fn() }),
+    ).resolves.toEqual({ outcome: "superseded" });
+    expect(log.mock.calls.flat().join(" ")).toContain('"outcome":"superseded"');
+  });
+
+  it("fails closed when the Deployer rejects a forbidden change set", async () => {
+    const fetch = vi.fn(async () =>
+      json(
+        {
+          error: "unsafe_code_release",
+          detail: "Code release contains forbidden or unknown path",
+        },
+        422,
+      ),
+    );
+
+    await expect(
+      runCodeRelease(environment(), { fetch, sleep: vi.fn(), log: vi.fn() }),
+    ).rejects.toThrow(/rejected \(422\).*unsafe_code_release/);
+  });
+
+  it("fails when the exact queued release never becomes current", async () => {
+    let now = 0;
+    const fetch = vi.fn(async (input) => {
+      const url = new URL(String(input));
+      return url.pathname === "/internal/code-release"
+        ? json(
+            {
+              status: "queued",
+              site_release_id: RELEASE_ID,
+              code_sha: CODE_SHA,
+            },
+            202,
+          )
+        : json({ site_release_id: "old", code_sha: "b".repeat(40) });
+    });
+    const sleep = vi.fn(async (milliseconds) => {
+      now += milliseconds;
+    });
+
+    await expect(
+      runCodeRelease(
+        environment({
+          CODE_RELEASE_WAIT_TIMEOUT_SECONDS: "1",
+          CODE_RELEASE_POLL_DELAY_MS: "1000",
+        }),
+        { fetch, sleep, now: () => now, log: vi.fn() },
+      ),
+    ).rejects.toThrow(/did not become the verified current pointer/);
+  });
+
+  it("retries only declared transient release-head failures", async () => {
+    let requestCount = 0;
+    const fetch = vi.fn(async (input) => {
+      const url = new URL(String(input));
+      if (url.pathname === "/internal/code-release") {
+        requestCount += 1;
+        return requestCount === 1
+          ? json({ error: "release_head_busy", retryable: true }, 409)
+          : json({ status: "already_current", code_sha: CODE_SHA });
+      }
+      return json({ site_release_id: RELEASE_ID, code_sha: CODE_SHA });
+    });
+    const sleep = vi.fn(async () => undefined);
+
+    await expect(
+      runCodeRelease(environment(), { fetch, sleep, log: vi.fn() }),
+    ).resolves.toEqual({ outcome: "deployed", siteReleaseId: RELEASE_ID });
+    expect(requestCount).toBe(2);
+    expect(sleep).toHaveBeenCalledOnce();
+  });
+});

--- a/workers/content/broker/index.test.ts
+++ b/workers/content/broker/index.test.ts
@@ -2,6 +2,7 @@ import { createHash } from "node:crypto";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   handleRollbackRequest,
+  isCommittedPromotionContext,
   pagesAssetHash,
   parseContentAddressedArtifact,
   parseDeterministicTar,
@@ -9,6 +10,24 @@ import {
   uploadPages,
   verifyDeployment,
 } from "./index";
+
+describe("promotion commit recovery", () => {
+  it("accepts only the target release at the next pointer generation", () => {
+    const context = {
+      current_site_release_id: "target-release",
+      pointer_generation: 8,
+    } as never;
+    expect(isCommittedPromotionContext(context, "target-release", 7)).toBe(
+      true,
+    );
+    expect(isCommittedPromotionContext(context, "other-release", 7)).toBe(
+      false,
+    );
+    expect(isCommittedPromotionContext(context, "target-release", 8)).toBe(
+      false,
+    );
+  });
+});
 
 const encoder = new TextEncoder();
 const databaseContentContract = {

--- a/workers/content/broker/index.ts
+++ b/workers/content/broker/index.ts
@@ -1206,6 +1206,17 @@ function comparePromotion(context: ArtifactContext, request: JsonRecord): void {
   }
 }
 
+export function isCommittedPromotionContext(
+  context: ArtifactContext,
+  targetSiteReleaseId: string,
+  expectedPointerGeneration: number,
+): boolean {
+  return (
+    context.current_site_release_id === targetSiteReleaseId &&
+    Number(context.pointer_generation) === expectedPointerGeneration + 1
+  );
+}
+
 async function promote(request: Request, env: Env): Promise<Response> {
   let body: JsonRecord;
   try {
@@ -1281,6 +1292,42 @@ async function promote(request: Request, env: Env): Promise<Response> {
     );
     return json({ ok: true, deployment_id: deployment.id, ...committed });
   } catch (error) {
+    if (
+      promotionStage === "commit_promotion" &&
+      deploymentChanged &&
+      authorization &&
+      context
+    ) {
+      const generation = Number(authorization.expected_pointer_generation);
+      try {
+        const committedContext = await deployContext(
+          sql,
+          context.site_release_id,
+        );
+        if (
+          isCommittedPromotionContext(
+            committedContext,
+            context.site_release_id,
+            generation,
+          )
+        ) {
+          return json({
+            ok: true,
+            idempotent: true,
+            site_release_id: context.site_release_id,
+            commit_response_recovered: true,
+          });
+        }
+      } catch {
+        // The commit result is ambiguous. Leave the verified target deployment
+        // in place so the fenced reconciler can finish or recover it safely.
+      }
+      console.error("[ContentBroker] promotion commit result is ambiguous", {
+        stage: promotionStage,
+        ...errorDiagnostics(error),
+      });
+      return json({ error: "promotion_commit_ambiguous" }, 503);
+    }
     if (authorization && context) {
       const token = Number(authorization.fencing_token);
       const generation = Number(authorization.expected_pointer_generation);

--- a/workers/content/deployer/index.test.ts
+++ b/workers/content/deployer/index.test.ts
@@ -3,9 +3,11 @@ import { createHash } from "node:crypto";
 import {
   dispatchOne,
   handleBuildContentRequest,
+  handleCodeReleaseRequest,
   handleRecoveryHealthCallback,
   outboxAlertReasons,
   runRetentionMaintenance,
+  validateCodeReleaseChangeSet,
   validateDispatchPayload,
 } from "./index";
 
@@ -31,6 +33,33 @@ async function signedRecoveryRequest(
   return new Request("https://deployer.test/internal/recovery-health", {
     method: "POST",
     headers: { "X-Content-Signature": hex },
+    body,
+  });
+}
+
+async function signedCodeReleaseRequest(
+  secret: string,
+  codeSha: string,
+): Promise<Request> {
+  const body = JSON.stringify({ code_sha: codeSha });
+  const key = await crypto.subtle.importKey(
+    "raw",
+    new TextEncoder().encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  const signature = await crypto.subtle.sign(
+    "HMAC",
+    key,
+    new TextEncoder().encode(body),
+  );
+  const hex = Array.from(new Uint8Array(signature), (value) =>
+    value.toString(16).padStart(2, "0"),
+  ).join("");
+  return new Request("https://deployer.test/internal/code-release", {
+    method: "POST",
+    headers: { "X-Code-Release-Signature": hex },
     body,
   });
 }
@@ -116,6 +145,386 @@ describe("content release dispatch recovery", () => {
       site_release_id: valid.site_release_id,
     });
     expect(events).toEqual(["failed", "building"]);
+    expect(end).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("automatic code release boundary", () => {
+  const baseCodeSha = "a".repeat(40);
+  const targetCodeSha = "b".repeat(40);
+
+  function comparison(files: Array<Record<string, unknown>>) {
+    return {
+      status: "ahead",
+      base_commit: { sha: baseCodeSha },
+      merge_base_commit: { sha: baseCodeSha },
+      commits: [{ sha: targetCodeSha }],
+      files,
+    };
+  }
+
+  it("allows publishable UI alongside classified inert and DB-owned files", () => {
+    expect(
+      validateCodeReleaseChangeSet(
+        comparison([
+          { filename: "astro/src/pages/index.astro", status: "modified" },
+          {
+            filename: "astro/src/components/QuietIndexHome.astro",
+            status: "modified",
+          },
+          {
+            filename: "astro/src/layouts/BaseLayout.astro",
+            status: "modified",
+          },
+          { filename: "astro/src/styles/quiet-index.css", status: "modified" },
+          { filename: "astro/src/scripts/authControls.ts", status: "modified" },
+          { filename: "astro/src/lib/searchIndex.ts", status: "modified" },
+          { filename: "astro/public/favicon.svg", status: "modified" },
+          { filename: "workers/content/deployer/index.ts", status: "modified" },
+          {
+            filename: "supabase/migrations/20260719000100_release.sql",
+            status: "added",
+          },
+          {
+            filename: ".github/workflows/automatic-code-release.yml",
+            status: "added",
+          },
+          {
+            filename: "data/daily/2026-07-19.json",
+            status: "modified",
+          },
+        ]),
+        {
+          baseCodeSha,
+          targetCodeSha,
+          structuredCutoverDate: "2026-07-16",
+        },
+      ),
+    ).toHaveLength(11);
+  });
+
+  it.each([
+    "astro/scripts/generate-static-data.mjs",
+    "static/highlights.json",
+    "content/about/index.md",
+    "data/daily/2026-07-15.json",
+    "assets/daily.json",
+    "unknown/release-input.json",
+  ])("rejects a mixed release containing %s", (forbiddenPath) => {
+    expect(() =>
+      validateCodeReleaseChangeSet(
+        comparison([
+          { filename: "astro/src/pages/index.astro", status: "modified" },
+          { filename: forbiddenPath, status: "modified" },
+        ]),
+        {
+          baseCodeSha,
+          targetCodeSha,
+          structuredCutoverDate: "2026-07-16",
+        },
+      ),
+    ).toThrow(
+      `Code release contains forbidden or unknown path: ${forbiddenPath}`,
+    );
+  });
+
+  it("rejects a rename whose previous filename is forbidden", () => {
+    expect(() =>
+      validateCodeReleaseChangeSet(
+        comparison([
+          {
+            filename: "astro/src/pages/index.astro",
+            previous_filename: "static/highlights.json",
+            status: "renamed",
+          },
+        ]),
+        {
+          baseCodeSha,
+          targetCodeSha,
+          structuredCutoverDate: "2026-07-16",
+        },
+      ),
+    ).toThrow(
+      "Code release contains forbidden or unknown path: static/highlights.json",
+    );
+  });
+
+  it("returns a retryable conflict when the requested SHA is already superseded", async () => {
+    const currentMainSha = "c".repeat(40);
+    const end = vi.fn(async () => undefined);
+    const sql = vi.fn(async (strings: TemplateStringsArray) => {
+      expect(strings.join("?")).toContain("get_code_release_base_v1");
+      return [
+        {
+          result: {
+            site_release_id: "11111111-1111-4111-8111-111111111111",
+            code_sha: baseCodeSha,
+            content_root_sha256: "d".repeat(64),
+            structured_cutover_date: "2026-07-16",
+          },
+        },
+      ];
+    });
+    Object.assign(sql, { end });
+    const compare = vi.fn();
+    const response = await handleCodeReleaseRequest(
+      await signedCodeReleaseRequest("code-secret", targetCodeSha),
+      { CODE_RELEASE_SECRET: "code-secret" } as never,
+      {
+        openDatabase: vi.fn(() => sql as never),
+        getCurrentMainSha: vi.fn(async () => currentMainSha),
+        compare,
+      },
+    );
+
+    expect(response.status).toBe(409);
+    expect(await response.json()).toEqual({
+      error: "code_release_target_superseded",
+      retryable: true,
+      requested_code_sha: targetCodeSha,
+      current_main_sha: currentMainSha,
+    });
+    expect(compare).not.toHaveBeenCalled();
+    expect(sql).toHaveBeenCalledTimes(1);
+    expect(end).toHaveBeenCalledWith({ timeout: 2 });
+  });
+
+  it("rechecks main immediately before reservation", async () => {
+    const newerMainSha = "c".repeat(40);
+    const end = vi.fn(async () => undefined);
+    const sql = vi.fn(async (strings: TemplateStringsArray) => {
+      const query = strings.join("?");
+      if (query.includes("get_code_release_base_v1")) {
+        return [
+          {
+            result: {
+              site_release_id: "11111111-1111-4111-8111-111111111111",
+              code_sha: baseCodeSha,
+              content_root_sha256: "d".repeat(64),
+              structured_cutover_date: "2026-07-16",
+            },
+          },
+        ];
+      }
+      throw new Error(`Reservation should not be attempted: ${query}`);
+    });
+    Object.assign(sql, { end });
+    const getCurrentMainSha = vi
+      .fn()
+      .mockResolvedValueOnce(targetCodeSha)
+      .mockResolvedValueOnce(newerMainSha);
+    const response = await handleCodeReleaseRequest(
+      await signedCodeReleaseRequest("code-secret", targetCodeSha),
+      { CODE_RELEASE_SECRET: "code-secret" } as never,
+      {
+        openDatabase: vi.fn(() => sql as never),
+        getCurrentMainSha,
+        compare: vi.fn(async () => ({
+          files: [
+            { filename: "astro/src/pages/index.astro", status: "modified" },
+          ],
+          changeSetSha256: "e".repeat(64),
+        })),
+      },
+    );
+
+    expect(response.status).toBe(409);
+    expect(await response.json()).toMatchObject({
+      error: "code_release_target_superseded",
+      retryable: true,
+      requested_code_sha: targetCodeSha,
+      current_main_sha: newerMainSha,
+    });
+    expect(getCurrentMainSha).toHaveBeenCalledTimes(2);
+    expect(sql).toHaveBeenCalledTimes(1);
+    expect(end).toHaveBeenCalledWith({ timeout: 2 });
+  });
+
+  it("returns no_changes for a classified infrastructure-only range", async () => {
+    const end = vi.fn(async () => undefined);
+    const sql = vi.fn(async (strings: TemplateStringsArray) => {
+      expect(strings.join("?")).toContain("get_code_release_base_v1");
+      return [
+        {
+          result: {
+            site_release_id: "11111111-1111-4111-8111-111111111111",
+            code_sha: baseCodeSha,
+            content_root_sha256: "d".repeat(64),
+            structured_cutover_date: "2026-07-16",
+          },
+        },
+      ];
+    });
+    Object.assign(sql, { end });
+    const getCurrentMainSha = vi.fn(async () => targetCodeSha);
+    const response = await handleCodeReleaseRequest(
+      await signedCodeReleaseRequest("code-secret", targetCodeSha),
+      { CODE_RELEASE_SECRET: "code-secret" } as never,
+      {
+        openDatabase: vi.fn(() => sql as never),
+        getCurrentMainSha,
+        compare: vi.fn(async () => ({
+          files: [
+            {
+              filename: "workers/content/deployer/index.ts",
+              status: "modified",
+            },
+            {
+              filename: "data/daily/2026-07-19.json",
+              status: "modified",
+            },
+          ],
+          changeSetSha256: "e".repeat(64),
+        })),
+      },
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      ok: true,
+      status: "no_changes",
+      code_sha: targetCodeSha,
+      changed_file_count: 2,
+    });
+    expect(getCurrentMainSha).toHaveBeenCalledTimes(1);
+    expect(sql).toHaveBeenCalledTimes(1);
+    expect(end).toHaveBeenCalledWith({ timeout: 2 });
+  });
+
+  it("materializes a cloned manifest and queues the exact main SHA", async () => {
+    const baseReleaseId = "11111111-1111-4111-8111-111111111111";
+    const nextReleaseId = "22222222-2222-4222-8222-222222222222";
+    const contentSha = "c".repeat(64);
+    const dispatchIds: string[] = [];
+    const idempotencyKeys: string[] = [];
+    const baseManifest = {
+      site_release_id: baseReleaseId,
+      site_release_sequence: 7,
+      expected_predecessor_id: null,
+      content_root_sha256: contentSha,
+      structured_cutover_date: "2026-07-16",
+      reports: [{ report_date: "2026-07-19", byte_sha256: "d".repeat(64) }],
+    };
+    const baseBytes = new TextEncoder().encode(
+      `${JSON.stringify(baseManifest)}\n`,
+    );
+    const baseHash = createHash("sha256").update(baseBytes).digest("hex");
+    const objects = new Map<string, Uint8Array>([
+      [`site-manifests/sha256/${baseHash}.json`, baseBytes],
+    ]);
+    const bucket = {
+      get: vi.fn(async (key: string) => {
+        const bytes = objects.get(key);
+        return bytes ? { arrayBuffer: async () => bytes.buffer } : null;
+      }),
+      put: vi.fn(async (key: string, bytes: Uint8Array) => {
+        objects.set(key, bytes);
+      }),
+    };
+    const end = vi.fn(async () => undefined);
+    const sql = vi.fn(
+      async (strings: TemplateStringsArray, ...values: unknown[]) => {
+        const query = strings.join("?");
+        if (query.includes("get_code_release_base_v1")) {
+          return [
+            {
+              result: {
+                site_release_id: baseReleaseId,
+                code_sha: baseCodeSha,
+                content_root_sha256: contentSha,
+                structured_cutover_date: "2026-07-16",
+              },
+            },
+          ];
+        }
+        if (query.includes("reserve_code_release_v1")) {
+          expect(values).toContain(targetCodeSha);
+          idempotencyKeys.push(String(values[0]));
+          return [
+            {
+              result: {
+                reservation_id: nextReleaseId,
+                site_release_id: nextReleaseId,
+                site_release_sequence: 8,
+                expected_predecessor_id: baseReleaseId,
+                content_root_sha256: contentSha,
+                base_manifest: {
+                  object_key: `site-manifests/sha256/${baseHash}.json`,
+                  byte_length: baseBytes.byteLength,
+                  sha256: baseHash,
+                },
+              },
+            },
+          ];
+        }
+        if (query.includes("finalize_code_release_v1")) {
+          const dispatchPayload = values.at(-1) as Record<string, unknown>;
+          dispatchIds.push(String(values[4]));
+          expect(dispatchPayload).toMatchObject({
+            dispatch_id: values[4],
+            site_release_id: nextReleaseId,
+            expected_predecessor_id: baseReleaseId,
+            code_sha: targetCodeSha,
+            expected_content_sha: contentSha,
+            mode: "production",
+          });
+          return [
+            {
+              result: {
+                site_release_id: nextReleaseId,
+                site_release_sequence: 8,
+              },
+            },
+          ];
+        }
+        throw new Error(`Unexpected SQL: ${query}`);
+      },
+    );
+    Object.assign(sql, { json: vi.fn((value: unknown) => value), end });
+    const dependencies = {
+      openDatabase: vi.fn(() => sql as never),
+      getCurrentMainSha: vi.fn(async () => targetCodeSha),
+      compare: vi.fn(async () => ({
+        files: [
+          {
+            filename: "astro/src/styles/quiet-index.css",
+            status: "modified",
+          },
+        ],
+        changeSetSha256: "e".repeat(64),
+      })),
+    };
+
+    for (let attempt = 0; attempt < 2; attempt += 1) {
+      const response = await handleCodeReleaseRequest(
+        await signedCodeReleaseRequest("code-secret", targetCodeSha),
+        {
+          CODE_RELEASE_SECRET: "code-secret",
+          SITE_MANIFESTS: bucket,
+        } as never,
+        dependencies,
+      );
+      expect(response.status).toBe(202);
+      expect(await response.json()).toMatchObject({
+        ok: true,
+        status: "queued",
+        site_release_id: nextReleaseId,
+        code_sha: targetCodeSha,
+        content_sha256: contentSha,
+      });
+    }
+
+    expect(idempotencyKeys).toHaveLength(2);
+    expect(idempotencyKeys).toEqual([
+      "b56f4d01-0b51-54ea-a471-f9da86f0c287",
+      "b56f4d01-0b51-54ea-a471-f9da86f0c287",
+    ]);
+    expect(dispatchIds).toHaveLength(2);
+    expect(dispatchIds).toEqual([
+      "b56f4d01-0b51-54ea-a471-f9da86f0c287",
+      "b56f4d01-0b51-54ea-a471-f9da86f0c287",
+    ]);
+    expect(bucket.put).toHaveBeenCalledTimes(1);
     expect(end).toHaveBeenCalledTimes(2);
   });
 });

--- a/workers/content/deployer/index.ts
+++ b/workers/content/deployer/index.ts
@@ -1,5 +1,6 @@
-import { sha256Hex } from "../shared/canonical";
+import { canonicalJsonBytes, sha256Hex } from "../shared/canonical";
 import { openContentDatabase, type ContentSql } from "../shared/db";
+import { putVerifiedImmutable } from "../shared/r2";
 
 type Env = {
   CONTENT_DB?: { connectionString?: string };
@@ -10,6 +11,7 @@ type Env = {
   DEPLOY_CALLBACK_SECRET: string;
   PREVIEW_DISPATCH_SECRET: string;
   CONTENT_BUILD_API_SECRET: string;
+  CODE_RELEASE_SECRET: string;
   RECOVERY_MONITOR_SECRET: string;
   REPORT_SNAPSHOTS?: R2BucketLike;
   SITE_MANIFESTS?: R2BucketLike;
@@ -17,11 +19,20 @@ type Env = {
 
 type R2BucketLike = {
   get(key: string): Promise<{ arrayBuffer(): Promise<ArrayBuffer> } | null>;
+  put(
+    key: string,
+    value: Uint8Array,
+    options?: {
+      onlyIf?: { etagDoesNotMatch?: string };
+      httpMetadata?: { contentType?: string };
+    },
+  ): Promise<unknown>;
 };
 
 const UUID =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 const DATE = /^\d{4}-\d{2}-\d{2}$/;
+const SHA1 = /^[a-f0-9]{40}$/;
 const CALLBACK_EVENTS = new Set([
   "building",
   "artifact_registered",
@@ -147,6 +158,251 @@ async function githubDispatch(
   );
   if (response.status !== 204)
     throw new Error(`GitHub dispatch rejected with ${response.status}`);
+}
+
+type GitHubFile = {
+  filename: string;
+  previous_filename?: string;
+  status: string;
+  sha?: string;
+};
+
+type GitHubCompare = {
+  status: string;
+  base_commit?: { sha?: string };
+  merge_base_commit?: { sha?: string };
+  commits?: Array<{ sha?: string }>;
+  files?: GitHubFile[];
+};
+
+async function githubJson(
+  env: Env,
+  path: string,
+): Promise<Record<string, unknown>> {
+  const repository = env.GITHUB_REPOSITORY?.trim();
+  if (!/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(repository))
+    throw new Error("Invalid GitHub repository");
+  const response = await fetch(
+    `https://api.github.com/repos/${repository}/${path}`,
+    {
+      headers: {
+        Authorization: `Bearer ${env.GITHUB_TOKEN}`,
+        Accept: "application/vnd.github+json",
+        "User-Agent": "bubble-content-deployer",
+        "X-GitHub-Api-Version": "2022-11-28",
+      },
+    },
+  );
+  if (!response.ok)
+    throw new Error(`GitHub request rejected with ${response.status}`);
+  return (await response.json()) as Record<string, unknown>;
+}
+
+type CodeReleasePathClass = "publishable" | "inert" | "db_owned";
+
+const INERT_ROOT_SCRIPTS = new Set([
+  "scripts/check-content-observability.mjs",
+  "scripts/check-content-observation-window.mjs",
+  "scripts/request-code-release.mjs",
+  "scripts/test-content-failure-matrix-local.mjs",
+  "scripts/validate-content-production-config.mjs",
+]);
+
+function assertGitHubComparePath(path: string): void {
+  if (
+    !path ||
+    path.startsWith("/") ||
+    path.includes("\\") ||
+    path
+      .split("/")
+      .some((segment) => !segment || segment === "." || segment === "..")
+  ) {
+    throw new Error("Malformed GitHub compare path");
+  }
+}
+
+function structuredDateFromPath(path: string): string | null {
+  const match =
+    /^(?:content\/daily\/(\d{4}-\d{2}-\d{2})(?:\.en)?\.md|daily\/(\d{4}-\d{2}-\d{2})\.md|data\/daily\/(\d{4}-\d{2}-\d{2})\.json)$/.exec(
+      path,
+    );
+  return match ? match[1] || match[2] || match[3] : null;
+}
+
+function classifyCodeReleasePath(
+  path: string,
+  structuredCutoverDate: string,
+): CodeReleasePathClass {
+  assertGitHubComparePath(path);
+
+  const structuredDate = structuredDateFromPath(path);
+  if (structuredDate && structuredDate >= structuredCutoverDate)
+    return "db_owned";
+
+  if (
+    /(?:^|\/)\w[^/]*\.test\.[cm]?[jt]sx?$/.test(path) ||
+    path.startsWith("workers/") ||
+    path.startsWith("supabase/") ||
+    path.startsWith(".github/") ||
+    path.startsWith("tests/") ||
+    path.startsWith("docs/") ||
+    path.startsWith("astro/.vscode/") ||
+    INERT_ROOT_SCRIPTS.has(path) ||
+    [
+      "astro/.editorconfig",
+      "astro/.gitignore",
+      "astro/.nvmrc",
+      "astro/.prettierignore",
+      "astro/AGENTS.md",
+      "astro/README.md",
+      "astro/eslint.config.js",
+      "astro/prettier.config.mjs",
+      "astro/vitest.config.ts",
+      "wrangler.content-deployer.toml",
+    ].includes(path) ||
+    (/^[^/]+\.md$/.test(path) && !path.startsWith("daily/"))
+  ) {
+    return "inert";
+  }
+
+  if (
+    [
+      "astro/src/pages/",
+      "astro/src/components/",
+      "astro/src/layouts/",
+      "astro/src/styles/",
+      "astro/src/scripts/",
+      "astro/src/lib/",
+    ].some((prefix) => path.startsWith(prefix)) ||
+    [
+      "astro/src/content.config.ts",
+      "astro/public/favicon.ico",
+      "astro/public/favicon.svg",
+      "astro/astro.config.mjs",
+      "astro/package.json",
+      "astro/package-lock.json",
+      "astro/raw-html-policy.json",
+      "astro/route-ownership.json",
+      "astro/tsconfig.json",
+    ].includes(path)
+  ) {
+    return "publishable";
+  }
+
+  throw new Error(`Code release contains forbidden or unknown path: ${path}`);
+}
+
+export function validateCodeReleaseChangeSet(
+  compare: GitHubCompare,
+  input: {
+    baseCodeSha: string;
+    targetCodeSha: string;
+    structuredCutoverDate: string;
+  },
+): GitHubFile[] {
+  const files = compare.files;
+  if (
+    compare.status !== "ahead" ||
+    compare.base_commit?.sha !== input.baseCodeSha ||
+    compare.merge_base_commit?.sha !== input.baseCodeSha ||
+    !Array.isArray(compare.commits) ||
+    compare.commits.at(-1)?.sha !== input.targetCodeSha ||
+    !Array.isArray(files) ||
+    files.length === 0 ||
+    files.length >= 300 ||
+    !DATE.test(input.structuredCutoverDate)
+  ) {
+    throw new Error("GitHub compare is not a complete fast-forward change set");
+  }
+  for (const file of files) {
+    if (
+      !file ||
+      typeof file.filename !== "string" ||
+      typeof file.status !== "string"
+    ) {
+      throw new Error("Malformed GitHub compare file");
+    }
+    classifyCodeReleasePath(file.filename, input.structuredCutoverDate);
+    if (file.previous_filename !== undefined) {
+      if (typeof file.previous_filename !== "string")
+        throw new Error("Malformed GitHub compare file");
+      classifyCodeReleasePath(
+        file.previous_filename,
+        input.structuredCutoverDate,
+      );
+    }
+  }
+  return files;
+}
+
+async function currentMainSha(env: Env): Promise<string> {
+  const ref = (env.GITHUB_WORKFLOW_REF || "main").replace(/^refs\/heads\//, "");
+  const result = await githubJson(
+    env,
+    `git/ref/heads/${encodeURIComponent(ref)}`,
+  );
+  const object = result.object as Record<string, unknown> | undefined;
+  const sha = String(object?.sha || "");
+  if (!SHA1.test(sha)) throw new Error("GitHub main ref is malformed");
+  return sha;
+}
+
+async function compareCodeRelease(
+  env: Env,
+  baseCodeSha: string,
+  targetCodeSha: string,
+  structuredCutoverDate: string,
+): Promise<{
+  files: GitHubFile[];
+  changeSetSha256: string;
+  publishableFileCount: number;
+}> {
+  const result = (await githubJson(
+    env,
+    `compare/${baseCodeSha}...${targetCodeSha}`,
+  )) as GitHubCompare;
+  const files = validateCodeReleaseChangeSet(result, {
+    baseCodeSha,
+    targetCodeSha,
+    structuredCutoverDate,
+  });
+  const normalized = files
+    .map((file) => ({
+      filename: file.filename,
+      previous_filename: file.previous_filename || null,
+      status: file.status,
+      sha: file.sha || null,
+    }))
+    .sort((left, right) => left.filename.localeCompare(right.filename));
+  return {
+    files,
+    publishableFileCount: files.filter(
+      (file) =>
+        classifyCodeReleasePath(file.filename, structuredCutoverDate) ===
+          "publishable" ||
+        (file.previous_filename !== undefined &&
+          classifyCodeReleasePath(
+            file.previous_filename,
+            structuredCutoverDate,
+          ) === "publishable"),
+    ).length,
+    changeSetSha256: await sha256Hex(
+      canonicalJsonBytes({
+        base_code_sha: baseCodeSha,
+        target_code_sha: targetCodeSha,
+        files: normalized,
+      }),
+    ),
+  };
+}
+
+function uuidFromHash(hash: string): string {
+  if (!/^[a-f0-9]{64}$/.test(hash)) throw new Error("Invalid UUID source hash");
+  const bytes = hash.slice(0, 32).split("");
+  bytes[12] = "5";
+  bytes[16] = ["8", "9", "a", "b"][parseInt(bytes[16], 16) % 4];
+  const value = bytes.join("");
+  return `${value.slice(0, 8)}-${value.slice(8, 12)}-${value.slice(12, 16)}-${value.slice(16, 20)}-${value.slice(20)}`;
 }
 
 async function recordEvent(
@@ -444,6 +700,290 @@ export async function handleRecoveryHealthCallback(
   }
 }
 
+const CODE_RELEASE_BUILD_ENVIRONMENT = "node22.17-astro7-hugo0.147.9-v1";
+
+type CodeReleaseDependencies = {
+  openDatabase?: typeof openContentDatabase;
+  getCurrentMainSha?: typeof currentMainSha;
+  compare?: typeof compareCodeRelease;
+};
+
+function supersededCodeRelease(
+  requestedCodeSha: string,
+  currentMainSha: string,
+): Response {
+  return json(
+    {
+      error: "code_release_target_superseded",
+      retryable: true,
+      requested_code_sha: requestedCodeSha,
+      current_main_sha: currentMainSha,
+    },
+    409,
+  );
+}
+
+async function readVerifiedManifest(
+  bucket: R2BucketLike | undefined,
+  descriptor: Record<string, unknown>,
+): Promise<Record<string, unknown>> {
+  if (!bucket) throw new Error("Site manifest binding is unavailable");
+  const key = String(descriptor.object_key || "");
+  const expectedHash = String(descriptor.sha256 || "");
+  const expectedLength = Number(descriptor.byte_length);
+  if (
+    key !== `site-manifests/sha256/${expectedHash}.json` ||
+    !/^[a-f0-9]{64}$/.test(expectedHash) ||
+    !Number.isSafeInteger(expectedLength) ||
+    expectedLength <= 0
+  ) {
+    throw new Error("Base site manifest descriptor is malformed");
+  }
+  const object = await bucket.get(key);
+  if (!object) throw new Error("Base site manifest is missing");
+  const bytes = new Uint8Array(await object.arrayBuffer());
+  if (
+    bytes.byteLength !== expectedLength ||
+    (await sha256Hex(bytes)) !== expectedHash
+  ) {
+    throw new Error("Base site manifest verification failed");
+  }
+  const parsed = JSON.parse(
+    new TextDecoder("utf-8", { fatal: true }).decode(bytes),
+  ) as unknown;
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed))
+    throw new Error("Base site manifest is malformed");
+  return parsed as Record<string, unknown>;
+}
+
+export async function handleCodeReleaseRequest(
+  request: Request,
+  env: Env,
+  dependencies: CodeReleaseDependencies = {},
+): Promise<Response> {
+  if (request.method !== "POST")
+    return json({ error: "method_not_allowed" }, 405);
+  const declared = Number(request.headers.get("Content-Length") || "0");
+  if (declared > 8 * 1024) return json({ error: "payload_too_large" }, 413);
+  const bytes = new Uint8Array(await request.arrayBuffer());
+  if (bytes.byteLength > 8 * 1024)
+    return json({ error: "payload_too_large" }, 413);
+  if (!env.CODE_RELEASE_SECRET)
+    return json({ error: "service_unavailable" }, 503);
+  const supplied = request.headers.get("X-Code-Release-Signature") || "";
+  const expected = await hmacHex(env.CODE_RELEASE_SECRET, bytes);
+  if (!timingSafeHex(supplied, expected))
+    return json({ error: "unauthorized" }, 401);
+
+  let payload: Record<string, unknown>;
+  try {
+    payload = JSON.parse(
+      new TextDecoder("utf-8", { fatal: true }).decode(bytes),
+    ) as Record<string, unknown>;
+  } catch {
+    return json({ error: "invalid_request" }, 400);
+  }
+  const targetCodeSha = String(payload.code_sha || "").toLowerCase();
+  if (!SHA1.test(targetCodeSha)) return json({ error: "invalid_request" }, 400);
+
+  const sql = (dependencies.openDatabase || openContentDatabase)(
+    env,
+    "automatic-code-release",
+  );
+  try {
+    const baseRows = await sql<Record<string, unknown>[]>`
+      select private.get_code_release_base_v1() as result
+    `;
+    const base = baseRows[0]?.result as Record<string, unknown> | undefined;
+    const baseCodeSha = String(base?.code_sha || "");
+    const structuredCutoverDate = String(base?.structured_cutover_date || "");
+    if (
+      !base ||
+      !SHA1.test(baseCodeSha) ||
+      !UUID.test(String(base.site_release_id || "")) ||
+      !DATE.test(structuredCutoverDate)
+    ) {
+      throw new Error("Code release base is unavailable");
+    }
+    if (baseCodeSha === targetCodeSha) {
+      return json({
+        ok: true,
+        status: "already_current",
+        code_sha: targetCodeSha,
+      });
+    }
+
+    const mainSha = await (dependencies.getCurrentMainSha || currentMainSha)(
+      env,
+    );
+    if (mainSha !== targetCodeSha) {
+      return supersededCodeRelease(targetCodeSha, mainSha);
+    }
+
+    let comparison: {
+      files: GitHubFile[];
+      changeSetSha256: string;
+      publishableFileCount?: number;
+    };
+    try {
+      comparison = await (dependencies.compare || compareCodeRelease)(
+        env,
+        baseCodeSha,
+        targetCodeSha,
+        structuredCutoverDate,
+      );
+    } catch (error) {
+      return json(
+        {
+          error: "unsafe_code_release",
+          detail: error instanceof Error ? error.message : "invalid_change_set",
+        },
+        422,
+      );
+    }
+    const publishableFileCount =
+      comparison.publishableFileCount ??
+      comparison.files.filter(
+        (file) =>
+          classifyCodeReleasePath(file.filename, structuredCutoverDate) ===
+            "publishable" ||
+          (file.previous_filename !== undefined &&
+            classifyCodeReleasePath(
+              file.previous_filename,
+              structuredCutoverDate,
+            ) === "publishable"),
+      ).length;
+    if (publishableFileCount === 0) {
+      return json({
+        ok: true,
+        status: "no_changes",
+        code_sha: targetCodeSha,
+        changed_file_count: comparison.files.length,
+      });
+    }
+
+    const idempotencyHash = await sha256Hex(
+      canonicalJsonBytes({
+        base_code_sha: baseCodeSha,
+        target_code_sha: targetCodeSha,
+        change_set_sha256: comparison.changeSetSha256,
+      }),
+    );
+    const idempotencyKey = uuidFromHash(idempotencyHash);
+    const dispatchId = idempotencyKey;
+    const latestMainSha = await (
+      dependencies.getCurrentMainSha || currentMainSha
+    )(env);
+    if (latestMainSha !== targetCodeSha) {
+      return supersededCodeRelease(targetCodeSha, latestMainSha);
+    }
+    const reservationRows = await sql<Record<string, unknown>[]>`
+      select private.reserve_code_release_v1(
+        ${idempotencyKey}::uuid,
+        ${targetCodeSha},
+        ${baseCodeSha},
+        ${CODE_RELEASE_BUILD_ENVIRONMENT},
+        ${comparison.changeSetSha256}
+      ) as result
+    `;
+    const reservation = reservationRows[0]?.result as
+      | Record<string, unknown>
+      | undefined;
+    if (
+      !reservation ||
+      !UUID.test(String(reservation.reservation_id || "")) ||
+      !Number.isSafeInteger(Number(reservation.site_release_sequence)) ||
+      String(reservation.expected_predecessor_id || "") !==
+        String(base.site_release_id) ||
+      String(reservation.content_root_sha256 || "") !==
+        String(base.content_root_sha256)
+    ) {
+      throw new Error("Code release reservation identity mismatch");
+    }
+
+    const baseManifest = await readVerifiedManifest(
+      env.SITE_MANIFESTS,
+      reservation.base_manifest as Record<string, unknown>,
+    );
+    if (
+      String(baseManifest.site_release_id || "") !==
+        String(base.site_release_id) ||
+      String(baseManifest.content_root_sha256 || "") !==
+        String(base.content_root_sha256) ||
+      !Array.isArray(baseManifest.reports)
+    ) {
+      throw new Error("Base manifest identity mismatch");
+    }
+    const nextManifestBytes = canonicalJsonBytes({
+      ...baseManifest,
+      site_release_id: reservation.site_release_id,
+      site_release_sequence: Number(reservation.site_release_sequence),
+      expected_predecessor_id: reservation.expected_predecessor_id,
+    });
+    if (!env.SITE_MANIFESTS)
+      throw new Error("Site manifest binding is unavailable");
+    const manifestObject = await putVerifiedImmutable(
+      env.SITE_MANIFESTS,
+      "site-manifests",
+      "json",
+      nextManifestBytes,
+      "application/json; charset=utf-8",
+    );
+    const dispatchPayload = {
+      dispatch_id: dispatchId,
+      site_release_id: reservation.site_release_id,
+      site_release_sequence: Number(reservation.site_release_sequence),
+      expected_predecessor_id: reservation.expected_predecessor_id,
+      expected_content_sha: base.content_root_sha256,
+      code_sha: targetCodeSha,
+      build_environment_version: CODE_RELEASE_BUILD_ENVIRONMENT,
+      mode: "production",
+    };
+    const finalRows = await sql<Record<string, unknown>[]>`
+      select private.finalize_code_release_v1(
+        ${String(reservation.reservation_id)}::uuid,
+        ${manifestObject.key},
+        ${manifestObject.byteLength},
+        ${manifestObject.sha256},
+        ${dispatchId}::uuid,
+        ${sql.json(dispatchPayload)}
+      ) as result
+    `;
+    const release = finalRows[0]?.result as Record<string, unknown> | undefined;
+    if (
+      String(release?.site_release_id || "") !==
+      String(reservation.site_release_id)
+    )
+      throw new Error("Code release finalization identity mismatch");
+    return json(
+      {
+        ok: true,
+        status: "queued",
+        site_release_id: release.site_release_id,
+        site_release_sequence: release.site_release_sequence,
+        code_sha: targetCodeSha,
+        content_sha256: base.content_root_sha256,
+        changed_file_count: comparison.files.length,
+      },
+      202,
+    );
+  } catch (error) {
+    const code =
+      error && typeof error === "object" && "code" in error
+        ? String((error as { code?: unknown }).code || "")
+        : "";
+    if (["55P03", "40001"].includes(code)) {
+      return json({ error: "release_head_busy", retryable: true }, 409);
+    }
+    console.error("[ContentDeployer] automatic code release failed", {
+      errorType: error instanceof Error ? error.name : "Error",
+    });
+    return json({ error: "service_unavailable", retryable: true }, 503);
+  } finally {
+    await sql.end({ timeout: 2 });
+  }
+}
+
 async function handlePreviewDispatch(
   request: Request,
   env: Env,
@@ -591,12 +1131,29 @@ export async function handleBuildContentRequest(
 }
 
 export default {
-  fetch(request: Request, env: Env): Promise<Response> {
+  async fetch(
+    request: Request,
+    env: Env,
+    context: ExecutionContext,
+  ): Promise<Response> {
     const url = new URL(request.url);
     if (url.pathname === "/callbacks/github")
       return handleDeploymentCallback(request, env);
     if (url.pathname === "/internal/recovery-health")
       return handleRecoveryHealthCallback(request, env);
+    if (url.pathname === "/internal/code-release") {
+      const response = await handleCodeReleaseRequest(request, env);
+      if (response.status === 202) {
+        context.waitUntil(
+          dispatchOne(env).catch((error) => {
+            console.error("[ContentDeployer] immediate code dispatch failed", {
+              errorType: error instanceof Error ? error.name : "Error",
+            });
+          }),
+        );
+      }
+      return response;
+    }
     if (
       url.pathname === "/internal/preview-dispatch" &&
       request.method === "POST"

--- a/workers/content/editorial/index.ts
+++ b/workers/content/editorial/index.ts
@@ -1,5 +1,9 @@
 import { canonicalJsonBytes, equalBytes, sha256Hex } from "../shared/canonical";
-import { openContentDatabase } from "../shared/db";
+import {
+  databaseErrorCode,
+  isRetryableReleaseContention,
+  openContentDatabase,
+} from "../shared/db";
 import { putVerifiedImmutable } from "../shared/r2";
 
 type Env = {
@@ -30,12 +34,12 @@ const ALLOWED_PATCH_FIELDS = new Set([
 function validReleaseContract(input: JsonRecord): boolean {
   return Boolean(
     Number.isSafeInteger(input.schema_version) &&
-      Number(input.schema_version) >= 1 &&
-      Number.isSafeInteger(input.taxonomy_version) &&
-      Number(input.taxonomy_version) >= 1 &&
-      CONTRACT_VERSION.test(String(input.serializer_version || "")) &&
-      CONTRACT_VERSION.test(String(input.search_contract_version || "")) &&
-      CONTRACT_VERSION.test(String(input.source_contract_version || "")),
+    Number(input.schema_version) >= 1 &&
+    Number.isSafeInteger(input.taxonomy_version) &&
+    Number(input.taxonomy_version) >= 1 &&
+    CONTRACT_VERSION.test(String(input.serializer_version || "")) &&
+    CONTRACT_VERSION.test(String(input.search_contract_version || "")) &&
+    CONTRACT_VERSION.test(String(input.source_contract_version || "")),
   );
 }
 
@@ -299,9 +303,18 @@ export async function processEditorialPublish(
     return "published";
   } catch (error) {
     if (claimed?.id) {
-      await sql`select private.fail_editorial_publish_request_v1(
-        ${String(claimed.id)}::uuid, ${workerId}, ${error instanceof Error ? error.name : "Error"}
-      )`.catch(() => undefined);
+      const errorCode =
+        databaseErrorCode(error) ||
+        (error instanceof Error ? error.name : "Error");
+      if (isRetryableReleaseContention(error)) {
+        await sql`select private.defer_editorial_publish_request_v1(
+          ${String(claimed.id)}::uuid, ${workerId}, ${errorCode}
+        )`.catch(() => undefined);
+      } else {
+        await sql`select private.fail_editorial_publish_request_v1(
+          ${String(claimed.id)}::uuid, ${workerId}, ${errorCode}
+        )`.catch(() => undefined);
+      }
     }
     throw error;
   } finally {
@@ -428,9 +441,18 @@ export async function processGlobalSuppression(
     return "published";
   } catch (error) {
     if (claimed?.id) {
-      await sql`select private.fail_global_suppression_request_v1(
-        ${String(claimed.id)}::uuid, ${workerId}, ${error instanceof Error ? error.name : "Error"}
-      )`.catch(() => undefined);
+      const errorCode =
+        databaseErrorCode(error) ||
+        (error instanceof Error ? error.name : "Error");
+      if (isRetryableReleaseContention(error)) {
+        await sql`select private.defer_global_suppression_request_v1(
+          ${String(claimed.id)}::uuid, ${workerId}, ${errorCode}
+        )`.catch(() => undefined);
+      } else {
+        await sql`select private.fail_global_suppression_request_v1(
+          ${String(claimed.id)}::uuid, ${workerId}, ${errorCode}
+        )`.catch(() => undefined);
+      }
     }
     throw error;
   } finally {

--- a/workers/content/ingestion/mirror.ts
+++ b/workers/content/ingestion/mirror.ts
@@ -3,6 +3,7 @@ import {
   failIngestionPublicationAttempt,
   finalizeSiteRelease,
   ingestReportSnapshot,
+  isRetryableReleaseContention,
   openContentDatabase,
   reserveIngestionSiteRelease,
   type ContentSql,
@@ -184,24 +185,30 @@ export async function mirrorStructuredReport(
       manifestSha256: manifestObject.sha256,
     };
   } catch (error) {
-    try {
-      await failIngestionPublicationAttempt(sql, {
-        reportDate: input.report.date,
-        batchId: input.batch,
-        inputSha256: reportObject.sha256,
-        triggerKind,
-        workerVersion,
-        errorCode: error instanceof Error ? error.name : "Error",
-        errorDetail: error instanceof Error ? error.message : String(error),
-      });
-    } catch (attemptError) {
-      console.error(
-        "[ContentMirror] failed to persist publication attempt failure",
-        {
-          errorType:
-            attemptError instanceof Error ? attemptError.name : "Error",
-        },
+    if (isRetryableReleaseContention(error)) {
+      console.warn(
+        "[ContentMirror] production release head is busy; retry later",
       );
+    } else {
+      try {
+        await failIngestionPublicationAttempt(sql, {
+          reportDate: input.report.date,
+          batchId: input.batch,
+          inputSha256: reportObject.sha256,
+          triggerKind,
+          workerVersion,
+          errorCode: error instanceof Error ? error.name : "Error",
+          errorDetail: error instanceof Error ? error.message : String(error),
+        });
+      } catch (attemptError) {
+        console.error(
+          "[ContentMirror] failed to persist publication attempt failure",
+          {
+            errorType:
+              attemptError instanceof Error ? attemptError.name : "Error",
+          },
+        );
+      }
     }
     throw error;
   } finally {

--- a/workers/content/shared/db.ts
+++ b/workers/content/shared/db.ts
@@ -7,6 +7,19 @@ type DatabaseEnv = {
 
 export type ContentSql = ReturnType<typeof postgres>;
 
+export function databaseErrorCode(error: unknown): string | null {
+  if (!error || typeof error !== "object") return null;
+  const value = error as { code?: unknown; cause?: unknown };
+  if (typeof value.code === "string" && value.code.length > 0) {
+    return value.code;
+  }
+  return value.cause === error ? null : databaseErrorCode(value.cause);
+}
+
+export function isRetryableReleaseContention(error: unknown): boolean {
+  return ["55P03", "40001"].includes(databaseErrorCode(error) || "");
+}
+
 export function openContentDatabase(
   env: DatabaseEnv,
   applicationName: string,

--- a/wrangler.content-deployer.toml
+++ b/wrangler.content-deployer.toml
@@ -27,5 +27,6 @@ bucket_name = "bubble-content-report-snapshots"
 binding = "SITE_MANIFESTS"
 bucket_name = "bubble-content-site-manifests"
 
-# Set GITHUB_TOKEN, DEPLOY_CALLBACK_SECRET, PREVIEW_DISPATCH_SECRET and
-# CONTENT_BUILD_API_SECRET and RECOVERY_MONITOR_SECRET as Worker secrets.
+# Set GITHUB_TOKEN, DEPLOY_CALLBACK_SECRET, PREVIEW_DISPATCH_SECRET,
+# CONTENT_BUILD_API_SECRET, CODE_RELEASE_SECRET and RECOVERY_MONITOR_SECRET
+# as Worker secrets.


### PR DESCRIPTION
## Summary\n- release Astro UI changes automatically after merges to main\n- wait for the exact Pages production pointer instead of treating queue acceptance as success\n- serialize code and content releases without changing the content root\n- fail closed for content-bearing or unknown change sets\n\n## Validation\n- npm test (514 tests)\n- npm run verify --prefix astro (67 tests, 631 routes, 27 XML endpoints, 99 demos)\n- bash scripts/test-supabase-local.sh (266 pgTAP tests in both passes, migration reapply)\n- Wrangler dry-runs for daily, deployer, broker, and editorial Workers\n\n## Rollout\nThe production secret, database migration, and affected Workers will be bootstrapped before merge. After merge, Automatic Code Release verifies both production current-pointer origins before succeeding. PITR and the recovery monitor remain disabled.