### PR TITLE
Bust shared timeline asset cache with build-time content hash

### DIFF
--- a/astro/src/components/DailyTimeline.astro
+++ b/astro/src/components/DailyTimeline.astro
@@ -1,4 +1,8 @@
 ---
+import { createHash } from 'node:crypto';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
 import { dailyDateFromKey, formatDailyWeekday, type DailyLocale } from '../lib/daily';
 import {
 	cleanTimelineSummary,
@@ -19,6 +23,19 @@ interface Props {
 
 const { report, locale, newerHref = null, olderHref = null } = Astro.props;
 const isEnglish = locale === 'en';
+
+// Shared timeline assets are served unhashed from static/, so bust the
+// browser cache with a build-time content hash query instead.
+const staticAssetVersion = (assetPath: string): string => {
+	try {
+		const bytes = readFileSync(resolve(process.cwd(), '..', 'static', assetPath));
+		return createHash('sha256').update(bytes).digest('hex').slice(0, 10);
+	} catch {
+		return 'local';
+	}
+};
+const timelineCssHref = `/css/daily-timeline.css?v=${staticAssetVersion('css/daily-timeline.css')}`;
+const timelineJsSrc = `/js/daily-timeline.js?v=${staticAssetVersion('js/daily-timeline.js')}`;
 const itemById = new Map(report.items.map((item) => [item.id, item]));
 const typeLabels: Record<'all' | DailyContentType, string> = isEnglish
 	? { all: 'All', news: 'News', project: 'Projects', paper: 'Papers', socialMedia: 'Social' }
@@ -69,7 +86,7 @@ const newerKey = hrefDateKey(newerHref);
 const olderKey = hrefDateKey(olderHref);
 ---
 
-<link rel="stylesheet" href="/css/daily-timeline.css" />
+<link rel="stylesheet" href={timelineCssHref} />
 
 <article
 	class="daily-timeline"
@@ -314,4 +331,4 @@ const olderKey = hrefDateKey(olderHref);
 	</footer>
 </article>
 
-<script is:inline type="module" src="/js/daily-timeline.js"></script>
+<script is:inline type="module" src={timelineJsSrc}></script>

--- a/scripts/verify-daily-renderers.mjs
+++ b/scripts/verify-daily-renderers.mjs
@@ -248,22 +248,25 @@ title: sanitizer fixture
     sanitizerHtml,
     /data-link="https:\/\/attr\.example\/a%5D\(https:\/\/attr\.example\/b\)"/u,
   );
-	assert.doesNotMatch(sanitizerHtml, /first\.example\/story/iu);
-	assert.match(sanitizerHtml, /<p>truncated before\s+truncated after<\/p>/u);
-	assert.match(
-		sanitizerHtml,
-		/<p>ordinary before <a href="https:\/\/ordinary\.example\/story">ordinary label<\/a> ordinary after<\/p>/u,
-	);
-	assert.match(
-		sanitizerHtml,
-		/<p>prose before https:\/\/zenodo\.example\/record，而正文 prose after<\/p>/u,
-	);
-	assert.doesNotMatch(sanitizerHtml, /href="https:\/\/zenodo\.example/iu);
-	assert.match(
-		sanitizerHtml,
-		/<p>combined before https:\/\/example\.com\/path。正文 combined after<\/p>/u,
-	);
-	assert.doesNotMatch(sanitizerHtml, /href="https:\/\/example\.com\/path%E3%80%82/iu);
+  assert.doesNotMatch(sanitizerHtml, /first\.example\/story/iu);
+  assert.match(sanitizerHtml, /<p>truncated before\s+truncated after<\/p>/u);
+  assert.match(
+    sanitizerHtml,
+    /<p>ordinary before <a href="https:\/\/ordinary\.example\/story">ordinary label<\/a> ordinary after<\/p>/u,
+  );
+  assert.match(
+    sanitizerHtml,
+    /<p>prose before https:\/\/zenodo\.example\/record，而正文 prose after<\/p>/u,
+  );
+  assert.doesNotMatch(sanitizerHtml, /href="https:\/\/zenodo\.example/iu);
+  assert.match(
+    sanitizerHtml,
+    /<p>combined before https:\/\/example\.com\/path。正文 combined after<\/p>/u,
+  );
+  assert.doesNotMatch(
+    sanitizerHtml,
+    /href="https:\/\/example\.com\/path%E3%80%82/iu,
+  );
 
   execFileSync("hugo", ["--destination", hugoOutput, "--cleanDestinationDir"], {
     cwd: repoRoot,
@@ -329,8 +332,24 @@ title: sanitizer fixture
     assert.match(html, /data-daily-timeline/);
     assert.match(html, /示例 AI 资讯/);
     assert.doesNotMatch(html, /proxy\.example|raw\.example/);
-    assert.match(html, /type="module" src="\/js\/daily-timeline\.js"/);
+    assert.match(
+      html,
+      /type="module" src="\/js\/daily-timeline\.js(?:\?v=[0-9a-f]{10})?"/,
+    );
   }
+  // Astro busts the shared timeline asset cache with a build-time content
+  // hash query; Hugo keeps the plain URL because it no longer serves
+  // production traffic.
+  assert.match(
+    astroStructured,
+    /href="\/css\/daily-timeline\.css\?v=[0-9a-f]{10}"/,
+    "Astro timeline stylesheet must carry a content-hash cache buster",
+  );
+  assert.match(
+    astroStructured,
+    /type="module" src="\/js\/daily-timeline\.js\?v=[0-9a-f]{10}"/,
+    "Astro timeline script must carry a content-hash cache buster",
+  );
   assertTimelineAccessibilityStructure(hugoStructured, "Hugo");
   assertTimelineAccessibilityStructure(astroStructured, "Astro");
   for (const attribute of [

--- a/workers/content/deployer/index.test.ts
+++ b/workers/content/deployer/index.test.ts
@@ -184,6 +184,10 @@ describe("automatic code release boundary", () => {
           { filename: "static/js/daily-timeline.js", status: "modified" },
           { filename: "workers/content/deployer/index.ts", status: "modified" },
           {
+            filename: "scripts/verify-daily-renderers.mjs",
+            status: "modified",
+          },
+          {
             filename: "supabase/migrations/20260719000100_release.sql",
             status: "added",
           },
@@ -202,7 +206,7 @@ describe("automatic code release boundary", () => {
           structuredCutoverDate: "2026-07-16",
         },
       ),
-    ).toHaveLength(13);
+    ).toHaveLength(14);
   });
 
   it.each([

--- a/workers/content/deployer/index.ts
+++ b/workers/content/deployer/index.ts
@@ -206,6 +206,7 @@ const INERT_ROOT_SCRIPTS = new Set([
   "scripts/request-code-release.mjs",
   "scripts/test-content-failure-matrix-local.mjs",
   "scripts/validate-content-production-config.mjs",
+  "scripts/verify-daily-renderers.mjs",
 ]);
 
 function assertGitHubComparePath(path: string): void {


### PR DESCRIPTION
## 问题

时间线 CSS/JS 从 `static/` 以无哈希 URL 提供，浏览器缓存 4 小时。CSS 变更后，老访客会拿到「新 HTML + 旧 CSS」，出现条目被挤成竖条的错乱（已在线上观察到）。

## 方案（评估后的最优解）

构建期对资源字节取 sha256 前 10 位，以 `?v=<hash>` 附加到 URL：内容不变 URL 不变（缓存友好），内容一变 URL 即变。比文件名指纹轻（不动构建管线与字节级 parity 断言），比改缓存头副作用小（不影响全站静态资源）。

## 改动

- `DailyTimeline.astro`：构建期为 `/css/daily-timeline.css`、`/js/daily-timeline.js` 生成内容哈希 query
- `verify-daily-renderers.mjs`：共享 script 标签契约容忍 `?v=`，并新增断言要求 Astro 产物必须带版本参数（Hugo 侧保持原 URL——已不承担线上流量，且改 `layouts/` 会引入额外的发布白名单变更，不划算）
- `deployer`：将 `scripts/verify-daily-renderers.mjs` 登记为 inert，否则本 PR 自身会被 422 拒

## 验证

- deployer vitest 21/21、astro check/lint/test 全过
- parity 脚本本地 211 条路由全过，dist 产物确认带 `?v=976dd3027f` / `?v=7df35b29f0`

## 合并后跟进（我会做）

1. 重新部署 content-deployer worker（白名单变更需生效）
2. 重跑 Automatic Code Release（合并触发的首轮会因 worker 未更新而失败，属预期）