### PR TITLE
style: remove daily overview line

### DIFF
--- a/astro/src/components/DailyTimeline.astro
+++ b/astro/src/components/DailyTimeline.astro
@@ -53,7 +53,6 @@ for (const item of report.items) {
 	typeCounts.set(item.content_type, (typeCounts.get(item.content_type) ?? 0) + 1);
 }
 
-const overview = cleanTimelineSummary(report.overview.text);
 const orderedBatches = orderTimelineBatches(report.batches);
 const reportDate = dailyDateFromKey(report.date);
 const dateTitle = new Intl.DateTimeFormat(locale, {
@@ -128,7 +127,6 @@ const olderKey = hrefDateKey(olderHref);
 			<time datetime={report.date}>{dateTitle}</time>
 			<span class="weekday">{weekday}</span>
 		</h1>
-		{overview && <p class="overview">{overview}</p>}
 		<div class="stats">
 			<span>{isEnglish ? `${report.items.length} items` : `${report.items.length} 条收录`}</span>
 			<span>{updatesStat}</span>


### PR DESCRIPTION
## What changed

- Remove the overview sentence beneath the date on the shared daily detail component.
- Apply the change to every Chinese and English daily detail page, including future reports.
- Keep the structured overview data intact for schema and generation compatibility.

## Why

The generic incremental-update sentence adds visual noise and repeats across all daily pages.

## Validation

- npm run verify (astro)
- 69 unit tests passed
- 633 routes, 27 XML endpoints, and 99 sandboxed demos verified
- Generated Chinese and English daily detail HTML contains neither the overview node nor the placeholder sentence
- git diff --check