### PR TITLE
fix: prevent editorial fallback from failing daily batches

### DIFF
--- a/src/daily/editorial.js
+++ b/src/daily/editorial.js
@@ -27,6 +27,13 @@ function cleanEditorialText(value) {
         .trim());
 }
 
+function hasEditorialSourceMaterial(item) {
+    return Boolean(
+        cleanEditorialText(item?.title)
+        || cleanEditorialText(item?.summary),
+    );
+}
+
 function codePoints(value) {
     return Array.from(value);
 }
@@ -158,6 +165,7 @@ export function editorialNeedsEnrichment(item) {
     if (item?.content_type !== SOCIAL_CONTENT_TYPE || item?.identity_strategy === 'fallback') {
         return false;
     }
+    if (!hasEditorialSourceMaterial(item)) return false;
     const title = cleanEditorialText(item.title);
     if (!title) return true;
     return (
@@ -239,12 +247,26 @@ export async function applyEditorialEnrichment(
     { itemIds = null, generate = callChatAPI, cache = new Map() } = {},
 ) {
     const allowedIds = itemIds ? new Set(itemIds) : null;
-    const candidates = buildResult.report.items.filter(item => (
+    const selectedSocialItems = buildResult.report.items.filter(item => (
         item.content_type === SOCIAL_CONTENT_TYPE
         && item.identity_strategy !== 'fallback'
         && (!allowedIds || allowedIds.has(item.id))
     ));
-    if (candidates.length === 0) return buildResult;
+    const candidates = selectedSocialItems.filter(hasEditorialSourceMaterial);
+    const skippedNoContentCount = selectedSocialItems.length - candidates.length;
+    if (candidates.length === 0) {
+        if (skippedNoContentCount === 0) return buildResult;
+        return {
+            ...buildResult,
+            metrics: {
+                ...buildResult.metrics,
+                editorial_count: 0,
+                editorial_ai_count: 0,
+                editorial_fallback_count: 0,
+                editorial_skipped_no_content_count: skippedNoContentCount,
+            },
+        };
+    }
 
     const missingCandidates = candidates.filter(item => !cache.has(item.id));
     let generated = [];
@@ -273,8 +295,10 @@ export async function applyEditorialEnrichment(
         const generatedItem = generatedById.get(item.id);
         const generatedTitle = normalizeEditorialHeadline(generatedItem?.title);
         const generatedSummary = normalizeEditorialSummary(generatedItem?.summary);
+        const fallbackTitle = compactEditorialTitle(item.title, item.summary)
+            || String(item.title || '').trim();
         cache.set(item.id, {
-            title: generatedTitle || compactEditorialTitle(item.title, item.summary),
+            title: generatedTitle || fallbackTitle,
             summary: generatedSummary,
             ai: Boolean(generatedTitle),
         });
@@ -285,8 +309,8 @@ export async function applyEditorialEnrichment(
     for (const item of report.items) {
         if (!candidateIds.has(item.id)) continue;
         const update = cache.get(item.id);
-        item.title = update.title;
-        if (update.summary) item.summary = update.summary;
+        if (update?.title) item.title = update.title;
+        if (update?.summary) item.summary = update.summary;
     }
 
     const aiCount = candidates.filter(item => cache.get(item.id)?.ai).length;
@@ -304,6 +328,7 @@ export async function applyEditorialEnrichment(
             editorial_count: candidates.length,
             editorial_ai_count: aiCount,
             editorial_fallback_count: fallbackCount,
+            editorial_skipped_no_content_count: skippedNoContentCount,
         },
     };
 }

--- a/src/daily/normalize.js
+++ b/src/daily/normalize.js
@@ -6,6 +6,8 @@ import { classifyKnowledgeItem } from '../knowledge/taxonomy.js';
 
 const BATCHES = new Set(['morning', 'afternoon', 'night', 'lateNight']);
 const CONTROL_CHARACTERS = /[\u0000-\u001f\u007f]/;
+const URL_PATTERN = /https?:\/\/\S+|www\.\S+/giu;
+const MEANINGFUL_TEXT_PATTERN = /[\p{L}\p{N}]/u;
 
 function cleanText(value, maxLength) {
     const cleaned = String(value || '')
@@ -26,6 +28,12 @@ function normalizeSourceId(value) {
     const normalized = String(value).normalize('NFC').trim();
     if (!normalized || normalized.length > 512 || CONTROL_CHARACTERS.test(normalized)) return null;
     return normalized;
+}
+
+function hasMeaningfulNonUrlText(...values) {
+    return values.some(value => MEANINGFUL_TEXT_PATTERN.test(
+        String(value || '').replace(URL_PATTERN, ' '),
+    ));
 }
 
 function beijingDate(instant) {
@@ -74,6 +82,17 @@ export async function normalizeSourceItem(raw, { provider, batch, runAt } = {}) 
     const title = cleanText(raw.title, 500);
     if (!title) return { accepted: false, reason: 'missing_title' };
 
+    const summary = sanitizeSummaryText(cleanText(
+        raw.summary || raw.description || raw.content_text || raw.content_html || raw.details?.content_html,
+        5000,
+    ));
+    if (
+        policy.contentType === 'socialMedia'
+        && !hasMeaningfulNonUrlText(title, summary)
+    ) {
+        return { accepted: false, reason: 'missing_social_content' };
+    }
+
     const sourceIdInput = raw.source_id ?? raw.id ?? null;
     const sourceId = normalizeSourceId(sourceIdInput);
     if (sourceIdInput !== null && sourceIdInput !== undefined && sourceIdInput !== '' && sourceId === null) {
@@ -100,10 +119,6 @@ export async function normalizeSourceItem(raw, { provider, batch, runAt } = {}) 
     const sourceName = cleanText(sourceNameInput || provider, 200) || provider;
     const normalizedHomepage = canonicalizeUrl(raw.source?.homepage || raw.source_homepage);
     const homepage = normalizedHomepage?.length <= 8192 ? normalizedHomepage : null;
-    const summary = sanitizeSummaryText(cleanText(
-        raw.summary || raw.description || raw.content_text || raw.content_html || raw.details?.content_html,
-        5000,
-    ));
     const classification = classifyKnowledgeItem(raw, {
         provider,
         title,

--- a/src/daily/structuredWorkflow.js
+++ b/src/daily/structuredWorkflow.js
@@ -337,7 +337,27 @@ export async function runStructuredDailyWorkflow(
                     .filter(item => !existingIds.has(item.id) || editorialNeedsEnrichment(item))
                     .map(item => item.id);
                 if (editorialIds.length > 0) {
-                    result = await deps.enrich(env, result, { itemIds: editorialIds, cache: editorialCache });
+                    const preEditorialResult = result;
+                    try {
+                        result = await deps.enrich(
+                            env,
+                            preEditorialResult,
+                            { itemIds: editorialIds, cache: editorialCache },
+                        );
+                    } catch (error) {
+                        console.warn('[StructuredDaily] editorial enrichment failed; publishing valid source data', {
+                            errorType: error?.name || 'Error',
+                            itemCount: editorialIds.length,
+                        });
+                        result = {
+                            ...preEditorialResult,
+                            metrics: {
+                                ...preEditorialResult.metrics,
+                                editorial_degraded: true,
+                                editorial_error_type: error?.name || 'Error',
+                            },
+                        };
+                    }
                 }
             }
             const expectedPaths = assertPublicationFiles(result.files, reportDate);

--- a/tests/worker/editorial.test.js
+++ b/tests/worker/editorial.test.js
@@ -96,6 +96,59 @@ describe('structured daily editorial enrichment', () => {
             content_type: 'news',
             title: 'English news headline',
         })).toBe(false);
+        expect(editorialNeedsEnrichment({
+            ...base,
+            title: 'https://x.com/i/article/1234567890',
+            summary: 'https://x.com/i/article/1234567890',
+        })).toBe(false);
+    });
+
+    it('rejects URL-only social entries before they can reach editorial generation', async () => {
+        const result = await build([socialItem({
+            id: 'article-url-only',
+            title: 'https://x.com/i/article/1234567890',
+            description: 'https://x.com/i/article/1234567890',
+            url: 'https://x.com/i/article/1234567890',
+        })]);
+
+        expect(result.report.items).toEqual([]);
+        expect(result.rejected).toEqual(['missing_social_content']);
+        expect(result.metrics).toMatchObject({ accepted_count: 0, rejected_count: 1 });
+    });
+
+    it('skips legacy URL-only entries instead of asking the model to invent content', async () => {
+        const original = await build();
+        const url = 'https://x.com/i/article/1234567890';
+        original.report.items[0].title = url;
+        original.report.items[0].summary = url;
+        const generate = vi.fn();
+
+        const result = await applyEditorialEnrichment(
+            { DAILY_EDITORIAL_ENRICHMENT_ENABLED: 'true' },
+            original,
+            { generate },
+        );
+
+        expect(result.report.items[0].title).toBe(url);
+        expect(generate).not.toHaveBeenCalled();
+        expect(result.metrics).toMatchObject({
+            editorial_count: 0,
+            editorial_skipped_no_content_count: 1,
+        });
+    });
+
+    it('never overwrites a valid source title with an empty cached fallback', async () => {
+        const original = await build();
+        const item = original.report.items[0];
+        const cache = new Map([[item.id, { title: '', summary: null, ai: false }]]);
+
+        const result = await applyEditorialEnrichment(
+            { DAILY_EDITORIAL_ENRICHMENT_ENABLED: 'false' },
+            original,
+            { cache },
+        );
+
+        expect(result.report.items[0].title).toBe(item.title);
     });
 
     it('stores AI title and summary without changing stable identity', async () => {

--- a/tests/worker/structuredWorkflow.test.js
+++ b/tests/worker/structuredWorkflow.test.js
@@ -165,6 +165,45 @@ describe('structured publication workflow', () => {
         expect(deps.commit).toHaveBeenCalledOnce();
     });
 
+    it('publishes the valid pre-editorial report when enrichment throws', async () => {
+        const originalBuild = {
+            files: files(),
+            noOp: false,
+            metrics: { raw_count: 1 },
+            report: {
+                items: [{
+                    id: 'fresh-social',
+                    content_type: 'socialMedia',
+                    identity_strategy: 'source_id',
+                    title: 'A valid source title that still needs Chinese editorial enrichment',
+                    summary: 'A valid source summary.',
+                }],
+            },
+        };
+        const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+        const deps = dependencies({
+            build: vi.fn(async () => originalBuild),
+            enrich: vi.fn(async () => { throw new Error('editorial unavailable'); }),
+        });
+
+        const result = await runStructuredDailyWorkflow(env, runInput, deps);
+
+        expect(deps.commit).toHaveBeenCalledWith(
+            env,
+            expect.objectContaining({ files: originalBuild.files }),
+            expect.any(Object),
+        );
+        expect(result.metrics).toMatchObject({
+            editorial_degraded: true,
+            editorial_error_type: 'Error',
+        });
+        expect(warn).toHaveBeenCalledWith(
+            '[StructuredDaily] editorial enrichment failed; publishing valid source data',
+            { errorType: 'Error', itemCount: 1 },
+        );
+        warn.mockRestore();
+    });
+
     it('fails closed unless all write gates and structured inputs are valid', async () => {
         const variants = [
             [{ ...env, EXTERNAL_WRITES_ENABLED: 'false' }, 'External writes'],


### PR DESCRIPTION
## Summary
- reject URL-only social items before editorial generation
- preserve valid source titles when AI output or cached fallback is empty
- degrade to the pre-editorial report if enrichment fails
- add regression coverage for URL-only and enrichment failure paths

## Validation
- npm test -- --reporter=dot (38 files, 548 tests)
- npm run worker:check
- npm run verify:renderers (212 daily routes)