### PR TITLE
fix: prioritize latest homepage batch

### DIFF
--- a/astro/src/components/QuietIndexHome.astro
+++ b/astro/src/components/QuietIndexHome.astro
@@ -13,11 +13,11 @@ import {
 	cleanTimelineSummary,
 	formatDailyTime,
 	formatTimelineTime,
+	homepageFeedItems,
 	isDatabaseOwnedDailyDate,
 	loadStructuredDailyReport,
 	timelineDisplayText,
 	type DailyContentType,
-	type StructuredDailyItem,
 } from '../lib/structuredDaily';
 import '../styles/quiet-index.css';
 
@@ -85,9 +85,7 @@ const liveLabel =
 const items = report?.items ?? [];
 const lead = items.find((item) => item.featured) ?? items[0] ?? null;
 const leadDisplayText = lead ? timelineDisplayText(lead) : null;
-const itemTimestamp = (item: StructuredDailyItem): number =>
-	Date.parse(item.published_at ?? item.published_date ?? item.ingested_at) || 0;
-const feedItems = [...items].sort((a, b) => itemTimestamp(b) - itemTimestamp(a)).slice(0, 8);
+const feedItems = homepageFeedItems(items, report?.batches ?? []);
 
 const categoryCounts = new Map<string, number>();
 const topicCounts = new Map<string, number>();
@@ -188,8 +186,8 @@ const previousDays = (
 							<span class="h-line" />
 							<span class="h-meta">
 								{isEnglish
-									? `${items.length} items · newest first`
-									: `${items.length} 条 · 最新在前`}
+									? `${items.length} items · latest additions first`
+									: `${items.length} 条 · 最新收录在前`}
 							</span>
 						</div>
 

--- a/astro/src/lib/structuredDaily.test.ts
+++ b/astro/src/lib/structuredDaily.test.ts
@@ -7,6 +7,7 @@ import { afterEach, describe, expect, it } from 'vitest';
 import {
 	dailyDataDirectory,
 	formatTimelineTime,
+	homepageFeedItems,
 	isDatabaseOwnedDailyDate,
 	loadStructuredDailyReport,
 	orderTimelineBatches,
@@ -153,6 +154,39 @@ describe('timeline batch order', () => {
 			'lateNight',
 		]);
 		expect(batches.map(({ id }) => id)).toEqual(['morning', 'afternoon', 'night', 'lateNight']);
+	});
+
+	it('orders the homepage by latest completed batch, then source publication time', () => {
+		const batches = [
+			batch('morning', 'completed'),
+			batch('afternoon', 'pending'),
+			batch('night', 'completed'),
+			batch('lateNight', 'completed'),
+		];
+		const item = (
+			id: string,
+			batchId: StructuredDailyBatch['id'],
+			publishedAt: string,
+		): StructuredDailyItem =>
+			({
+				id,
+				batch: batchId,
+				published_at: publishedAt,
+				published_date: publishedAt.slice(0, 10),
+				ingested_at: '2026-07-20T03:00:00.000Z',
+			}) as StructuredDailyItem;
+		const items = [
+			item('night-newer-source', 'night', '2026-07-19T22:00:00.000Z'),
+			item('late-night-older-source', 'lateNight', '2026-07-18T06:00:00.000Z'),
+			item('late-night-newer-source', 'lateNight', '2026-07-19T15:00:00.000Z'),
+			item('pending', 'afternoon', '2026-07-20T00:00:00.000Z'),
+		];
+
+		expect(homepageFeedItems(items, batches, 3).map(({ id }) => id)).toEqual([
+			'late-night-newer-source',
+			'late-night-older-source',
+			'night-newer-source',
+		]);
 	});
 });
 

--- a/astro/src/lib/structuredDaily.ts
+++ b/astro/src/lib/structuredDaily.ts
@@ -74,6 +74,29 @@ export function orderTimelineBatches(
 	return [...completed.reverse(), ...pending];
 }
 
+const itemPublishedTimestamp = (item: StructuredDailyItem): number =>
+	Date.parse(item.published_at ?? item.published_date ?? item.ingested_at) || 0;
+
+export function homepageFeedItems(
+	items: readonly StructuredDailyItem[],
+	batches: readonly StructuredDailyBatch[],
+	limit = 8,
+): StructuredDailyItem[] {
+	const completedBatchRank = new Map(
+		orderTimelineBatches(batches)
+			.filter((batch) => batch.status === 'completed')
+			.map((batch, index) => [batch.id, index]),
+	);
+
+	return items
+		.filter((item) => completedBatchRank.has(item.batch))
+		.sort((a, b) => {
+			const batchOrder = completedBatchRank.get(a.batch)! - completedBatchRank.get(b.batch)!;
+			return batchOrder || itemPublishedTimestamp(b) - itemPublishedTimestamp(a);
+		})
+		.slice(0, Math.max(0, Math.trunc(limit)));
+}
+
 const reportCache = new Map<string, Promise<StructuredDailyReport | null>>();
 const dateKeyPattern = /^\d{4}-\d{2}-\d{2}$/;
 export const DEFAULT_STRUCTURED_CUTOVER_DATE = '2026-07-16';


### PR DESCRIPTION
## What changed

- Rank homepage feed items by completed collection batch before source publication time.
- Keep source publication ordering within each batch.
- Change the homepage label to latest additions first.
- Add a regression test proving older source content from a newer batch outranks newer source content from an older batch.

## Why

The homepage previously sorted the full day only by source published_at. Five of the seven 03:00 additions were therefore omitted from the eight-item homepage feed even though they were successfully collected and published.

## User impact

The latest completed batch now appears first as a complete group. For the 2026-07-19 report, all seven 03:00 additions occupy the first seven homepage positions, followed by the newest item from the prior batch.

## Validation

- npm run verify (Astro)
- 70 unit tests passed
- 633 routes, 27 XML endpoints, and 99 sandboxed demos verified
- Generated homepage contains all seven late-night batch canonical URLs
- Homepage label reads 最新收录在前
- git diff --check