### PR TITLE
fix: simplify X source labels

### DIFF
--- a/astro/src/components/DailyTimeline.astro
+++ b/astro/src/components/DailyTimeline.astro
@@ -10,6 +10,7 @@ import {
 	formatTimelineTime,
 	orderTimelineBatches,
 	timelineDisplayText,
+	timelineSourceDisplay,
 	type DailyContentType,
 	type StructuredDailyReport,
 } from '../lib/structuredDaily';
@@ -221,9 +222,12 @@ const olderKey = hrefDateKey(olderHref);
 						{!pending &&
 							items.map((item, index) => {
 								const displayText = timelineDisplayText(item);
+								const source = timelineSourceDisplay(item);
 								const summary = displayText.summary;
 								const rawSummary = cleanTimelineSummary(item.summary);
-								const sourceName = cleanTimelineSummary(item.source.name) || item.source_type;
+								const sourceSearchTerms = [
+									...new Set([source.name, cleanTimelineSummary(item.source.name)]),
+								];
 								const title =
 									displayText.title || (isEnglish ? 'Open original source' : '查看原文');
 								const topics = item.topic_ids
@@ -235,7 +239,7 @@ const olderKey = hrefDateKey(olderHref);
 								const reason = item.reason ? cleanTimelineSummary(item.reason) : '';
 								const searchText = [
 									title,
-									sourceName,
+									...sourceSearchTerms,
 									rawSummary,
 									item.category,
 									...topics.flatMap((topic) => [taxonomyLabel(topic, locale), ...topic.aliases]),
@@ -259,8 +263,17 @@ const olderKey = hrefDateKey(olderHref);
 										<span class="dot" aria-hidden="true" />
 										<div class="item-body">
 											<div class="meta">
-												<span class="src">{sourceName}</span>
-												<span class="badge">{typeLabels[item.content_type]}</span>
+												<span class:list={['src', { 'src-x': source.isX }]}>
+													{source.isX && (
+														<span class="x-logo" aria-label="X">
+															<i class="ph ph-x-logo" aria-hidden="true" />
+														</span>
+													)}
+													<span>{source.name}</span>
+												</span>
+												{item.content_type !== 'socialMedia' && (
+													<span class="badge">{typeLabels[item.content_type]}</span>
+												)}
 												{item.featured && (
 													<span class="badge featured-badge">
 														{isEnglish ? 'Selected' : '精选'}

--- a/astro/src/components/QuietIndexHome.astro
+++ b/astro/src/components/QuietIndexHome.astro
@@ -17,6 +17,7 @@ import {
 	isDatabaseOwnedDailyDate,
 	loadStructuredDailyReport,
 	timelineDisplayText,
+	timelineSourceDisplay,
 	type DailyContentType,
 } from '../lib/structuredDaily';
 import '../styles/quiet-index.css';
@@ -85,6 +86,7 @@ const liveLabel =
 const items = report?.items ?? [];
 const lead = items.find((item) => item.featured) ?? items[0] ?? null;
 const leadDisplayText = lead ? timelineDisplayText(lead) : null;
+const leadSource = lead ? timelineSourceDisplay(lead) : null;
 const feedItems = homepageFeedItems(items, report?.batches ?? []);
 
 const categoryCounts = new Map<string, number>();
@@ -175,8 +177,16 @@ const previousDays = (
 								<h2>{leadDisplayText?.title || lead.title}</h2>
 								{leadDisplayText?.summary && <p>{leadDisplayText.summary}</p>}
 								<p class="src">
-									{cleanTimelineSummary(lead.source.name) || lead.source_type} ·{' '}
-									{formatTimelineTime(lead, locale, report.date)}
+									<span class:list={['source-label', { 'src-x': leadSource?.isX }]}>
+										{leadSource?.isX && (
+											<span class="x-logo" aria-label="X">
+												<i class="ph ph-x-logo" aria-hidden="true" />
+											</span>
+										)}
+										<span>{leadSource?.name}</span>
+									</span>
+									<span aria-hidden="true">·</span>
+									<span>{formatTimelineTime(lead, locale, report.date)}</span>
 								</p>
 							</a>
 						)}
@@ -193,6 +203,7 @@ const previousDays = (
 
 						{feedItems.map((item) => {
 							const displayText = timelineDisplayText(item);
+							const source = timelineSourceDisplay(item);
 							const title = displayText.title || (isEnglish ? 'Open original source' : '查看原文');
 							const summary = displayText.summary;
 							return (
@@ -200,10 +211,17 @@ const previousDays = (
 									<span class="time">{formatTimelineTime(item, locale, report.date)}</span>
 									<div>
 										<div class="meta">
-											<span class="src">
-												{cleanTimelineSummary(item.source.name) || item.source_type}
+											<span class:list={['src', { 'src-x': source.isX }]}>
+												{source.isX && (
+													<span class="x-logo" aria-label="X">
+														<i class="ph ph-x-logo" aria-hidden="true" />
+													</span>
+												)}
+												<span>{source.name}</span>
 											</span>
-											<span class="badge">{typeLabels[item.content_type]}</span>
+											{item.content_type !== 'socialMedia' && (
+												<span class="badge">{typeLabels[item.content_type]}</span>
+											)}
 										</div>
 										<h3>
 											{item.canonical_url ? (

--- a/astro/src/lib/structuredDaily.test.ts
+++ b/astro/src/lib/structuredDaily.test.ts
@@ -13,6 +13,7 @@ import {
 	orderTimelineBatches,
 	structuredCutoverDate,
 	timelineDisplayText,
+	timelineSourceDisplay,
 	type StructuredDailyBatch,
 	type StructuredDailyItem,
 } from './structuredDaily';
@@ -218,5 +219,53 @@ describe('timeline editorial compatibility', () => {
 			title: item.title,
 			summary: item.summary,
 		});
+	});
+});
+
+describe('timeline source display', () => {
+	const sourceItem = (overrides: Partial<StructuredDailyItem>): StructuredDailyItem =>
+		({
+			source_type: 'rss',
+			canonical_url: 'https://example.com/post',
+			source: { name: 'Example', homepage: 'https://example.com' },
+			...overrides,
+		}) as StructuredDailyItem;
+
+	it('shows X posts with the twitter prefix removed', () => {
+		expect(
+			timelineSourceDisplay(
+				sourceItem({
+					source_type: 'twitter_extra',
+					canonical_url: 'https://x.com/gdb/status/123',
+					source: { name: 'twitter-Greg Brockman', homepage: 'https://x.com/gdb' },
+				}),
+			),
+		).toEqual({ name: 'Greg Brockman', isX: true });
+	});
+
+	it('recognizes X URLs even when the source metadata is generic', () => {
+		expect(
+			timelineSourceDisplay(
+				sourceItem({
+					canonical_url: 'https://www.x.com/openai/status/123',
+					source: { name: 'OpenAI', homepage: null },
+				}),
+			),
+		).toEqual({ name: 'OpenAI', isX: true });
+	});
+
+	it('keeps regular source names unchanged', () => {
+		expect(timelineSourceDisplay(sourceItem({}))).toEqual({ name: 'Example', isX: false });
+	});
+
+	it('falls back to X when a prefixed source has no author name', () => {
+		expect(
+			timelineSourceDisplay(
+				sourceItem({
+					source_type: 'twitter_extra',
+					source: { name: 'twitter-', homepage: null },
+				}),
+			),
+		).toEqual({ name: 'X', isX: true });
 	});
 });

--- a/astro/src/lib/structuredDaily.ts
+++ b/astro/src/lib/structuredDaily.ts
@@ -164,6 +164,36 @@ export function cleanTimelineSummary(value: string): string {
 	return sanitizeSummaryText(value);
 }
 
+export function timelineSourceDisplay(item: StructuredDailyItem): {
+	name: string;
+	isX: boolean;
+} {
+	const rawName = cleanTimelineSummary(item.source.name);
+	const sourceType = item.source_type.trim().toLocaleLowerCase('en');
+	let canonicalHost = '';
+	try {
+		canonicalHost = item.canonical_url
+			? new URL(item.canonical_url).hostname.toLocaleLowerCase('en')
+			: '';
+	} catch {
+		// Invalid source URLs are handled by the report validator; keep display rendering fail-safe.
+	}
+
+	const isX =
+		/^twitter(?:[_-].*)?$/i.test(sourceType) ||
+		/^twitter[-\s:]/i.test(rawName) ||
+		canonicalHost === 'x.com' ||
+		canonicalHost.endsWith('.x.com') ||
+		canonicalHost === 'twitter.com' ||
+		canonicalHost.endsWith('.twitter.com');
+	if (!isX) return { name: rawName || item.source_type, isX: false };
+
+	return {
+		name: rawName.replace(/^twitter[-\s:]*/i, '').trim() || 'X',
+		isX: true,
+	};
+}
+
 export function timelineDisplayText(item: StructuredDailyItem): { title: string; summary: string } {
 	const rawTitle = cleanTimelineSummary(item.title);
 	const rawSummary = cleanTimelineSummary(item.summary);

--- a/astro/src/styles/quiet-index.css
+++ b/astro/src/styles/quiet-index.css
@@ -171,6 +171,9 @@
 }
 
 .quiet-home .lead-story .src {
+	display: flex;
+	align-items: center;
+	gap: 6px;
 	margin-top: 14px;
 	color: var(--ink-faint);
 	font-family: var(--mono);
@@ -230,8 +233,17 @@
 }
 
 .quiet-home .feed-item .meta .src {
+	display: inline-flex;
+	align-items: center;
+	gap: 5px;
 	color: var(--ink-soft);
 	font-weight: 600;
+}
+
+.quiet-home .src-x .x-logo {
+	display: inline-flex;
+	font-size: 0.9rem;
+	line-height: 1;
 }
 
 .quiet-home .feed-item .meta .badge {

--- a/static/css/daily-timeline.css
+++ b/static/css/daily-timeline.css
@@ -315,8 +315,17 @@
 }
 
 .daily-timeline .item .meta .src {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
   color: var(--ink-soft);
   font-weight: 600;
+}
+
+.daily-timeline .item .meta .src-x .x-logo {
+  display: inline-flex;
+  font-size: 0.9rem;
+  line-height: 1;
 }
 
 .daily-timeline .item .meta .badge {


### PR DESCRIPTION
## Summary

- show X icons with clean author names instead of `twitter-` prefixes
- remove redundant item-level Social badges while keeping the timeline filter
- apply the same source presentation to the homepage, lead story, and daily detail page
- preserve legacy source-name search compatibility

## Validation

- `cd astro && npm run verify`
- `npm test`
- `npm run verify:renderers` (212 daily routes)
- Playwright browser check of the homepage and 2026-07-20 daily detail page