### PR TITLE
fix: keep database sync after lock release failures

### DIFF
--- a/src/daily/gitAtomic.js
+++ b/src/daily/gitAtomic.js
@@ -3,6 +3,7 @@ import { expectedPublicationPaths, parsePublicationCommit, validatePublicationPu
 
 const PUBLICATION_LOCK_TTL_MS = 15 * 60 * 1000;
 const PUBLICATION_LOCK_RELEASE_PREFIX = 'Publication lock released ';
+const PUBLICATION_LOCK_RELEASE_ATTEMPTS = 3;
 
 function refPath(branch) {
     return branch.split('/').map(encodeURIComponent).join('/');
@@ -480,6 +481,10 @@ export async function releasePublicationLock(env, lock, { api, now = new Date() 
     const currentSha = await refShaOrNull(env, lock.branch, { api });
     if (currentSha === null) return { reconciled: true };
     if (currentSha !== lock.sha) {
+        const current = await api(env, `/git/commits/${currentSha}`);
+        const releasedByOwner = String(current?.message || '').startsWith(PUBLICATION_LOCK_RELEASE_PREFIX)
+            && current?.parents?.some(parent => parent?.sha === lock.sha);
+        if (releasedByOwner) return { reconciled: true };
         throw new AtomicGitUncertainError('Publication lock owner changed before release');
     }
     const instant = now instanceof Date ? now : new Date(now);
@@ -855,28 +860,62 @@ export async function commitFilesViaPullRequest(env, input, dependencies = {}) {
     const api = dependencies.api || callGitHubApi;
     const acquireLock = dependencies.acquireLock || acquirePublicationLock;
     const releaseLock = dependencies.releaseLock || releasePublicationLock;
+    const releaseRetryWait = dependencies.releaseRetryWait
+        || (milliseconds => new Promise(resolve => setTimeout(resolve, milliseconds)));
     const baseBranch = input?.snapshot?.baseBranch || input?.snapshot?.branch;
     const lock = await acquireLock(env, input.snapshot, baseBranch, {
         api,
         ...(dependencies.lockNow ? { now: dependencies.lockNow } : {}),
     });
     let publicationError = null;
+    let publication = null;
     try {
-        return await commitFilesViaPullRequestLocked(env, input, { api });
+        publication = await commitFilesViaPullRequestLocked(env, input, { api });
     } catch (error) {
         publicationError = error;
-        throw error;
-    } finally {
+    }
+
+    let releaseError = null;
+    let releaseAttempts = 0;
+    for (let attempt = 1; attempt <= PUBLICATION_LOCK_RELEASE_ATTEMPTS; attempt += 1) {
+        releaseAttempts = attempt;
         try {
             await releaseLock(env, lock, { api });
-        } catch (releaseError) {
-            if (!publicationError) throw releaseError;
+            releaseError = null;
+            break;
+        } catch (error) {
+            releaseError = error;
+            if (attempt < PUBLICATION_LOCK_RELEASE_ATTEMPTS) {
+                await releaseRetryWait(attempt * 250);
+            }
+        }
+    }
+
+    if (publicationError) {
+        if (releaseError) {
             console.error('[GitPublication] publication and lock release both failed', {
                 publicationErrorType: publicationError?.name || 'Error',
                 releaseErrorType: releaseError?.name || 'Error',
+                releaseAttempts,
             });
         }
+        throw publicationError;
     }
+    if (releaseError) {
+        console.error('[GitPublication] lock release failed after successful publication; continuing', {
+            releaseErrorType: releaseError?.name || 'Error',
+            releaseAttempts,
+        });
+        return {
+            ...publication,
+            lockRelease: {
+                status: 'failed',
+                error_type: releaseError?.name || 'Error',
+                attempts: releaseAttempts,
+            },
+        };
+    }
+    return publication;
 }
 
 export async function publishFilesAtomically(env, input, dependencies = {}) {

--- a/src/daily/structuredWorkflow.js
+++ b/src/daily/structuredWorkflow.js
@@ -443,6 +443,7 @@ export async function runStructuredDailyWorkflow(
                     publication_status: published.pending === true ? 'pending' : 'published',
                     ...(published.branch ? { publication_branch: published.branch } : {}),
                     ...(published.pullRequest ? { pull_request: published.pullRequest } : {}),
+                    ...(published.lockRelease ? { lock_release: published.lockRelease } : {}),
                     metrics: result.metrics,
                     database_mirror: await mirrorWithoutBlocking(
                         env,

--- a/src/index.js
+++ b/src/index.js
@@ -18,6 +18,14 @@ import { SOURCE_REGISTRY } from './daily/sourceRegistry.js';
 const SAFE_PROVIDER_NAMES = new Set(Object.keys(SOURCE_REGISTRY));
 const SAFE_CONTENT_TYPES = new Set(['news', 'project', 'paper', 'socialMedia']);
 const SAFE_FAILURE_STAGES = new Set(['fetch', 'transform']);
+const SAFE_WORKFLOW_FAILURE_STAGES = new Set([
+    'fetch',
+    'build',
+    'git_publish',
+    'lock_release',
+    'database_mirror',
+    'unknown',
+]);
 const SAFE_PROVIDER_ERROR_CODES = new Set([
     'missing_config',
     'invalid_config',
@@ -134,6 +142,13 @@ function scheduledFailureMarker(error, runAt) {
         error_type: error?.name === 'StructuredSourceFetchError'
             ? 'structured_source_fetch_failed'
             : 'scheduled_workflow_failed',
+        failure_stage: SAFE_WORKFLOW_FAILURE_STAGES.has(error?.failureStage)
+            ? error.failureStage
+            : error?.name === 'StructuredSourceFetchError'
+                ? 'fetch'
+                : error?.name === 'AtomicGitConflictError' || error?.name === 'AtomicGitUncertainError'
+                    ? 'git_publish'
+                    : 'unknown',
         ...(sourceErrors.length > 0 ? { source_errors: sourceErrors } : {}),
     };
 }
@@ -241,6 +256,7 @@ export function createWorker({
                     const marker = scheduledFailureMarker(error, runAt);
                     console.error('[Scheduled] workflow failed', {
                         errorType: marker.error_type,
+                        failureStage: marker.failure_stage,
                         sourceErrors: Array.isArray(marker.source_errors)
                             ? marker.source_errors.map(sourceError => ({
                                 provider: sourceError.provider,

--- a/tests/worker/gitAtomic.test.js
+++ b/tests/worker/gitAtomic.test.js
@@ -270,6 +270,9 @@ describe('atomic Git publication', () => {
     it('never releases another owner lock and reconciles a lost release CAS response', async () => {
         const changedOwnerApi = vi.fn(async (_env, path, method = 'GET') => {
             if (path === lockRefPath) return { object: { sha: sha('2') } };
+            if (path === `/git/commits/${sha('2')}`) {
+                return { message: 'Publication lock another-owner', parents: [{ sha: sha('9') }] };
+            }
             throw new Error(`unexpected ${method} ${path}`);
         });
         await expect(
@@ -282,7 +285,7 @@ describe('atomic Git publication', () => {
                 { api: changedOwnerApi },
             ),
         ).rejects.toBeInstanceOf(AtomicGitUncertainError);
-        expect(changedOwnerApi.mock.calls.some((call) => call[1] === '/git/commits')).toBe(false);
+        expect(changedOwnerApi.mock.calls.some((call) => call[1] === `/git/commits/${sha('2')}`)).toBe(true);
 
         let currentSha = sha('1');
         const calls = [];
@@ -321,6 +324,28 @@ describe('atomic Git publication', () => {
             force: false,
         });
         expect(calls.some((call) => call.method === 'DELETE')).toBe(false);
+    });
+
+    it('reconciles an earlier release response loss from the exact owner successor', async () => {
+        const api = vi.fn(async (_env, path, method = 'GET') => {
+            if (path === lockRefPath) return { object: { sha: sha('3') } };
+            if (path === `/git/commits/${sha('3')}`) {
+                return {
+                    message: 'Publication lock released prior-attempt',
+                    parents: [{ sha: sha('1') }],
+                };
+            }
+            throw new Error(`unexpected ${method} ${path}`);
+        });
+
+        await expect(
+            releasePublicationLock(
+                lockEnv,
+                { branch: lockBranch, sha: sha('1') },
+                { api },
+            ),
+        ).resolves.toEqual({ reconciled: true });
+        expect(api.mock.calls.some((call) => call[2] === 'PATCH')).toBe(false);
     });
 
     it('cannot overwrite a stale takeover that wins during release', async () => {
@@ -384,14 +409,19 @@ describe('atomic Git publication', () => {
                         sha: sha('1'),
                     })),
                     releaseLock,
+                    releaseRetryWait: vi.fn(async () => undefined),
                 },
             ),
         ).rejects.toBe(publicationError);
-        expect(releaseLock).toHaveBeenCalledOnce();
+        expect(releaseLock).toHaveBeenCalledTimes(3);
     });
 
-    it('propagates a lock release failure after a successful publication', async () => {
+    it('keeps a successful publication when lock release exhausts its retries', async () => {
         const releaseError = new AtomicGitUncertainError('release failed');
+        const releaseLock = vi.fn(async () => {
+            throw releaseError;
+        });
+        const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
         const api = vi.fn(async (_env, path, method = 'GET') => {
             if (path === '/git/blobs') return { sha: sha('c') };
             if (path === '/git/trees') return { sha: sha('d') };
@@ -426,12 +456,67 @@ describe('atomic Git publication', () => {
                         branch: lockBranch,
                         sha: sha('9'),
                     })),
-                    releaseLock: vi.fn(async () => {
-                        throw releaseError;
-                    }),
+                    releaseLock,
+                    releaseRetryWait: vi.fn(async () => undefined),
                 },
             ),
-        ).rejects.toBe(releaseError);
+        ).resolves.toMatchObject({
+            commitSha: sha('1'),
+            lockRelease: {
+                status: 'failed',
+                error_type: 'AtomicGitUncertainError',
+                attempts: 3,
+            },
+        });
+        expect(releaseLock).toHaveBeenCalledTimes(3);
+        expect(consoleSpy).toHaveBeenCalledWith(
+            '[GitPublication] lock release failed after successful publication; continuing',
+            expect.objectContaining({ releaseAttempts: 3 }),
+        );
+    });
+
+    it('retries a transient lock release without changing the publication result', async () => {
+        const api = vi.fn(async (_env, path, method = 'GET') => {
+            if (path === '/git/blobs') return { sha: sha('c') };
+            if (path === '/git/trees') return { sha: sha('d') };
+            if (path === '/git/commits') return { sha: sha('1') };
+            if (path === '/pulls?state=open&base=main&per_page=100') return [];
+            if (path === '/git/refs' && method === 'POST') return {};
+            if (path === '/pulls' && method === 'POST') {
+                return { number: 42, html_url: 'https://example.test/pr/42', state: 'open' };
+            }
+            throw new Error(`unexpected ${method} ${path}`);
+        });
+        const releaseLock = vi
+            .fn()
+            .mockRejectedValueOnce(new AtomicGitUncertainError('temporary'))
+            .mockRejectedValueOnce(new AtomicGitUncertainError('temporary'))
+            .mockResolvedValueOnce({ reconciled: false });
+        const releaseRetryWait = vi.fn(async () => undefined);
+
+        await expect(
+            commitFilesViaPullRequest(
+                lockEnv,
+                {
+                    snapshot,
+                    files: [{ path: 'daily.md', content: 'daily' }],
+                    message: 'publish',
+                    committedAt: '2026-07-14T02:00:00Z',
+                    reportDate: '2026-07-14',
+                    batch: 'morning',
+                    mode: 'structured',
+                },
+                {
+                    api,
+                    acquireLock: vi.fn(async () => ({ branch: lockBranch, sha: sha('9') })),
+                    releaseLock,
+                    releaseRetryWait,
+                },
+            ),
+        ).resolves.toMatchObject({ commitSha: sha('1') });
+        expect(releaseLock).toHaveBeenCalledTimes(3);
+        expect(releaseRetryWait).toHaveBeenNthCalledWith(1, 250);
+        expect(releaseRetryWait).toHaveBeenNthCalledWith(2, 500);
     });
 
     it('resolves an immutable branch head and reads nested files only through its tree', async () => {

--- a/tests/worker/structuredWorkflow.test.js
+++ b/tests/worker/structuredWorkflow.test.js
@@ -506,6 +506,36 @@ describe('structured publication workflow', () => {
         expect(mirror).toHaveBeenCalledOnce();
     });
 
+    it('surfaces a non-blocking publication lock release warning', async () => {
+        const mirror = vi.fn(async () => ({ status: 'disabled' }));
+        const deps = dependencies({
+            mirror,
+            commit: vi.fn(async () => ({
+                commitSha: sha('e'),
+                reconciled: false,
+                pending: true,
+                branch: 'automation/daily/candidate',
+                pullRequest: { number: 42, url: 'https://example.test/pr/42' },
+                lockRelease: {
+                    status: 'failed',
+                    error_type: 'AtomicGitUncertainError',
+                    attempts: 3,
+                },
+            })),
+        });
+
+        await expect(runStructuredDailyWorkflow(env, runInput, deps)).resolves.toMatchObject({
+            success: true,
+            commit_sha: sha('e'),
+            lock_release: {
+                status: 'failed',
+                error_type: 'AtomicGitUncertainError',
+                attempts: 3,
+            },
+        });
+        expect(mirror).toHaveBeenCalledOnce();
+    });
+
     it('reconciles a failed mirror from the exact merged commit without refetching providers', async () => {
         const canonicalJson = `${JSON.stringify({ date: runInput.reportDate })}\n`;
         const mirrorEnv = {

--- a/tests/worker/workerRegression.test.js
+++ b/tests/worker/workerRegression.test.js
@@ -57,6 +57,7 @@ describe('worker regression guards', () => {
             trigger_type: 'scheduled',
             run_at: '2026-07-14T00:00:00.000Z',
             error_type: 'structured_source_fetch_failed',
+            failure_stage: 'fetch',
             source_errors: [{
                 provider: 'aibase',
                 content_type: 'news',
@@ -119,6 +120,7 @@ describe('worker regression guards', () => {
         const marker = JSON.parse(DATA_KV.put.mock.calls[0][1]);
         expect(marker).toMatchObject({
             error_type: 'scheduled_workflow_failed',
+            failure_stage: 'unknown',
             source_errors: [{
                 provider: 'unknown',
                 content_type: 'unknown',


### PR DESCRIPTION
## Summary
- retry publication lock release three times with bounded backoff
- reconcile a lost release response only when the current ref is the exact owner's release successor
- keep a successful Git publication moving into database mirroring if release still fails
- persist a sanitized workflow failure stage for future production diagnosis

## Verification
- npm test (554 passed)
- npm run worker:check
- git diff --check