### PR TITLE
fix: verify production site identity after release

### DIFF
--- a/.github/workflows/automatic-code-release.yml
+++ b/.github/workflows/automatic-code-release.yml
@@ -29,6 +29,8 @@ jobs:
       CODE_RELEASE_ORIGIN: ${{ vars.CONTENT_DEPLOYER_ORIGIN }}
       CODE_RELEASE_SECRET: ${{ secrets.CODE_RELEASE_SECRET }}
       CONTENT_CURRENT_URLS: https://content-api.bubblenews.today/v1/current,https://content-api-origin.bubblenews.today/v1/current
+      CONTENT_SITE_IDENTITY_URLS: https://bubblenews.today/release-manifests/site-route-manifest.json,https://ai-bubblebrain-daily-news.pages.dev/release-manifests/site-route-manifest.json
+      CODE_RELEASE_SITE_PROBES_PER_ORIGIN: "3"
       CODE_RELEASE_WAIT_TIMEOUT_SECONDS: "2700"
       GH_TOKEN: ${{ github.token }}
 

--- a/scripts/request-code-release.mjs
+++ b/scripts/request-code-release.mjs
@@ -12,6 +12,32 @@ function positiveInteger(value, fallback, label) {
   return normalized;
 }
 
+function exactVerifierUrls(env, label, expectedPath) {
+  const urls = String(env[label] || "")
+    .split(",")
+    .map((value) => value.trim())
+    .filter(Boolean)
+    .map((value) => new URL(value));
+  if (
+    urls.length < 2 ||
+    new Set(urls.map((url) => url.origin)).size < 2 ||
+    urls.some(
+      (url) =>
+        url.protocol !== "https:" ||
+        url.pathname !== expectedPath ||
+        url.search ||
+        url.hash ||
+        url.username ||
+        url.password,
+    )
+  ) {
+    throw new Error(
+      `${label} must contain at least two distinct exact HTTPS ${expectedPath} origins`,
+    );
+  }
+  return urls;
+}
+
 function codeReleaseConfiguration(env) {
   const origin = env.CODE_RELEASE_ORIGIN?.trim();
   const secret = env.CODE_RELEASE_SECRET?.trim();
@@ -22,31 +48,28 @@ function codeReleaseConfiguration(env) {
   const requestUrl = new URL("/internal/code-release", origin);
   if (requestUrl.protocol !== "https:")
     throw new Error("Code release origin must use HTTPS");
-  const currentUrls = String(env.CONTENT_CURRENT_URLS || "")
-    .split(",")
-    .map((value) => value.trim())
-    .filter(Boolean)
-    .map((value) => new URL(value));
-  if (
-    currentUrls.length < 2 ||
-    new Set(currentUrls.map((url) => url.origin)).size < 2 ||
-    currentUrls.some(
-      (url) =>
-        url.protocol !== "https:" ||
-        url.pathname !== "/v1/current" ||
-        url.search ||
-        url.hash ||
-        url.username ||
-        url.password,
-    )
-  ) {
-    throw new Error(
-      "CONTENT_CURRENT_URLS must contain at least two distinct exact HTTPS /v1/current origins",
-    );
-  }
+  const currentUrls = exactVerifierUrls(
+    env,
+    "CONTENT_CURRENT_URLS",
+    "/v1/current",
+  );
+  const siteIdentityUrls = exactVerifierUrls(
+    env,
+    "CONTENT_SITE_IDENTITY_URLS",
+    "/release-manifests/site-route-manifest.json",
+  );
+  const siteProbesPerOrigin = positiveInteger(
+    env.CODE_RELEASE_SITE_PROBES_PER_ORIGIN,
+    3,
+    "CODE_RELEASE_SITE_PROBES_PER_ORIGIN",
+  );
+  if (siteProbesPerOrigin > 5)
+    throw new Error("CODE_RELEASE_SITE_PROBES_PER_ORIGIN must not exceed 5");
   return {
     codeSha,
     currentUrls,
+    siteIdentityUrls,
+    siteProbesPerOrigin,
     requestUrl,
     secret,
     requestAttempts: positiveInteger(
@@ -178,6 +201,49 @@ function pointerMatches(pointer, codeSha, siteReleaseId) {
   );
 }
 
+function siteIdentityMatches(manifest, codeSha, siteReleaseId) {
+  return pointerMatches(manifest?.build, codeSha, siteReleaseId);
+}
+
+async function observeJsonIdentity(
+  url,
+  configuration,
+  siteReleaseId,
+  dependencies,
+  kind,
+) {
+  try {
+    const response = await dependencies.fetch(url, {
+      headers: {
+        Accept: "application/json",
+        "Cache-Control": "no-cache",
+      },
+    });
+    const body = await responseJson(response);
+    const identity = kind === "current" ? body : body?.build;
+    return {
+      kind,
+      url: url.origin,
+      ok: response.ok,
+      site_release_id: identity?.site_release_id || null,
+      code_sha: identity?.code_sha || null,
+      matches:
+        response.ok &&
+        (kind === "current"
+          ? pointerMatches(body, configuration.codeSha, siteReleaseId)
+          : siteIdentityMatches(body, configuration.codeSha, siteReleaseId)),
+    };
+  } catch (error) {
+    return {
+      kind,
+      url: url.origin,
+      ok: false,
+      error: error instanceof Error ? error.name : "Error",
+      matches: false,
+    };
+  }
+}
+
 async function waitForCurrentPointer(
   configuration,
   siteReleaseId,
@@ -186,35 +252,28 @@ async function waitForCurrentPointer(
   const startedAt = dependencies.now();
   let lastObserved = [];
   while (dependencies.now() - startedAt < configuration.waitTimeoutMs) {
-    const observations = await Promise.all(
-      configuration.currentUrls.map(async (url) => {
-        try {
-          const response = await dependencies.fetch(url, {
-            headers: {
-              Accept: "application/json",
-              "Cache-Control": "no-cache",
-            },
-          });
-          const body = await responseJson(response);
-          return {
-            url: url.origin,
-            ok: response.ok,
-            site_release_id: body?.site_release_id || null,
-            code_sha: body?.code_sha || null,
-            matches:
-              response.ok &&
-              pointerMatches(body, configuration.codeSha, siteReleaseId),
-          };
-        } catch (error) {
-          return {
-            url: url.origin,
-            ok: false,
-            error: error instanceof Error ? error.name : "Error",
-            matches: false,
-          };
-        }
-      }),
-    );
+    const observations = await Promise.all([
+      ...configuration.currentUrls.map((url) =>
+        observeJsonIdentity(
+          url,
+          configuration,
+          siteReleaseId,
+          dependencies,
+          "current",
+        ),
+      ),
+      ...configuration.siteIdentityUrls.flatMap((url) =>
+        Array.from({ length: configuration.siteProbesPerOrigin }, () =>
+          observeJsonIdentity(
+            url,
+            configuration,
+            siteReleaseId,
+            dependencies,
+            "site",
+          ),
+        ),
+      ),
+    ]);
     lastObserved = observations;
     if (observations.every((value) => value.matches)) {
       dependencies.log(
@@ -222,7 +281,13 @@ async function waitForCurrentPointer(
           outcome: "deployed",
           site_release_id: siteReleaseId || observations[0].site_release_id,
           code_sha: configuration.codeSha,
-          verified_current_origins: observations.map((value) => value.url),
+          verified_current_origins: configuration.currentUrls.map(
+            (url) => url.origin,
+          ),
+          verified_site_origins: configuration.siteIdentityUrls.map(
+            (url) => url.origin,
+          ),
+          site_probes_per_origin: configuration.siteProbesPerOrigin,
         }),
       );
       return {
@@ -233,7 +298,7 @@ async function waitForCurrentPointer(
     await dependencies.sleep(configuration.pollDelayMs);
   }
   throw new Error(
-    `Automatic code release did not become the verified current pointer before timeout: ${JSON.stringify(lastObserved)}`,
+    `Automatic code release did not converge across current pointers and site identities before timeout: ${JSON.stringify(lastObserved)}`,
   );
 }
 

--- a/scripts/validate-content-production-config.mjs
+++ b/scripts/validate-content-production-config.mjs
@@ -618,20 +618,35 @@ function validateCodeReleaseEnvironment(env) {
     originOnly: true,
   });
   secret("CODE_RELEASE_SECRET", env.CODE_RELEASE_SECRET, 32);
-  const currentUrls = required("CONTENT_CURRENT_URLS", env.CONTENT_CURRENT_URLS)
-    .split(",")
-    .map((value) => httpsUrl("CONTENT_CURRENT_URLS", value.trim()));
-  if (currentUrls.length < 2)
-    fail("CONTENT_CURRENT_URLS must contain at least two verifier origins");
-  if (new Set(currentUrls.map((url) => url.origin)).size < 2)
-    fail("CONTENT_CURRENT_URLS must contain distinct verifier origins");
-  if (
-    currentUrls.some(
-      (url) => url.pathname !== "/v1/current" || url.search || url.hash,
-    )
-  ) {
-    fail("CONTENT_CURRENT_URLS must contain exact /v1/current endpoints");
-  }
+  const validateVerifierUrls = (label, expectedPath) => {
+    const urls = required(label, env[label])
+      .split(",")
+      .map((value) => httpsUrl(label, value.trim()));
+    if (urls.length < 2)
+      fail(`${label} must contain at least two verifier origins`);
+    if (new Set(urls.map((url) => url.origin)).size < 2)
+      fail(`${label} must contain distinct verifier origins`);
+    if (
+      urls.some(
+        (url) => url.pathname !== expectedPath || url.search || url.hash,
+      )
+    ) {
+      fail(`${label} must contain exact ${expectedPath} endpoints`);
+    }
+  };
+  validateVerifierUrls("CONTENT_CURRENT_URLS", "/v1/current");
+  validateVerifierUrls(
+    "CONTENT_SITE_IDENTITY_URLS",
+    "/release-manifests/site-route-manifest.json",
+  );
+  const siteProbes = Number(
+    required(
+      "CODE_RELEASE_SITE_PROBES_PER_ORIGIN",
+      env.CODE_RELEASE_SITE_PROBES_PER_ORIGIN,
+    ),
+  );
+  if (!Number.isInteger(siteProbes) || siteProbes < 2 || siteProbes > 5)
+    fail("CODE_RELEASE_SITE_PROBES_PER_ORIGIN must be between 2 and 5");
   const waitTimeout = Number(
     required(
       "CODE_RELEASE_WAIT_TIMEOUT_SECONDS",

--- a/tests/worker/contentProductionConfig.test.js
+++ b/tests/worker/contentProductionConfig.test.js
@@ -200,6 +200,9 @@ describe("content production preflight", () => {
       CODE_RELEASE_SECRET: "b".repeat(32),
       CONTENT_CURRENT_URLS:
         "https://content-api.example.com/v1/current,https://content-api-origin.example.com/v1/current",
+      CONTENT_SITE_IDENTITY_URLS:
+        "https://site.example.com/release-manifests/site-route-manifest.json,https://pages.example.com/release-manifests/site-route-manifest.json",
+      CODE_RELEASE_SITE_PROBES_PER_ORIGIN: "3",
       CODE_RELEASE_WAIT_TIMEOUT_SECONDS: "2700",
     };
     expect(
@@ -231,6 +234,19 @@ describe("content production preflight", () => {
           "https://content-api.example.com/v1/current?cached=true,https://content-api-origin.example.com/v1/current",
       }),
     ).toThrow(/exact \/v1\/current endpoints/);
+    expect(() =>
+      validateWorkflowEnvironment("workflow-code-release", {
+        ...environment,
+        CONTENT_SITE_IDENTITY_URLS:
+          "https://site.example.com/manifest.json,https://pages.example.com/release-manifests/site-route-manifest.json",
+      }),
+    ).toThrow(/exact \/release-manifests\/site-route-manifest\.json endpoints/);
+    expect(() =>
+      validateWorkflowEnvironment("workflow-code-release", {
+        ...environment,
+        CODE_RELEASE_SITE_PROBES_PER_ORIGIN: "1",
+      }),
+    ).toThrow(/must be between 2 and 5/);
   });
 
   it("requires a topology-approved deployer-only observability environment", () => {

--- a/tests/worker/requestCodeRelease.test.js
+++ b/tests/worker/requestCodeRelease.test.js
@@ -12,6 +12,9 @@ function environment(overrides = {}) {
     EXACT_CODE_SHA: CODE_SHA,
     CONTENT_CURRENT_URLS:
       "https://api-one.example.test/v1/current,https://api-two.example.test/v1/current",
+    CONTENT_SITE_IDENTITY_URLS:
+      "https://site.example.test/release-manifests/site-route-manifest.json,https://pages.example.test/release-manifests/site-route-manifest.json",
+    CODE_RELEASE_SITE_PROBES_PER_ORIGIN: "3",
     CODE_RELEASE_REQUEST_MAX_ATTEMPTS: "2",
     CODE_RELEASE_REQUEST_DELAY_MS: "1",
     CODE_RELEASE_POLL_DELAY_MS: "1",
@@ -39,6 +42,11 @@ describe("automatic code release request and deployment wait", () => {
           202,
         );
       }
+      if (url.pathname === "/release-manifests/site-route-manifest.json") {
+        return json({
+          build: { site_release_id: RELEASE_ID, code_sha: CODE_SHA },
+        });
+      }
       pointerRound += 1;
       if (pointerRound <= 2) {
         return json({ site_release_id: "old", code_sha: "b".repeat(40) });
@@ -57,8 +65,46 @@ describe("automatic code release request and deployment wait", () => {
         log: vi.fn(),
       }),
     ).resolves.toEqual({ outcome: "deployed", siteReleaseId: RELEASE_ID });
-    expect(fetch).toHaveBeenCalledTimes(5);
+    expect(fetch).toHaveBeenCalledTimes(17);
     expect(sleep).toHaveBeenCalledOnce();
+  });
+
+  it("waits when one site edge still serves the predecessor identity", async () => {
+    let now = 0;
+    let siteProbe = 0;
+    const fetch = vi.fn(async (input) => {
+      const url = new URL(String(input));
+      if (url.pathname === "/internal/code-release") {
+        return json(
+          { status: "queued", site_release_id: RELEASE_ID, code_sha: CODE_SHA },
+          202,
+        );
+      }
+      if (url.pathname === "/v1/current") {
+        return json({ site_release_id: RELEASE_ID, code_sha: CODE_SHA });
+      }
+      siteProbe += 1;
+      return json({
+        build:
+          siteProbe === 2
+            ? { site_release_id: "old", code_sha: "b".repeat(40) }
+            : { site_release_id: RELEASE_ID, code_sha: CODE_SHA },
+      });
+    });
+    const sleep = vi.fn(async (milliseconds) => {
+      now += milliseconds;
+    });
+
+    await expect(
+      runCodeRelease(environment(), {
+        fetch,
+        sleep,
+        now: () => now,
+        log: vi.fn(),
+      }),
+    ).resolves.toEqual({ outcome: "deployed", siteReleaseId: RELEASE_ID });
+    expect(sleep).toHaveBeenCalledOnce();
+    expect(siteProbe).toBe(12);
   });
 
   it("reports a non-UI change set as an explicit safe no-op", async () => {
@@ -113,16 +159,22 @@ describe("automatic code release request and deployment wait", () => {
     let now = 0;
     const fetch = vi.fn(async (input) => {
       const url = new URL(String(input));
-      return url.pathname === "/internal/code-release"
-        ? json(
-            {
-              status: "queued",
-              site_release_id: RELEASE_ID,
-              code_sha: CODE_SHA,
-            },
-            202,
-          )
-        : json({ site_release_id: "old", code_sha: "b".repeat(40) });
+      if (url.pathname === "/internal/code-release") {
+        return json(
+          {
+            status: "queued",
+            site_release_id: RELEASE_ID,
+            code_sha: CODE_SHA,
+          },
+          202,
+        );
+      }
+      if (url.pathname === "/release-manifests/site-route-manifest.json") {
+        return json({
+          build: { site_release_id: RELEASE_ID, code_sha: CODE_SHA },
+        });
+      }
+      return json({ site_release_id: "old", code_sha: "b".repeat(40) });
     });
     const sleep = vi.fn(async (milliseconds) => {
       now += milliseconds;
@@ -136,7 +188,9 @@ describe("automatic code release request and deployment wait", () => {
         }),
         { fetch, sleep, now: () => now, log: vi.fn() },
       ),
-    ).rejects.toThrow(/did not become the verified current pointer/);
+    ).rejects.toThrow(
+      /did not converge across current pointers and site identities/,
+    );
   });
 
   it("retries only declared transient release-head failures", async () => {
@@ -148,6 +202,11 @@ describe("automatic code release request and deployment wait", () => {
         return requestCount === 1
           ? json({ error: "release_head_busy", retryable: true }, 409)
           : json({ status: "already_current", code_sha: CODE_SHA });
+      }
+      if (url.pathname === "/release-manifests/site-route-manifest.json") {
+        return json({
+          build: { site_release_id: RELEASE_ID, code_sha: CODE_SHA },
+        });
       }
       return json({ site_release_id: RELEASE_ID, code_sha: CODE_SHA });
     });


### PR DESCRIPTION
## Summary\n- verify both production current-pointer origins and public site manifests\n- sample each site origin three times in the same automated release step\n- keep the release workflow pending while any CDN edge still serves the predecessor identity\n\n## Evidence\nThe first automatic release reached release #7 successfully, but the custom domain briefly alternated between release #6 and #7 after the pointer moved. The local hardened verifier now passes against both live origins.\n\n## Validation\n- npm test (515 tests)\n- live verifier: both current origins + both site identity origins, 3 probes per site origin