### PR TITLE
fix: avoid redundant broker asset hashing

### DIFF
--- a/workers/content/broker/index.test.ts
+++ b/workers/content/broker/index.test.ts
@@ -332,7 +332,7 @@ describe("content-addressed Pages upload", () => {
     };
   }
 
-  it("fetches and verifies only missing R2 assets before direct upload", async () => {
+  it("fetches only missing immutable R2 assets before direct upload", async () => {
     const value = setup();
     await expect(
       uploadPages(value.bundle, context, value.env as never),
@@ -352,13 +352,11 @@ describe("content-addressed Pages upload", () => {
     ]);
   });
 
-  it("stops before Pages upload when an R2 asset fails byte verification", async () => {
-    const corrupt = pageBytes.slice();
-    corrupt[0] ^= 1;
-    const value = setup(corrupt);
+  it("stops before Pages upload when an immutable R2 asset length drifts", async () => {
+    const value = setup(pageBytes.slice(1));
     await expect(
       uploadPages(value.bundle, context, value.env as never),
-    ).rejects.toThrow("asset hash mismatch");
+    ).rejects.toThrow("asset is unavailable");
     expect(
       value.requests.some(({ url }) => url.endsWith("/assets/upload")),
     ).toBe(false);

--- a/workers/content/broker/index.ts
+++ b/workers/content/broker/index.ts
@@ -1,5 +1,6 @@
 import { blake3 } from "@noble/hashes/blake3.js";
 import { bytesToHex } from "@noble/hashes/utils.js";
+import { Buffer } from "node:buffer";
 import { openContentDatabase, type ContentSql } from "../shared/db";
 
 type Env = {
@@ -143,14 +144,11 @@ async function hmacHex(secret: string, bytes: Uint8Array): Promise<string> {
 }
 
 function base64(bytes: Uint8Array): string {
-  let result = "";
-  const chunkSize = 0x8000;
-  for (let offset = 0; offset < bytes.length; offset += chunkSize) {
-    result += String.fromCharCode(
-      ...bytes.subarray(offset, offset + chunkSize),
-    );
-  }
-  return btoa(result);
+  return Buffer.from(
+    bytes.buffer,
+    bytes.byteOffset,
+    bytes.byteLength,
+  ).toString("base64");
 }
 
 function tarText(bytes: Uint8Array, start: number, length: number): string {

--- a/workers/content/broker/index.ts
+++ b/workers/content/broker/index.ts
@@ -542,15 +542,12 @@ async function fetchContentAddressedAsset(
     throw new Error("Content-addressed artifact asset is unavailable");
   }
   const bytes = new Uint8Array(await object.arrayBuffer());
-  // The immutable inventory is already verified against its database-bound
-  // fingerprint before any asset is loaded. Recomputing the Pages BLAKE3 key
-  // here base64-encodes every missing asset and can exhaust Worker CPU for a
-  // media-heavy release. The content SHA is sufficient to prove that these
-  // bytes are the exact bytes named by the verified inventory; Pages still
-  // receives the inventory's precomputed pages_hash as the upload key.
-  if ((await sha256(bytes)) !== asset.sha256) {
-    throw new Error("Content-addressed artifact asset hash mismatch");
-  }
+  // The workflow SHA-verifies each object after its conditional R2 upload,
+  // and an indefinite object lock prevents replacement. The database-bound
+  // inventory also requires object_key=assets/sha256/<sha>. Rehashing every
+  // small asset again here can exceed the Free-plan CPU budget before Pages
+  // receives the already verified bytes, so deployment verifies the immutable
+  // object identity and length without repeating hundreds of digests.
   return bytes;
 }
 


### PR DESCRIPTION
## Summary
- stop rehashing every immutable content-addressed R2 object during Pages upload
- retain object-key, byte-length, inventory-fingerprint and indefinite-lock checks
- keep production uploads within the Free-plan Worker CPU budget

## Validation
- `npm test` (38 files, 556 tests)
- `npm run content:production:preflight`
- Broker Worker dry-run
- patched Broker version `57c158b0-fecb-4f8a-a8c0-8cb05e52bf9e` deployed