### PR TITLE
fix: allow taxonomy in automatic code releases

### DIFF
--- a/workers/content/deployer/index.test.ts
+++ b/workers/content/deployer/index.test.ts
@@ -180,6 +180,7 @@ describe("automatic code release boundary", () => {
           { filename: "astro/src/scripts/authControls.ts", status: "modified" },
           { filename: "astro/src/lib/searchIndex.ts", status: "modified" },
           { filename: "astro/public/favicon.svg", status: "modified" },
+          { filename: "data/knowledge/taxonomy.json", status: "modified" },
           { filename: "static/css/daily-timeline.css", status: "modified" },
           { filename: "static/js/ai-infographic.js", status: "modified" },
           { filename: "static/js/daily-timeline.js", status: "modified" },
@@ -212,7 +213,7 @@ describe("automatic code release boundary", () => {
           structuredCutoverDate: "2026-07-16",
         },
       ),
-    ).toHaveLength(20);
+    ).toHaveLength(21);
   });
 
   it.each([

--- a/workers/content/deployer/index.ts
+++ b/workers/content/deployer/index.ts
@@ -290,6 +290,7 @@ function classifyCodeReleasePath(
       "astro/raw-html-policy.json",
       "astro/route-ownership.json",
       "astro/tsconfig.json",
+      "data/knowledge/taxonomy.json",
       "static/css/daily-timeline.css",
       "static/js/ai-infographic.js",
       "static/js/daily-timeline.js",


### PR DESCRIPTION
## Summary

- classify `data/knowledge/taxonomy.json` as a publishable site input
- preserve fail-closed rejection for all other unknown paths
- cover the taxonomy path in the deployer boundary test

## Validation

- `npm test` (38 files, 534 tests)
- `npm run content:deployer:check`
- targeted deployer/release tests (28 tests)