### PR TITLE
fix: preserve broker recovery request budget

### DIFF
--- a/workers/content/broker/index.test.ts
+++ b/workers/content/broker/index.test.ts
@@ -613,6 +613,23 @@ describe("production convergence verification", () => {
     expect(value.manifestAttempts.get("https://www.example.test")).toBe(10);
   });
 
+  it("supports one recovery probe so rollback retains the invocation budget", async () => {
+    const value = setup(false, 9);
+    const clock = controlledClock();
+    await expect(
+      verifyDeployment(
+        context,
+        "https://deploy.pages.dev",
+        value.env,
+        { kind: "tar", files },
+        clock.startedAt,
+        { ...clock.dependencies, maximumAttempts: 1 },
+      ),
+    ).rejects.toThrow("did not converge");
+    expect(value.manifestAttempts.get("https://deploy.pages.dev")).toBe(1);
+    expect(value.manifestAttempts.get("https://www.example.test")).toBe(1);
+  });
+
   it("fails closed when a custom-domain search artifact drifts", async () => {
     const value = setup(true);
     const clock = controlledClock();

--- a/workers/content/broker/index.ts
+++ b/workers/content/broker/index.ts
@@ -78,6 +78,7 @@ type VerificationDependencies = {
   fetch?: typeof fetch;
   now?: () => number;
   sleep?: (milliseconds: number) => Promise<void>;
+  maximumAttempts?: number;
 };
 type VerificationProbeResult =
   | { ok: true; evidence: JsonRecord }
@@ -939,6 +940,13 @@ export async function verifyDeployment(
     ((milliseconds: number) =>
       new Promise<void>((resolve) => setTimeout(resolve, milliseconds)));
   const fetcher = dependencies.fetch || fetch;
+  const maximumAttempts = dependencies.maximumAttempts;
+  if (
+    maximumAttempts !== undefined &&
+    (!Number.isSafeInteger(maximumAttempts) || maximumAttempts < 1)
+  ) {
+    throw new Error("Maximum verification attempts is invalid");
+  }
   const maximumInconsistencyMs = Number(
     env.MAX_PRODUCTION_INCONSISTENCY_MS || "240000",
   );
@@ -1034,6 +1042,7 @@ export async function verifyDeployment(
       else failures.push(result.failure);
     }
     if (evidenceByOrigin.size === bases.length) break;
+    if (maximumAttempts !== undefined && round + 1 >= maximumAttempts) break;
     const remainingAfterProbe =
       maximumInconsistencyMs - (now() - windowStartedAt);
     if (remainingAfterProbe <= 0) break;
@@ -1494,11 +1503,16 @@ export async function reconcileProduction(
     const deployment = await latestProductionDeployment(env);
     try {
       const targetFiles = await artifactFiles(target, env);
+      // Recovery runs on the Free-plan 50-subrequest budget. Probe the
+      // interrupted target once; if it has not already converged, preserve the
+      // rest of this invocation for restoring and verifying last-known-good.
       const evidence = await verifyDeployment(
         target,
         deployment.url,
         env,
         targetFiles,
+        undefined,
+        { maximumAttempts: 1 },
       );
       await purgeContentCaches(env);
       if (slot.operation === "forward") {


### PR DESCRIPTION
## Summary
- bound scheduled target reconciliation to one exact multi-origin probe
- preserve the remaining Free-plan Worker subrequest budget for last-known-good restoration
- add a regression test proving delayed edges are not retried during recovery

## Validation
- `npm test` (38 files, 556 tests)
- `npm run content:production:preflight`
- Broker Worker dry-run
- patched Broker version `d6846b7a-b853-4cec-85ce-ba882915cbc2` deployed for fenced recovery