### PR TITLE
fix: allow navigation assets in code releases

### DIFF
--- a/workers/content/deployer/index.test.ts
+++ b/workers/content/deployer/index.test.ts
@@ -181,7 +181,11 @@ describe("automatic code release boundary", () => {
           { filename: "astro/src/lib/searchIndex.ts", status: "modified" },
           { filename: "astro/public/favicon.svg", status: "modified" },
           { filename: "static/css/daily-timeline.css", status: "modified" },
+          { filename: "static/js/ai-infographic.js", status: "modified" },
           { filename: "static/js/daily-timeline.js", status: "modified" },
+          { filename: "static/js/knowledge-search.js", status: "modified" },
+          { filename: "static/js/navigation.js", status: "added" },
+          { filename: "static/js/site-shell.js", status: "modified" },
           { filename: "workers/content/deployer/index.ts", status: "modified" },
           { filename: "src/daily/sourceAdapters.js", status: "modified" },
           { filename: "wrangler.toml", status: "modified" },
@@ -208,7 +212,7 @@ describe("automatic code release boundary", () => {
           structuredCutoverDate: "2026-07-16",
         },
       ),
-    ).toHaveLength(16);
+    ).toHaveLength(20);
   });
 
   it.each([

--- a/workers/content/deployer/index.ts
+++ b/workers/content/deployer/index.ts
@@ -291,7 +291,11 @@ function classifyCodeReleasePath(
       "astro/route-ownership.json",
       "astro/tsconfig.json",
       "static/css/daily-timeline.css",
+      "static/js/ai-infographic.js",
       "static/js/daily-timeline.js",
+      "static/js/knowledge-search.js",
+      "static/js/navigation.js",
+      "static/js/site-shell.js",
     ].includes(path)
   ) {
     return "publishable";


### PR DESCRIPTION
## Problem

The production code-release Deployer rejected PR #73 at the fail-closed path boundary with `422 unsafe_code_release`: `static/js/ai-infographic.js` was not classified as publishable. The same release also includes three other shared navigation runtime assets that would be rejected next.

## Fix

Keep the boundary exact and fail-closed while adding only these intended runtime files:

- `static/js/ai-infographic.js`
- `static/js/knowledge-search.js`
- `static/js/navigation.js`
- `static/js/site-shell.js`

The existing `static/js/daily-timeline.js` allowlist remains unchanged.

## Validation

- `npx vitest run workers/content/deployer tests/worker/requestCodeRelease.test.js` — 28/28 tests passed
- `npm run content:deployer:check` — Wrangler production bundle dry-run passed

## Release follow-up

After merge, deploy the updated `content-deployer` Worker and dispatch `Automatic Code Release` with the exact current `main` SHA.