### PR TITLE
fix: eliminate page navigation flicker

### DIFF
--- a/astro/src/components/LegacyPage.astro
+++ b/astro/src/components/LegacyPage.astro
@@ -398,4 +398,4 @@ const libraryApi =
 	}
 </BaseLayout>
 
-{directoryKind && <script is:inline type="module" src="/js/legacy-directory.js" />}
+{directoryKind && <script is:inline src="/js/legacy-directory.js" />}

--- a/astro/src/components/PromptLibraryDetail.astro
+++ b/astro/src/components/PromptLibraryDetail.astro
@@ -43,5 +43,5 @@ const canonicalPath = isEnglish ? '/en/prompts/library/' : '/prompts/library/';
 			<div></div>
 		</nav>
 	</article>
-	<script is:inline type="module" src="/js/prompt-library-detail.js"></script>
+	<script is:inline src="/js/prompt-library-detail.js"></script>
 </BaseLayout>

--- a/astro/src/components/tools/AIInfographicTool.astro
+++ b/astro/src/components/tools/AIInfographicTool.astro
@@ -103,4 +103,4 @@ const isEnglish = locale === 'en';
 	</aside>
 </section>
 
-<script is:inline type="module" src="/js/ai-infographic.js"></script>
+<script is:inline src="/js/ai-infographic.js"></script>

--- a/astro/src/components/tools/ImageCompressTool.astro
+++ b/astro/src/components/tools/ImageCompressTool.astro
@@ -46,4 +46,4 @@ const isEnglish = locale === 'en';
 
 <script is:inline src="https://cdn.jsdelivr.net/npm/heic2any@0.0.4/dist/heic2any.min.js" defer></script>
 <script is:inline src="https://cdn.jsdelivr.net/npm/jszip@3.10.1/dist/jszip.min.js" defer></script>
-<script is:inline type="module" src="/js/image-compress.js"></script>
+<script is:inline src="/js/image-compress.js"></script>

--- a/astro/src/layouts/BaseLayout.astro
+++ b/astro/src/layouts/BaseLayout.astro
@@ -1,5 +1,6 @@
 ---
 import '../styles/migration.css';
+import { ClientRouter } from 'astro:transitions';
 import AuthControls from '../components/AuthControls.astro';
 
 interface Props {
@@ -82,6 +83,8 @@ const navLinks = isEnglish
 		/>
 		<title>{title}</title>
 		<script is:inline src="/js/theme-bootstrap.js"></script>
+		<ClientRouter fallback="swap" />
+		<script is:inline type="module" src="/js/navigation.js"></script>
 	</head>
 	<body>
 		<a class="skip-link" href="#main-content">{isEnglish ? 'Skip to content' : '跳到正文'}</a>

--- a/astro/src/scripts/authCallback.ts
+++ b/astro/src/scripts/authCallback.ts
@@ -1,8 +1,10 @@
 import { completeOAuthCallback } from '../lib/auth/authStore';
 import { safeRelativeNext } from '../lib/auth/redirect';
 
-const root = document.querySelector<HTMLElement>('[data-auth-callback]');
-if (root) {
+function initAuthCallback(): void {
+	const root = document.querySelector<HTMLElement>('[data-auth-callback]');
+	if (!root || root.dataset.bound === 'true') return;
+	root.dataset.bound = 'true';
 	const title = root.querySelector<HTMLElement>('[data-callback-title]');
 	const status = root.querySelector<HTMLElement>('[data-callback-status]');
 	const retry = root.querySelector<HTMLAnchorElement>('[data-callback-retry]');
@@ -58,3 +60,6 @@ if (root) {
 		}
 	})();
 }
+
+document.addEventListener('astro:page-load', initAuthCallback);
+initAuthCallback();

--- a/astro/src/scripts/authControls.ts
+++ b/astro/src/scripts/authControls.ts
@@ -75,45 +75,84 @@ function render(root: HTMLElement, state: AuthState): void {
 	}
 }
 
-for (const root of document.querySelectorAll<HTMLElement>('[data-auth-controls]')) {
-	if (root.dataset.bound === 'true') continue;
-	root.dataset.bound = 'true';
-	const locale = root.dataset.locale === 'en' ? 'en' : 'zh-CN';
-	const trigger = root.querySelector<HTMLButtonElement>('[data-auth-trigger]');
-	const panel = root.querySelector<HTMLElement>('[data-auth-panel]');
-	const close = (): void => {
-		if (!trigger || !panel) return;
-		trigger.ariaExpanded = 'false';
-		panel.hidden = true;
-	};
-	if (trigger) trigger.disabled = false;
-	trigger?.addEventListener('click', () => {
-		if (!panel) return;
-		const open = panel.hidden;
-		panel.hidden = !open;
-		trigger.ariaExpanded = String(open);
-		if (open && authSnapshot().status === 'booting') void bootAuth();
-	});
-	root.querySelector('[data-auth-login]')?.addEventListener('click', () => {
-		void signInWithGoogle(`${location.pathname}${location.search}${location.hash}`, locale).catch(
-			() => undefined,
+const cleanupByRoot = new Map<HTMLElement, () => void>();
+
+function initAuthControls(): void {
+	for (const root of document.querySelectorAll<HTMLElement>('[data-auth-controls]')) {
+		if (root.dataset.bound === 'true') continue;
+		root.dataset.bound = 'true';
+		const controller = new AbortController();
+		const options = { signal: controller.signal };
+		const locale = root.dataset.locale === 'en' ? 'en' : 'zh-CN';
+		const trigger = root.querySelector<HTMLButtonElement>('[data-auth-trigger]');
+		const panel = root.querySelector<HTMLElement>('[data-auth-panel]');
+		const close = (): void => {
+			if (!trigger || !panel) return;
+			trigger.ariaExpanded = 'false';
+			panel.hidden = true;
+		};
+		if (trigger) trigger.disabled = false;
+		trigger?.addEventListener(
+			'click',
+			() => {
+				if (!panel) return;
+				const open = panel.hidden;
+				panel.hidden = !open;
+				trigger.ariaExpanded = String(open);
+				if (open && authSnapshot().status === 'booting') void bootAuth();
+			},
+			options,
 		);
-	});
-	root
-		.querySelector('[data-auth-signout]')
-		?.addEventListener('click', () => void signOut().catch(() => undefined));
-	root.querySelector('[data-auth-retry]')?.addEventListener('click', () => void bootAuth());
-	document.addEventListener('keydown', (event) => {
-		if (event.key === 'Escape' && panel && !panel.hidden) {
-			close();
-			trigger?.focus();
-		}
-	});
-	document.addEventListener('click', (event) => {
-		if (event.target instanceof Node && !root.contains(event.target)) close();
-	});
-	subscribeAuth((state) => render(root, state));
+		root.querySelector('[data-auth-login]')?.addEventListener(
+			'click',
+			() => {
+				void signInWithGoogle(
+					`${location.pathname}${location.search}${location.hash}`,
+					locale,
+				).catch(() => undefined);
+			},
+			options,
+		);
+		root
+			.querySelector('[data-auth-signout]')
+			?.addEventListener('click', () => void signOut().catch(() => undefined), options);
+		root
+			.querySelector('[data-auth-retry]')
+			?.addEventListener('click', () => void bootAuth(), options);
+		document.addEventListener(
+			'keydown',
+			(event) => {
+				if (event.key === 'Escape' && panel && !panel.hidden) {
+					close();
+					trigger?.focus();
+				}
+			},
+			options,
+		);
+		document.addEventListener(
+			'click',
+			(event) => {
+				if (event.target instanceof Node && !root.contains(event.target)) close();
+			},
+			options,
+		);
+		const unsubscribe = subscribeAuth((state) => render(root, state));
+		cleanupByRoot.set(root, () => {
+			controller.abort();
+			unsubscribe();
+		});
+	}
 }
+
+document.addEventListener('astro:after-swap', () => {
+	for (const [root, cleanup] of cleanupByRoot) {
+		if (root.isConnected) continue;
+		cleanup();
+		cleanupByRoot.delete(root);
+	}
+});
+document.addEventListener('astro:page-load', initAuthControls);
+initAuthControls();
 
 const scheduleBoot = (): void => void bootAuth();
 if ('requestIdleCallback' in window) {

--- a/astro/src/scripts/discussion.ts
+++ b/astro/src/scripts/discussion.ts
@@ -109,410 +109,433 @@ function safeAvatar(url: string | null): string | null {
 	}
 }
 
-for (const root of document.querySelectorAll<HTMLElement>('[data-discussion]')) {
-	if (root.dataset.bound === 'true') continue;
-	root.dataset.bound = 'true';
-	const locale = root.dataset.locale ?? 'zh-CN';
-	const labels = copy(locale);
-	const threadId = root.dataset.threadId ?? '';
-	const list = root.querySelector<HTMLOListElement>('[data-discussion-list]');
-	const status = root.querySelector<HTMLElement>('[data-discussion-status]');
-	const count = root.querySelector<HTMLElement>('[data-discussion-count]');
-	const retry = root.querySelector<HTMLButtonElement>('[data-discussion-retry]');
-	const authNote = root.querySelector<HTMLElement>('[data-discussion-auth-note]');
-	const form = root.querySelector<HTMLFormElement>('[data-discussion-form]');
-	const textarea = form?.elements.namedItem('content') as HTMLTextAreaElement | null;
-	const typeSelect = form?.elements.namedItem('type') as HTMLSelectElement | null;
-	const charCount = root.querySelector('[data-character-count]');
-	const replyContext = root.querySelector<HTMLElement>('[data-reply-context]');
-	const replyLabel = root.querySelector('[data-reply-label]');
-	let comments: PageComment[] = [];
-	let loaded = false;
-	let parentId: string | null = null;
-	let turnstileToken = '';
-	let turnstileWidget: string | null = null;
-	let turnstileSetupPromise: Promise<void> | null = null;
-	let turnstileFailed = false;
+const cleanupByRoot = new Map<HTMLElement, () => void>();
 
-	function setState(next: string, message: string, isError = false): void {
-		root.dataset.state = next;
-		text(status, message);
-		if (status) status.setAttribute('role', isError ? 'alert' : 'status');
-		if (retry) retry.hidden = next !== 'load_error' && next !== 'turnstile_error';
-	}
+function initDiscussions(): void {
+	for (const root of document.querySelectorAll<HTMLElement>('[data-discussion]')) {
+		if (root.dataset.bound === 'true') continue;
+		root.dataset.bound = 'true';
+		const locale = root.dataset.locale ?? 'zh-CN';
+		const labels = copy(locale);
+		const threadId = root.dataset.threadId ?? '';
+		const list = root.querySelector<HTMLOListElement>('[data-discussion-list]');
+		const status = root.querySelector<HTMLElement>('[data-discussion-status]');
+		const count = root.querySelector<HTMLElement>('[data-discussion-count]');
+		const retry = root.querySelector<HTMLButtonElement>('[data-discussion-retry]');
+		const authNote = root.querySelector<HTMLElement>('[data-discussion-auth-note]');
+		const form = root.querySelector<HTMLFormElement>('[data-discussion-form]');
+		const textarea = form?.elements.namedItem('content') as HTMLTextAreaElement | null;
+		const typeSelect = form?.elements.namedItem('type') as HTMLSelectElement | null;
+		const charCount = root.querySelector('[data-character-count]');
+		const replyContext = root.querySelector<HTMLElement>('[data-reply-context]');
+		const replyLabel = root.querySelector('[data-reply-label]');
+		let comments: PageComment[] = [];
+		let loaded = false;
+		let parentId: string | null = null;
+		let turnstileToken = '';
+		let turnstileWidget: string | null = null;
+		let turnstileSetupPromise: Promise<void> | null = null;
+		let turnstileFailed = false;
+		let observer: IntersectionObserver | null = null;
 
-	function setReply(comment: PageComment | null): void {
-		parentId = comment?.id ?? null;
-		if (replyContext) replyContext.hidden = !comment;
-		if (typeSelect) typeSelect.disabled = Boolean(comment);
-		text(replyLabel, comment ? `${labels.replying} ${comment.display_name ?? ''}` : '');
-		textarea?.focus();
-	}
+		function setState(next: string, message: string, isError = false): void {
+			root.dataset.state = next;
+			text(status, message);
+			if (status) status.setAttribute('role', isError ? 'alert' : 'status');
+			if (retry) retry.hidden = next !== 'load_error' && next !== 'turnstile_error';
+		}
 
-	async function beginReply(comment: PageComment): Promise<void> {
-		let state = authSnapshot();
-		if (
-			state.status === 'booting' ||
-			state.status === 'authenticated' ||
-			state.status === 'provisioning_profile'
-		) {
-			setState('auth_checking', labels.authChecking);
-			try {
-				state = await bootAuth();
-			} catch {
+		function setReply(comment: PageComment | null): void {
+			parentId = comment?.id ?? null;
+			if (replyContext) replyContext.hidden = !comment;
+			if (typeSelect) typeSelect.disabled = Boolean(comment);
+			text(replyLabel, comment ? `${labels.replying} ${comment.display_name ?? ''}` : '');
+			textarea?.focus();
+		}
+
+		async function beginReply(comment: PageComment): Promise<void> {
+			let state = authSnapshot();
+			if (
+				state.status === 'booting' ||
+				state.status === 'authenticated' ||
+				state.status === 'provisioning_profile'
+			) {
+				setState('auth_checking', labels.authChecking);
+				try {
+					state = await bootAuth();
+				} catch {
+					setState('mutation_error', labels.authError, true);
+					return;
+				}
+			}
+			const config = browserCommunityConfig();
+			if (state.status === 'anonymous') {
+				void signInWithGoogle(
+					`${location.pathname}#discussion`,
+					locale === 'en' ? 'en' : 'zh-CN',
+				).catch(() => setState('mutation_error', labels.authError, true));
+				return;
+			}
+			if (state.status !== 'ready') {
 				setState('mutation_error', labels.authError, true);
 				return;
 			}
+			if (!config?.commentsWriteUiEnabled || !config.turnstileSiteKey) {
+				setState('mutation_error', labels.unavailable, true);
+				return;
+			}
+			setReply(comment);
 		}
-		const config = browserCommunityConfig();
-		if (state.status === 'anonymous') {
-			void signInWithGoogle(
-				`${location.pathname}#discussion`,
-				locale === 'en' ? 'en' : 'zh-CN',
-			).catch(() => setState('mutation_error', labels.authError, true));
-			return;
-		}
-		if (state.status !== 'ready') {
-			setState('mutation_error', labels.authError, true);
-			return;
-		}
-		if (!config?.commentsWriteUiEnabled || !config.turnstileSiteKey) {
-			setState('mutation_error', labels.unavailable, true);
-			return;
-		}
-		setReply(comment);
-	}
 
-	function render(): void {
-		if (!list) return;
-		list.replaceChildren();
-		const config = browserCommunityConfig();
-		const mutationsAvailable = Boolean(
-			config?.commentsWriteUiEnabled && config.turnstileSiteKey,
-		);
-		const roots = comments
-			.filter((item) => !item.parent_id)
-			.sort((a, b) => b.created_at.localeCompare(a.created_at));
-		for (const comment of roots) {
-			const item = document.createElement('li');
-			const article = document.createElement('article');
-			article.id = `comment-${comment.id}`;
-			article.tabIndex = -1;
-			const header = document.createElement('header');
-			const identity = document.createElement('div');
-			const avatarUrl = safeAvatar(comment.avatar_url);
-			if (avatarUrl) {
-				const image = document.createElement('img');
-				image.src = avatarUrl;
-				image.alt = '';
-				image.referrerPolicy = 'no-referrer';
-				identity.append(image);
-			} else {
-				const fallback = document.createElement('span');
-				fallback.className = 'discussion-avatar';
-				fallback.textContent = (comment.display_name ?? '?').slice(0, 1).toLocaleUpperCase(locale);
-				identity.append(fallback);
-			}
-			const name = document.createElement('strong');
-			name.textContent = comment.display_name ?? (locale === 'en' ? 'Reader' : '读者');
-			identity.append(name);
-			const type = document.createElement('span');
-			type.className = 'discussion-type';
-			type.textContent =
-				locale === 'en'
-					? {
-							question: 'Question',
-							repro: 'Repro feedback',
-							suggestion: 'Suggestion',
-							reply: 'Reply',
-						}[comment.type]
-					: { question: '提问', repro: '复现反馈', suggestion: '改进建议', reply: '回复' }[
-							comment.type
-						];
-			identity.append(type);
-			const time = document.createElement('time');
-			time.dateTime = comment.created_at;
-			time.textContent = new Intl.DateTimeFormat(locale, {
-				dateStyle: 'medium',
-				timeStyle: 'short',
-			}).format(new Date(comment.created_at));
-			header.append(identity, time);
-			const content = document.createElement('p');
-			content.textContent = comment.content;
-			article.append(header, content);
-			if (mutationsAvailable) {
-				const actions = document.createElement('div');
-				actions.className = 'discussion-actions';
-				const reply = document.createElement('button');
-				reply.type = 'button';
-				reply.textContent = labels.reply;
-				reply.addEventListener('click', () => void beginReply(comment));
-				actions.append(reply);
-				if (
-					authSnapshot().user?.id === comment.user_id &&
-					!comments.some((child) => child.parent_id === comment.id)
-				) {
-					const remove = document.createElement('button');
-					remove.type = 'button';
-					remove.textContent = labels.remove;
-					remove.addEventListener('click', () => void removeComment(comment, remove));
-					actions.append(remove);
+		function render(): void {
+			if (!list) return;
+			list.replaceChildren();
+			const config = browserCommunityConfig();
+			const mutationsAvailable = Boolean(config?.commentsWriteUiEnabled && config.turnstileSiteKey);
+			const roots = comments
+				.filter((item) => !item.parent_id)
+				.sort((a, b) => b.created_at.localeCompare(a.created_at));
+			for (const comment of roots) {
+				const item = document.createElement('li');
+				const article = document.createElement('article');
+				article.id = `comment-${comment.id}`;
+				article.tabIndex = -1;
+				const header = document.createElement('header');
+				const identity = document.createElement('div');
+				const avatarUrl = safeAvatar(comment.avatar_url);
+				if (avatarUrl) {
+					const image = document.createElement('img');
+					image.src = avatarUrl;
+					image.alt = '';
+					image.referrerPolicy = 'no-referrer';
+					identity.append(image);
+				} else {
+					const fallback = document.createElement('span');
+					fallback.className = 'discussion-avatar';
+					fallback.textContent = (comment.display_name ?? '?')
+						.slice(0, 1)
+						.toLocaleUpperCase(locale);
+					identity.append(fallback);
 				}
-				article.append(actions);
-			}
-			const replies = comments
-				.filter((child) => child.parent_id === comment.id)
-				.sort((a, b) => a.created_at.localeCompare(b.created_at));
-			if (replies.length) {
-				const replyList = document.createElement('ol');
-				replyList.className = 'discussion-replies';
-				for (const child of replies) {
-					const childItem = document.createElement('li');
-					const childArticle = document.createElement('article');
-					childArticle.id = `comment-${child.id}`;
-					childArticle.tabIndex = -1;
-					const childHeader = document.createElement('header');
-					const childName = document.createElement('strong');
-					childName.textContent = child.display_name ?? (locale === 'en' ? 'Reader' : '读者');
-					const childTime = document.createElement('time');
-					childTime.dateTime = child.created_at;
-					childTime.textContent = new Intl.DateTimeFormat(locale, {
-						dateStyle: 'medium',
-						timeStyle: 'short',
-					}).format(new Date(child.created_at));
-					childHeader.append(childName, childTime);
-					const childContent = document.createElement('p');
-					childContent.textContent = child.content;
-					childArticle.append(childHeader, childContent);
-					if (mutationsAvailable && authSnapshot().user?.id === child.user_id) {
-						const childActions = document.createElement('div');
-						childActions.className = 'discussion-actions';
+				const name = document.createElement('strong');
+				name.textContent = comment.display_name ?? (locale === 'en' ? 'Reader' : '读者');
+				identity.append(name);
+				const type = document.createElement('span');
+				type.className = 'discussion-type';
+				type.textContent =
+					locale === 'en'
+						? {
+								question: 'Question',
+								repro: 'Repro feedback',
+								suggestion: 'Suggestion',
+								reply: 'Reply',
+							}[comment.type]
+						: { question: '提问', repro: '复现反馈', suggestion: '改进建议', reply: '回复' }[
+								comment.type
+							];
+				identity.append(type);
+				const time = document.createElement('time');
+				time.dateTime = comment.created_at;
+				time.textContent = new Intl.DateTimeFormat(locale, {
+					dateStyle: 'medium',
+					timeStyle: 'short',
+				}).format(new Date(comment.created_at));
+				header.append(identity, time);
+				const content = document.createElement('p');
+				content.textContent = comment.content;
+				article.append(header, content);
+				if (mutationsAvailable) {
+					const actions = document.createElement('div');
+					actions.className = 'discussion-actions';
+					const reply = document.createElement('button');
+					reply.type = 'button';
+					reply.textContent = labels.reply;
+					reply.addEventListener('click', () => void beginReply(comment));
+					actions.append(reply);
+					if (
+						authSnapshot().user?.id === comment.user_id &&
+						!comments.some((child) => child.parent_id === comment.id)
+					) {
 						const remove = document.createElement('button');
 						remove.type = 'button';
 						remove.textContent = labels.remove;
-						remove.addEventListener('click', () => void removeComment(child, remove));
-						childActions.append(remove);
-						childArticle.append(childActions);
+						remove.addEventListener('click', () => void removeComment(comment, remove));
+						actions.append(remove);
 					}
-					childItem.append(childArticle);
-					replyList.append(childItem);
+					article.append(actions);
 				}
-				article.append(replyList);
+				const replies = comments
+					.filter((child) => child.parent_id === comment.id)
+					.sort((a, b) => a.created_at.localeCompare(b.created_at));
+				if (replies.length) {
+					const replyList = document.createElement('ol');
+					replyList.className = 'discussion-replies';
+					for (const child of replies) {
+						const childItem = document.createElement('li');
+						const childArticle = document.createElement('article');
+						childArticle.id = `comment-${child.id}`;
+						childArticle.tabIndex = -1;
+						const childHeader = document.createElement('header');
+						const childName = document.createElement('strong');
+						childName.textContent = child.display_name ?? (locale === 'en' ? 'Reader' : '读者');
+						const childTime = document.createElement('time');
+						childTime.dateTime = child.created_at;
+						childTime.textContent = new Intl.DateTimeFormat(locale, {
+							dateStyle: 'medium',
+							timeStyle: 'short',
+						}).format(new Date(child.created_at));
+						childHeader.append(childName, childTime);
+						const childContent = document.createElement('p');
+						childContent.textContent = child.content;
+						childArticle.append(childHeader, childContent);
+						if (mutationsAvailable && authSnapshot().user?.id === child.user_id) {
+							const childActions = document.createElement('div');
+							childActions.className = 'discussion-actions';
+							const remove = document.createElement('button');
+							remove.type = 'button';
+							remove.textContent = labels.remove;
+							remove.addEventListener('click', () => void removeComment(child, remove));
+							childActions.append(remove);
+							childArticle.append(childActions);
+						}
+						childItem.append(childArticle);
+						replyList.append(childItem);
+					}
+					article.append(replyList);
+				}
+				item.append(article);
+				list.append(item);
 			}
-			item.append(article);
-			list.append(item);
-		}
-		text(count, String(comments.length));
-		if (turnstileFailed && authSnapshot().status === 'ready')
-			setState('turnstile_error', labels.turnstileError, true);
-		else
-			setState(comments.length ? 'ready_data' : 'ready_empty', comments.length ? '' : labels.empty);
-	}
-
-	async function load(): Promise<void> {
-		setState('loading', labels.loading);
-		try {
-			comments = await loadPageComments(threadId);
-			loaded = true;
-			render();
-		} catch {
-			setState('load_error', labels.error, true);
-		}
-	}
-
-	function discardTurnstile(): void {
-		turnstileToken = '';
-		turnstileFailed = false;
-		try {
-			if (turnstileWidget && window.turnstile) window.turnstile.remove(turnstileWidget);
-		} catch {
-			// A failed widget may already have removed itself.
-		}
-		turnstileWidget = null;
-	}
-
-	function setupTurnstile(): Promise<void> {
-		const config = browserCommunityConfig();
-		const container = root.querySelector<HTMLElement>('[data-turnstile]');
-		if (
-			!config?.commentsWriteUiEnabled ||
-			!config.turnstileSiteKey ||
-			!container ||
-			turnstileWidget
-		)
-			return Promise.resolve();
-		if (turnstileSetupPromise) return turnstileSetupPromise;
-		turnstileSetupPromise = (async () => {
-			try {
-				const api = await loadTurnstile();
-				if (turnstileWidget) return;
-				turnstileWidget = api.render(container, {
-					sitekey: config.turnstileSiteKey,
-					action: 'comment',
-					size: 'flexible',
-					callback: (token: string) => {
-						turnstileToken = token;
-					},
-					'expired-callback': () => {
-						turnstileToken = '';
-					},
-					'error-callback': () => {
-						turnstileToken = '';
-						turnstileFailed = true;
-						setState('turnstile_error', labels.turnstileError, true);
-					},
-				});
-				turnstileFailed = false;
-				setState(comments.length ? 'ready_data' : 'ready_empty', '');
-			} catch {
-				turnstileFailed = true;
+			text(count, String(comments.length));
+			if (turnstileFailed && authSnapshot().status === 'ready')
 				setState('turnstile_error', labels.turnstileError, true);
+			else
+				setState(
+					comments.length ? 'ready_data' : 'ready_empty',
+					comments.length ? '' : labels.empty,
+				);
+		}
+
+		async function load(): Promise<void> {
+			setState('loading', labels.loading);
+			try {
+				comments = await loadPageComments(threadId);
+				loaded = true;
+				render();
+			} catch {
+				setState('load_error', labels.error, true);
 			}
-		})().finally(() => {
-			turnstileSetupPromise = null;
-		});
-		return turnstileSetupPromise;
-	}
+		}
 
-	function updateAuth(state: AuthState): void {
-		const config = browserCommunityConfig();
-		if (!authNote || !form) return;
-		authNote.replaceChildren();
-		if (state.status === 'anonymous') {
-			const button = document.createElement('button');
-			button.type = 'button';
-			button.textContent = labels.login;
-			button.addEventListener(
-				'click',
-				() =>
-					void signInWithGoogle(
-						`${location.pathname}#discussion`,
-						locale === 'en' ? 'en' : 'zh-CN',
-					).catch(() => setState('mutation_error', labels.authError, true)),
-			);
-			authNote.append(button);
-			form.hidden = true;
-		} else if (
-			state.status === 'ready' &&
-			config?.commentsWriteUiEnabled &&
-			config.turnstileSiteKey
-		) {
-			form.hidden = false;
-			void setupTurnstile();
-		} else if (state.status === 'ready') {
-			text(authNote, labels.unavailable);
-			form.hidden = true;
-		} else {
-			text(authNote, state.status === 'recoverable_error' ? labels.authError : '');
-			form.hidden = true;
-		}
-		if (loaded) render();
-	}
-
-	async function removeComment(comment: PageComment, button: HTMLButtonElement): Promise<void> {
-		if (!browserCommunityConfig()?.commentsWriteUiEnabled) {
-			setState('mutation_error', labels.unavailable, true);
-			return;
-		}
-		if (!turnstileToken) {
-			setState(
-				'mutation_error',
-				locale === 'en' ? 'Complete human verification first.' : '请先完成人机验证。',
-				true,
-			);
-			return;
-		}
-		if (!confirm(locale === 'en' ? 'Delete this comment?' : '确认删除这条评论吗？')) return;
-		const siblings = comments
-			.filter((item) => item.parent_id === comment.parent_id)
-			.sort((a, b) => a.created_at.localeCompare(b.created_at));
-		const index = siblings.findIndex((item) => item.id === comment.id);
-		const focusId = siblings[index + 1]?.id ?? siblings[index - 1]?.id ?? comment.parent_id;
-		button.disabled = true;
-		try {
-			await deletePageComment(comment.id, turnstileToken);
-			comments = comments.filter((item) => item.id !== comment.id);
+		function discardTurnstile(): void {
 			turnstileToken = '';
-			if (turnstileWidget && window.turnstile) window.turnstile.reset(turnstileWidget);
-			render();
-			setState(comments.length ? 'ready_data' : 'ready_empty', labels.deleted);
-			if (focusId) document.querySelector<HTMLElement>(`#comment-${focusId}`)?.focus();
-			else status?.focus();
-		} catch {
-			setState('mutation_error', labels.deleteFailed, true);
-		} finally {
-			button.disabled = false;
+			turnstileFailed = false;
+			try {
+				if (turnstileWidget && window.turnstile) window.turnstile.remove(turnstileWidget);
+			} catch {
+				// A failed widget may already have removed itself.
+			}
+			turnstileWidget = null;
 		}
-	}
 
-	form?.addEventListener('submit', async (event) => {
-		event.preventDefault();
-		if (!browserCommunityConfig()?.commentsWriteUiEnabled) {
-			setState('mutation_error', labels.unavailable, true);
-			return;
-		}
-		const content = textarea?.value.trim() ?? '';
-		if (!content || !turnstileToken || !typeSelect) {
-			setState(
-				'mutation_error',
-				locale === 'en'
-					? 'Write a comment and complete human verification.'
-					: '请填写内容并完成人机验证。',
-				true,
-			);
-			return;
-		}
-		const submit = form.querySelector<HTMLButtonElement>('button[type="submit"]');
-		if (submit) submit.disabled = true;
-		setState('posting', labels.posting);
-		try {
-			const created = await createPageComment({
-				threadId,
-				type: typeSelect.value as 'question' | 'repro' | 'suggestion',
-				content,
-				turnstileToken,
-				parentId,
-			});
-			comments.push(created);
-			if (textarea) textarea.value = '';
-			text(charCount, '0 / 4000');
-			setReply(null);
-			turnstileToken = '';
-			if (turnstileWidget && window.turnstile) window.turnstile.reset(turnstileWidget);
-			render();
-			setState('ready_data', labels.published);
-			document.querySelector<HTMLElement>(`#comment-${created.id}`)?.focus();
-		} catch {
-			setState('mutation_error', labels.failed, true);
-		} finally {
-			if (submit) submit.disabled = false;
-		}
-	});
-
-	textarea?.addEventListener('input', () => text(charCount, `${textarea.value.length} / 4000`));
-	root.querySelector('[data-cancel-reply]')?.addEventListener('click', () => setReply(null));
-	retry?.addEventListener('click', () => {
-		if (root.dataset.state === 'turnstile_error') {
-			discardTurnstile();
-			void setupTurnstile();
-		} else void load();
-	});
-	subscribeAuth(updateAuth);
-
-	if ('IntersectionObserver' in window) {
-		const observer = new IntersectionObserver(
-			(entries) => {
-				if (entries.some((entry) => entry.isIntersecting)) {
-					observer.disconnect();
-					void bootAuth();
-					void load();
+		function setupTurnstile(): Promise<void> {
+			const config = browserCommunityConfig();
+			const container = root.querySelector<HTMLElement>('[data-turnstile]');
+			if (
+				!config?.commentsWriteUiEnabled ||
+				!config.turnstileSiteKey ||
+				!container ||
+				turnstileWidget
+			)
+				return Promise.resolve();
+			if (turnstileSetupPromise) return turnstileSetupPromise;
+			turnstileSetupPromise = (async () => {
+				try {
+					const api = await loadTurnstile();
+					if (turnstileWidget) return;
+					turnstileWidget = api.render(container, {
+						sitekey: config.turnstileSiteKey,
+						action: 'comment',
+						size: 'flexible',
+						callback: (token: string) => {
+							turnstileToken = token;
+						},
+						'expired-callback': () => {
+							turnstileToken = '';
+						},
+						'error-callback': () => {
+							turnstileToken = '';
+							turnstileFailed = true;
+							setState('turnstile_error', labels.turnstileError, true);
+						},
+					});
+					turnstileFailed = false;
+					setState(comments.length ? 'ready_data' : 'ready_empty', '');
+				} catch {
+					turnstileFailed = true;
+					setState('turnstile_error', labels.turnstileError, true);
 				}
-			},
-			{ rootMargin: '600px 0px' },
-		);
-		observer.observe(root);
-	} else {
-		void bootAuth();
-		void load();
+			})().finally(() => {
+				turnstileSetupPromise = null;
+			});
+			return turnstileSetupPromise;
+		}
+
+		function updateAuth(state: AuthState): void {
+			const config = browserCommunityConfig();
+			if (!authNote || !form) return;
+			authNote.replaceChildren();
+			if (state.status === 'anonymous') {
+				const button = document.createElement('button');
+				button.type = 'button';
+				button.textContent = labels.login;
+				button.addEventListener(
+					'click',
+					() =>
+						void signInWithGoogle(
+							`${location.pathname}#discussion`,
+							locale === 'en' ? 'en' : 'zh-CN',
+						).catch(() => setState('mutation_error', labels.authError, true)),
+				);
+				authNote.append(button);
+				form.hidden = true;
+			} else if (
+				state.status === 'ready' &&
+				config?.commentsWriteUiEnabled &&
+				config.turnstileSiteKey
+			) {
+				form.hidden = false;
+				void setupTurnstile();
+			} else if (state.status === 'ready') {
+				text(authNote, labels.unavailable);
+				form.hidden = true;
+			} else {
+				text(authNote, state.status === 'recoverable_error' ? labels.authError : '');
+				form.hidden = true;
+			}
+			if (loaded) render();
+		}
+
+		async function removeComment(comment: PageComment, button: HTMLButtonElement): Promise<void> {
+			if (!browserCommunityConfig()?.commentsWriteUiEnabled) {
+				setState('mutation_error', labels.unavailable, true);
+				return;
+			}
+			if (!turnstileToken) {
+				setState(
+					'mutation_error',
+					locale === 'en' ? 'Complete human verification first.' : '请先完成人机验证。',
+					true,
+				);
+				return;
+			}
+			if (!confirm(locale === 'en' ? 'Delete this comment?' : '确认删除这条评论吗？')) return;
+			const siblings = comments
+				.filter((item) => item.parent_id === comment.parent_id)
+				.sort((a, b) => a.created_at.localeCompare(b.created_at));
+			const index = siblings.findIndex((item) => item.id === comment.id);
+			const focusId = siblings[index + 1]?.id ?? siblings[index - 1]?.id ?? comment.parent_id;
+			button.disabled = true;
+			try {
+				await deletePageComment(comment.id, turnstileToken);
+				comments = comments.filter((item) => item.id !== comment.id);
+				turnstileToken = '';
+				if (turnstileWidget && window.turnstile) window.turnstile.reset(turnstileWidget);
+				render();
+				setState(comments.length ? 'ready_data' : 'ready_empty', labels.deleted);
+				if (focusId) document.querySelector<HTMLElement>(`#comment-${focusId}`)?.focus();
+				else status?.focus();
+			} catch {
+				setState('mutation_error', labels.deleteFailed, true);
+			} finally {
+				button.disabled = false;
+			}
+		}
+
+		form?.addEventListener('submit', async (event) => {
+			event.preventDefault();
+			if (!browserCommunityConfig()?.commentsWriteUiEnabled) {
+				setState('mutation_error', labels.unavailable, true);
+				return;
+			}
+			const content = textarea?.value.trim() ?? '';
+			if (!content || !turnstileToken || !typeSelect) {
+				setState(
+					'mutation_error',
+					locale === 'en'
+						? 'Write a comment and complete human verification.'
+						: '请填写内容并完成人机验证。',
+					true,
+				);
+				return;
+			}
+			const submit = form.querySelector<HTMLButtonElement>('button[type="submit"]');
+			if (submit) submit.disabled = true;
+			setState('posting', labels.posting);
+			try {
+				const created = await createPageComment({
+					threadId,
+					type: typeSelect.value as 'question' | 'repro' | 'suggestion',
+					content,
+					turnstileToken,
+					parentId,
+				});
+				comments.push(created);
+				if (textarea) textarea.value = '';
+				text(charCount, '0 / 4000');
+				setReply(null);
+				turnstileToken = '';
+				if (turnstileWidget && window.turnstile) window.turnstile.reset(turnstileWidget);
+				render();
+				setState('ready_data', labels.published);
+				document.querySelector<HTMLElement>(`#comment-${created.id}`)?.focus();
+			} catch {
+				setState('mutation_error', labels.failed, true);
+			} finally {
+				if (submit) submit.disabled = false;
+			}
+		});
+
+		textarea?.addEventListener('input', () => text(charCount, `${textarea.value.length} / 4000`));
+		root.querySelector('[data-cancel-reply]')?.addEventListener('click', () => setReply(null));
+		retry?.addEventListener('click', () => {
+			if (root.dataset.state === 'turnstile_error') {
+				discardTurnstile();
+				void setupTurnstile();
+			} else void load();
+		});
+		const unsubscribe = subscribeAuth(updateAuth);
+
+		if ('IntersectionObserver' in window) {
+			observer = new IntersectionObserver(
+				(entries) => {
+					if (entries.some((entry) => entry.isIntersecting)) {
+						observer?.disconnect();
+						void bootAuth();
+						void load();
+					}
+				},
+				{ rootMargin: '600px 0px' },
+			);
+			observer.observe(root);
+		} else {
+			void bootAuth();
+			void load();
+		}
+		cleanupByRoot.set(root, () => {
+			unsubscribe();
+			observer?.disconnect();
+			discardTurnstile();
+		});
 	}
 }
+
+document.addEventListener('astro:after-swap', () => {
+	for (const [root, cleanup] of cleanupByRoot) {
+		if (root.isConnected) continue;
+		cleanup();
+		cleanupByRoot.delete(root);
+	}
+});
+document.addEventListener('astro:page-load', initDiscussions);
+initDiscussions();

--- a/astro/src/scripts/loginPage.ts
+++ b/astro/src/scripts/loginPage.ts
@@ -1,28 +1,35 @@
 import { bootAuth, signInWithGoogle } from '../lib/auth/authStore';
 import { safeRelativeNext } from '../lib/auth/redirect';
 
-const root = document.querySelector<HTMLElement>('[data-login-page]');
-const button = root?.querySelector<HTMLButtonElement>('[data-login-google]');
-const status = root?.querySelector<HTMLElement>('[data-login-status]');
-const locale = root?.dataset.locale === 'en' ? 'en' : 'zh-CN';
-if (button) button.disabled = false;
-button?.addEventListener('click', async () => {
-	button.disabled = true;
-	if (status) status.textContent = locale === 'en' ? 'Opening Google…' : '正在前往 Google…';
-	try {
-		const auth = await bootAuth();
-		if (auth.status === 'recoverable_error') throw new Error('Authentication is unavailable.');
-		const next = safeRelativeNext(
-			new URLSearchParams(location.search).get('next'),
-			locale === 'en' ? '/en/' : '/',
-		);
-		await signInWithGoogle(next, locale);
-	} catch {
-		if (status)
-			status.textContent =
-				locale === 'en'
-					? 'Sign-in is temporarily unavailable. Please retry.'
-					: '登录暂时不可用，请重试。';
-		button.disabled = false;
-	}
-});
+function initLoginPage(): void {
+	const root = document.querySelector<HTMLElement>('[data-login-page]');
+	if (!root || root.dataset.bound === 'true') return;
+	root.dataset.bound = 'true';
+	const button = root.querySelector<HTMLButtonElement>('[data-login-google]');
+	const status = root.querySelector<HTMLElement>('[data-login-status]');
+	const locale = root.dataset.locale === 'en' ? 'en' : 'zh-CN';
+	if (button) button.disabled = false;
+	button?.addEventListener('click', async () => {
+		button.disabled = true;
+		if (status) status.textContent = locale === 'en' ? 'Opening Google…' : '正在前往 Google…';
+		try {
+			const auth = await bootAuth();
+			if (auth.status === 'recoverable_error') throw new Error('Authentication is unavailable.');
+			const next = safeRelativeNext(
+				new URLSearchParams(location.search).get('next'),
+				locale === 'en' ? '/en/' : '/',
+			);
+			await signInWithGoogle(next, locale);
+		} catch {
+			if (status)
+				status.textContent =
+					locale === 'en'
+						? 'Sign-in is temporarily unavailable. Please retry.'
+						: '登录暂时不可用，请重试。';
+			button.disabled = false;
+		}
+	});
+}
+
+document.addEventListener('astro:page-load', initLoginPage);
+initLoginPage();

--- a/astro/src/styles/migration.css
+++ b/astro/src/styles/migration.css
@@ -55,6 +55,17 @@ html {
 	scroll-behavior: smooth;
 }
 
+/*
+ * Client-side navigation removes full-document reload flashes. Keep the DOM
+ * swap deliberately motionless: the browser's default root cross-fade reads
+ * as another flash on fast page changes.
+ */
+::view-transition-group(root),
+::view-transition-old(root),
+::view-transition-new(root) {
+	animation: none;
+}
+
 body {
 	min-width: 320px;
 	min-height: 100vh;

--- a/static/js/ai-infographic.js
+++ b/static/js/ai-infographic.js
@@ -1,3 +1,4 @@
+(() => {
 const root = document.querySelector('[data-aig-root]');
 
 if (root) {
@@ -163,3 +164,4 @@ if (root) {
 		content.focus();
 	});
 }
+})();

--- a/static/js/daily-timeline.js
+++ b/static/js/daily-timeline.js
@@ -133,9 +133,15 @@ export function initDailyTimeline(root) {
     input?.focus();
   });
 
-  window.addEventListener("popstate", () => {
+  const handlePopState = () => {
     commit(parseTimelineState(window.location.search), false);
-  });
+  };
+  window.addEventListener("popstate", handlePopState);
+  document.addEventListener(
+    "astro:before-swap",
+    () => window.removeEventListener("popstate", handlePopState),
+    { once: true },
+  );
   applyState(root, state);
 }
 
@@ -144,6 +150,7 @@ if (typeof document !== "undefined") {
     document
       .querySelectorAll("[data-daily-timeline]")
       .forEach(initDailyTimeline);
+  document.addEventListener("astro:page-load", start);
   if (document.readyState === "loading")
     document.addEventListener("DOMContentLoaded", start, { once: true });
   else start();

--- a/static/js/knowledge-search.js
+++ b/static/js/knowledge-search.js
@@ -271,14 +271,21 @@ function initKnowledgeSearch(root) {
     void apply({ query: "", type: "all", topicId: "", entityId: "" });
     controls.query?.focus();
   });
-  window.addEventListener("popstate", () => {
+  const handlePopState = () => {
     void apply(parseKnowledgeSearchState(window.location.search, options), false);
-  });
+  };
+  window.addEventListener("popstate", handlePopState);
+  document.addEventListener(
+    "astro:before-swap",
+    () => window.removeEventListener("popstate", handlePopState),
+    { once: true },
+  );
   void apply(state, false);
 }
 
 if (typeof document !== "undefined") {
   const start = () => initKnowledgeSearch(document.querySelector("[data-knowledge-search]"));
+  document.addEventListener("astro:page-load", start);
   if (document.readyState === "loading") {
     document.addEventListener("DOMContentLoaded", start, { once: true });
   } else start();

--- a/static/js/navigation.js
+++ b/static/js/navigation.js
@@ -1,0 +1,9 @@
+// Preserve user-owned document state while Astro swaps server-rendered pages.
+// The next document is always authored with the light-theme default, so copying
+// the active theme before the swap prevents a light frame in dark mode.
+document.addEventListener("astro:before-swap", (event) => {
+  const theme = document.documentElement.dataset.theme;
+  if (theme === "light" || theme === "dark") {
+    event.newDocument.documentElement.dataset.theme = theme;
+  }
+});

--- a/static/js/site-shell.js
+++ b/static/js/site-shell.js
@@ -6,24 +6,35 @@ function syncThemeIcons() {
   }
 }
 
-for (const toggle of document.querySelectorAll("[data-theme-toggle]")) {
-  toggle.addEventListener("click", () => {
-    const next = root.dataset.theme === "dark" ? "light" : "dark";
-    root.dataset.theme = next;
-    try {
-      localStorage.setItem("bb-theme", next);
-    } catch {
-      // Theme switching still works when browser storage is unavailable.
-    }
-    syncThemeIcons();
-  });
-}
-syncThemeIcons();
+function initSiteShell() {
+  for (const toggle of document.querySelectorAll("[data-theme-toggle]")) {
+    if (toggle.dataset.shellBound === "true") continue;
+    toggle.dataset.shellBound = "true";
+    toggle.addEventListener("click", () => {
+      const next = root.dataset.theme === "dark" ? "light" : "dark";
+      root.dataset.theme = next;
+      try {
+        localStorage.setItem("bb-theme", next);
+      } catch {
+        // Theme switching still works when browser storage is unavailable.
+      }
+      syncThemeIcons();
+    });
+  }
 
-const menuButton = document.querySelector(".mobile-nav-toggle");
-const menu = document.querySelector("#rail-menu");
-menuButton?.addEventListener("click", () => {
-  const expanded = menuButton.getAttribute("aria-expanded") === "true";
-  menuButton.setAttribute("aria-expanded", String(!expanded));
-  menu?.classList.toggle("is-open", !expanded);
-});
+  const menuButton = document.querySelector(".mobile-nav-toggle");
+  const menu = document.querySelector("#rail-menu");
+  if (menuButton && menuButton.dataset.shellBound !== "true") {
+    menuButton.dataset.shellBound = "true";
+    menuButton.addEventListener("click", () => {
+      const expanded = menuButton.getAttribute("aria-expanded") === "true";
+      menuButton.setAttribute("aria-expanded", String(!expanded));
+      menu?.classList.toggle("is-open", !expanded);
+    });
+  }
+
+  syncThemeIcons();
+}
+
+document.addEventListener("astro:page-load", initSiteShell);
+initSiteShell();


### PR DESCRIPTION
## What changed

- enable Astro client-side routing with swap fallback
- disable root view-transition animation to prevent a cross-fade flash
- preserve the selected color theme across DOM swaps
- reinitialize navigation-dependent account, discussion, login, search, timeline, prompt, and tool interactions

## Root cause

Internal links were performing full document reloads. The blank/repaint interval made every navigation flash briefly, including nested page transitions.

## User impact

Internal navigation now swaps page content in the existing document without a white/blank flash, while retaining theme and interactive behavior.

## Validation

- `npm run verify` from `astro/`
- 11 test files / 67 tests passed
- 309 pages built
- 633 routes, 27 XML endpoints, and 99 sandboxed demos verified
- CSP verification passed
- local browser regression confirmed home → archive → detail → previous detail kept the same document with no console errors or dark-mode light frame