### PR TITLE
fix: remove duplicate homepage summaries

### DIFF
--- a/astro/src/components/QuietIndexHome.astro
+++ b/astro/src/components/QuietIndexHome.astro
@@ -15,6 +15,7 @@ import {
 	formatTimelineTime,
 	isDatabaseOwnedDailyDate,
 	loadStructuredDailyReport,
+	timelineDisplayText,
 	type DailyContentType,
 	type StructuredDailyItem,
 } from '../lib/structuredDaily';
@@ -69,7 +70,6 @@ const monthDay = latestDate
 	: '—';
 const weekdayLong = latestDate ? formatDailyWeekday(latestDate, locale) : '';
 
-const overview = report ? cleanTimelineSummary(report.overview.text) : '';
 const completedBatches = (report?.batches ?? []).filter(
 	(batch) => batch.status === 'completed' && batch.generated_at,
 );
@@ -84,6 +84,7 @@ const liveLabel =
 
 const items = report?.items ?? [];
 const lead = items.find((item) => item.featured) ?? items[0] ?? null;
+const leadDisplayText = lead ? timelineDisplayText(lead) : null;
 const itemTimestamp = (item: StructuredDailyItem): number =>
 	Date.parse(item.published_at ?? item.published_date ?? item.ingested_at) || 0;
 const feedItems = [...items].sort((a, b) => itemTimestamp(b) - itemTimestamp(a)).slice(0, 8);
@@ -136,7 +137,6 @@ const previousDays = (
 								{isEnglish ? ' · Today' : ' · 今日'}
 							</span>
 						</h1>
-						{overview && <p class="sub">{overview}</p>}
 					</div>
 					{liveLabel && (
 						<span class="live-pill">
@@ -174,8 +174,8 @@ const previousDays = (
 								{...(lead.canonical_url ? { target: '_blank', rel: 'noopener noreferrer' } : {})}
 							>
 								<p class="tag">{isEnglish ? 'TOP STORY' : '今日头条 · TOP STORY'}</p>
-								<h2>{cleanTimelineSummary(lead.title) || lead.title}</h2>
-								{cleanTimelineSummary(lead.summary) && <p>{cleanTimelineSummary(lead.summary)}</p>}
+								<h2>{leadDisplayText?.title || lead.title}</h2>
+								{leadDisplayText?.summary && <p>{leadDisplayText.summary}</p>}
 								<p class="src">
 									{cleanTimelineSummary(lead.source.name) || lead.source_type} ·{' '}
 									{formatTimelineTime(lead, locale, report.date)}
@@ -194,10 +194,9 @@ const previousDays = (
 						</div>
 
 						{feedItems.map((item) => {
-							const title =
-								cleanTimelineSummary(item.title) ||
-								(isEnglish ? 'Open original source' : '查看原文');
-							const summary = cleanTimelineSummary(item.summary);
+							const displayText = timelineDisplayText(item);
+							const title = displayText.title || (isEnglish ? 'Open original source' : '查看原文');
+							const summary = displayText.summary;
 							return (
 								<article class="feed-item">
 									<span class="time">{formatTimelineTime(item, locale, report.date)}</span>


### PR DESCRIPTION
## What changed

- Remove the incremental-update overview sentence from the live homepage header.
- Reuse the daily detail page editorial display helper for homepage titles and summaries.
- Suppress summaries that duplicate compact social headlines while retaining summaries that add distinct context.
- Apply the same behavior to the homepage lead story and feed.

## Root cause

The daily detail component used timelineDisplayText, but the homepage rendered raw item title and summary fields independently. Legacy social titles often repeat the beginning of their summaries.

## Validation

- npm run verify (Astro)
- 69 unit tests passed
- 633 routes, 27 XML endpoints, and 99 sandboxed demos verified
- Playwright browser snapshot confirms duplicate examples render as title-only while non-duplicate summaries remain
- Generated homepage contains no incremental overview sentence and each reported duplicate phrase occurs once
- git diff --check