### PR TITLE
Allow shared daily timeline assets in code release changesets

### DIFF
--- a/workers/content/deployer/index.test.ts
+++ b/workers/content/deployer/index.test.ts
@@ -180,6 +180,8 @@ describe("automatic code release boundary", () => {
           { filename: "astro/src/scripts/authControls.ts", status: "modified" },
           { filename: "astro/src/lib/searchIndex.ts", status: "modified" },
           { filename: "astro/public/favicon.svg", status: "modified" },
+          { filename: "static/css/daily-timeline.css", status: "modified" },
+          { filename: "static/js/daily-timeline.js", status: "modified" },
           { filename: "workers/content/deployer/index.ts", status: "modified" },
           {
             filename: "supabase/migrations/20260719000100_release.sql",
@@ -200,7 +202,7 @@ describe("automatic code release boundary", () => {
           structuredCutoverDate: "2026-07-16",
         },
       ),
-    ).toHaveLength(11);
+    ).toHaveLength(13);
   });
 
   it.each([

--- a/workers/content/deployer/index.ts
+++ b/workers/content/deployer/index.ts
@@ -284,6 +284,8 @@ function classifyCodeReleasePath(
       "astro/raw-html-policy.json",
       "astro/route-ownership.json",
       "astro/tsconfig.json",
+      "static/css/daily-timeline.css",
+      "static/js/daily-timeline.js",
     ].includes(path)
   ) {
     return "publishable";


### PR DESCRIPTION
## 问题

#65 合并后线上未更新：main 上的 Automatic Code Release 工作流被 deployer 以 422 `unsafe_code_release` 拒绝——`static/css/daily-timeline.css` 不在代码发布允许清单里。

## 修复

- `workers/content/deployer/index.ts`：将 `static/css/daily-timeline.css`、`static/js/daily-timeline.js` 归类为 publishable（Astro 与 Hugo 共享的时间线静态资源，parity 脚本本就强制两者一致）
- `index.test.ts`：允许清单用例同步覆盖这两个路径

## 验证

- `npx vitest run workers/content/deployer tests/worker/requestCodeRelease.test.js`：28/28 通过

## 合并后还需要两步（我会跟进）

1. 重新部署 content-deployer worker（`wrangler deploy --config wrangler.content-deployer.toml`），线上 worker 仍带旧清单
2. 手动重跑 Automatic Code Release（workflow_dispatch，code_sha=新 main SHA）