### PR TITLE
fix: separate 03:00 content publication slot

### DIFF
--- a/scripts/check-content-observability.mjs
+++ b/scripts/check-content-observability.mjs
@@ -15,7 +15,7 @@ const BATCHES = [
   [7, "afternoon"],
   [15, "night"],
   [18, "lateNight"],
-  [19, "lateNight"],
+  [19, "lateNightSupplement"],
 ];
 
 function required(label, value) {
@@ -336,6 +336,9 @@ export function evaluateContentObservability(input, now = Date.now()) {
 
   const deadLetterCount = Number(database.outbox?.dead_letter_count || 0);
   const staleQueuedCount = Number(database.outbox?.stale_queued_count || 0);
+  const releaseHeadStaleCount = Number(
+    database.outbox?.release_head_stale_count || 0,
+  );
   if (
     !Number.isSafeInteger(deadLetterCount) ||
     deadLetterCount < 0 ||
@@ -348,6 +351,14 @@ export function evaluateContentObservability(input, now = Date.now()) {
       reasons.push(`outbox_dead_letter:${deadLetterCount}`);
     if (staleQueuedCount > 0)
       reasons.push(`outbox_stale_queued:${staleQueuedCount}`);
+  }
+  if (
+    !Number.isSafeInteger(releaseHeadStaleCount) ||
+    releaseHeadStaleCount < 0
+  ) {
+    reasons.push("release_head_state_invalid");
+  } else if (releaseHeadStaleCount > 0) {
+    reasons.push(`release_head_stale:${releaseHeadStaleCount}`);
   }
 
   const requests = Number(input.analytics?.requests || 0);
@@ -392,6 +403,7 @@ export function evaluateContentObservability(input, now = Date.now()) {
     healthy: reasons.length === 0,
     outbox: {
       dead_letter_count: deadLetterCount,
+      release_head_stale_count: releaseHeadStaleCount,
       stale_queued_count: staleQueuedCount,
     },
     reasons,

--- a/supabase/migrations/20260720000100_late_night_supplement_slots.sql
+++ b/supabase/migrations/20260720000100_late_night_supplement_slots.sql
@@ -1,0 +1,102 @@
+begin;
+
+alter table private.publication_slots
+  drop constraint if exists publication_slots_batch_id_check;
+alter table private.publication_slots
+  add constraint publication_slots_batch_id_check check (
+    batch_id in ('morning', 'afternoon', 'night', 'lateNight', 'lateNightSupplement')
+  );
+
+alter table private.publication_attempts
+  drop constraint if exists publication_attempts_batch_id_check;
+alter table private.publication_attempts
+  add constraint publication_attempts_batch_id_check check (
+    batch_id in ('morning', 'afternoon', 'night', 'lateNight', 'lateNightSupplement')
+  );
+
+set local role content_rpc_owner;
+
+-- Keep the frozen daily-report schema at four presentation batches. The extra
+-- identity exists only in publication fencing so the 02:00 close and 03:00
+-- supplement cannot collide while each remains independently idempotent.
+do $migration$
+declare
+  function_definition text;
+  updated_definition text;
+  old_identity constant text := $$('morning', 'afternoon', 'night', 'lateNight')$$;
+  new_identity constant text := $$('morning', 'afternoon', 'night', 'lateNight', 'lateNightSupplement')$$;
+begin
+  select pg_get_functiondef(
+    'private.reserve_ingestion_site_release_v1(uuid,text,text,text,text,text)'::regprocedure
+  ) into function_definition;
+  updated_definition := replace(function_definition, old_identity, new_identity);
+  if updated_definition = function_definition
+    and position('lateNightSupplement' in function_definition) = 0 then
+    raise exception 'reserve ingestion publication identity guard changed unexpectedly';
+  end if;
+  execute updated_definition;
+
+  select pg_get_functiondef(
+    'private.fail_ingestion_publication_attempt_v1(date,text,text,text,text,text,text)'::regprocedure
+  ) into function_definition;
+  updated_definition := replace(function_definition, old_identity, new_identity);
+  if updated_definition = function_definition
+    and position('lateNightSupplement' in function_definition) = 0 then
+    raise exception 'failed ingestion publication identity guard changed unexpectedly';
+  end if;
+  execute updated_definition;
+end;
+$migration$;
+
+create or replace function private.get_deployer_alert_state_v1()
+returns jsonb
+language sql
+stable
+security definer
+set search_path = ''
+as $$
+  select jsonb_build_object(
+    'dead_letter_count', count(*) filter (
+      where outbox.status = 'dead_letter'
+        and outbox.last_error is distinct from 'superseded_by_history_bootstrap'
+    ),
+    'resolved_dead_letter_count', count(*) filter (
+      where outbox.status = 'dead_letter'
+        and outbox.last_error = 'superseded_by_history_bootstrap'
+    ),
+    'stale_queued_count', count(*) filter (
+      where (
+        outbox.status in ('queued','failed','claimed','dispatched','building','promoting')
+        and outbox.inserted_at <= current_timestamp - interval '10 minutes'
+      )
+      or (
+        outbox.status = 'preview_verified'
+        and outbox.payload ->> 'mode' = 'production'
+        and outbox.updated_at <= current_timestamp - interval '10 minutes'
+      )
+    ),
+    'oldest_actionable_at', min(outbox.inserted_at) filter (
+      where outbox.status in ('queued','failed','claimed','dispatched','building','promoting')
+        or (
+          outbox.status = 'preview_verified'
+          and outbox.payload ->> 'mode' = 'production'
+        )
+    ),
+    'release_head_stale_count', (
+      select count(*)
+      from private.release_head_claims claim
+      where claim.inserted_at <= current_timestamp - interval '10 minutes'
+        or claim.expires_at <= current_timestamp
+    ),
+    'oldest_release_head_claimed_at', (
+      select min(claim.inserted_at)
+      from private.release_head_claims claim
+    )
+  )
+  from private.content_outbox outbox
+$$;
+
+comment on function private.get_deployer_alert_state_v1() is
+  'Returns actionable outbox and release-head health, including stalled production preview verification.';
+
+commit;

--- a/supabase/tests/database/content_database_security.test.sql
+++ b/supabase/tests/database/content_database_security.test.sql
@@ -1,7 +1,7 @@
 begin;
 
 create extension if not exists pgtap with schema extensions;
-select plan(112);
+select plan(114);
 
 select cmp_ok(
   (select count(*) from information_schema.tables where table_schema = 'private' and table_name like '%content%' or table_schema = 'private' and table_name like '%release%'),
@@ -176,6 +176,22 @@ select ok(
 select ok(has_function_privilege('content_ingestor', 'private.ingest_report_snapshot_v1(jsonb,text,bigint,text,text,text,text)', 'execute'), 'ingestor can ingest snapshots');
 select ok(has_function_privilege('content_ingestor', 'private.reserve_site_release_v1(uuid)', 'execute'), 'ingestor can reserve releases');
 select ok(has_function_privilege('content_ingestor', 'private.reserve_ingestion_site_release_v1(uuid,text,text,text,text,text)', 'execute'), 'ingestor can reserve deterministic publication slots');
+select ok(
+  position('lateNightSupplement' in (
+    select p.prosrc
+    from pg_proc p join pg_namespace n on n.oid = p.pronamespace
+    where n.nspname = 'private' and p.proname = 'reserve_ingestion_site_release_v1'
+  )) > 0,
+  '03:00 supplement has an independent deterministic publication slot'
+);
+select ok(
+  position('lateNightSupplement' in (
+    select p.prosrc
+    from pg_proc p join pg_namespace n on n.oid = p.pronamespace
+    where n.nspname = 'private' and p.proname = 'fail_ingestion_publication_attempt_v1'
+  )) > 0,
+  '03:00 supplement failures retain independent attempt history'
+);
 select ok(not has_function_privilege('content_editor', 'private.reserve_ingestion_site_release_v1(uuid,text,text,text,text,text)', 'execute'), 'routine editor cannot reserve ingestion publication slots');
 select ok(has_function_privilege('content_ingestor', 'private.fail_ingestion_publication_attempt_v1(date,text,text,text,text,text,text)', 'execute'), 'ingestor can record a failed publication attempt');
 select ok(not has_function_privilege('content_editor', 'private.fail_ingestion_publication_attempt_v1(date,text,text,text,text,text,text)', 'execute'), 'routine editor cannot record ingestion publication attempts');

--- a/tests/worker/contentMirror.test.js
+++ b/tests/worker/contentMirror.test.js
@@ -1,5 +1,8 @@
 import { describe, expect, it, vi } from 'vitest';
-import { mirrorStructuredReport } from '../../workers/content/ingestion/mirror.ts';
+import {
+    mirrorStructuredReport,
+    publicationBatchId,
+} from '../../workers/content/ingestion/mirror.ts';
 import { canonicalJsonBytes } from '../../workers/content/shared/canonical.ts';
 
 const decode = (bytes) => new TextDecoder().decode(bytes);
@@ -35,9 +38,11 @@ function database({
     loseFirstFinalizeResponse = false,
     rejectFinalize = false,
     reserveError = null,
+    reserveFailureCount = Number.POSITIVE_INFINITY,
 } = {}) {
     const calls = [];
     let finalized = false;
+    let reserveFailures = 0;
     let attemptStatus = 'started';
     const release = {
         site_release_id: '22222222-2222-4222-8222-222222222222',
@@ -69,7 +74,10 @@ function database({
             ];
         }
         if (query.includes('reserve_ingestion_site_release_v1')) {
-            if (reserveError) throw reserveError;
+            if (reserveError && reserveFailures < reserveFailureCount) {
+                reserveFailures += 1;
+                throw reserveError;
+            }
             return [{ result: { ...reservation, idempotent: finalized } }];
         }
         if (query.includes('finalize_site_release_v1')) {
@@ -120,6 +128,32 @@ function input(value = report()) {
 }
 
 describe('structured content database mirror', () => {
+    it('uses a separate publication fence for the scheduled 03:00 supplement', () => {
+        expect(publicationBatchId('lateNight', `scheduled:${Date.parse('2026-07-20T18:00:00.000Z')}`))
+            .toBe('lateNight');
+        expect(publicationBatchId('lateNight', `scheduled:${Date.parse('2026-07-20T19:00:00.000Z')}`))
+            .toBe('lateNightSupplement');
+        expect(publicationBatchId('lateNight', 'manual:repair')).toBe('lateNight');
+        expect(publicationBatchId('morning', `scheduled:${Date.parse('2026-07-20T19:00:00.000Z')}`))
+            .toBe('morning');
+    });
+
+    it('passes the 03:00 supplement identity to the database without changing report batches', async () => {
+        const env = enabledEnv();
+        const db = database();
+        await mirrorStructuredReport(
+            env,
+            {
+                ...input(),
+                batch: 'lateNight',
+                triggerId: `scheduled:${Date.parse('2026-07-20T19:00:00.000Z')}`,
+            },
+            { openDatabase: vi.fn(() => db.sql) },
+        );
+        const reserve = db.calls.find((call) => call.query.includes('reserve_ingestion_site_release_v1'));
+        expect(reserve.values[1]).toBe('lateNightSupplement');
+    });
+
     it('does not touch R2 or Postgres while the mirror gate is disabled', async () => {
         const openDatabase = vi.fn();
 
@@ -251,6 +285,28 @@ describe('structured content database mirror', () => {
     });
 
     it.each(['55P03', '40001'])(
+        'retries transient database contention with bounded backoff %s',
+        async (code) => {
+            const env = enabledEnv();
+            const contention = Object.assign(new Error('Release head is busy'), { code });
+            const db = database({ reserveError: contention, reserveFailureCount: 1 });
+            const sleep = vi.fn(async () => undefined);
+
+            await expect(
+                mirrorStructuredReport(env, input(), {
+                    openDatabase: vi.fn(() => db.sql),
+                    sleep,
+                }),
+            ).resolves.toMatchObject({ status: 'mirrored' });
+
+            expect(
+                db.calls.filter((call) => call.query.includes('reserve_ingestion_site_release_v1')),
+            ).toHaveLength(2);
+            expect(sleep).toHaveBeenCalledWith(100);
+        },
+    );
+
+    it.each(['55P03', '40001'])(
         'does not permanently fail a publication attempt for transient database contention %s',
         async (code) => {
             const env = enabledEnv();
@@ -262,9 +318,13 @@ describe('structured content database mirror', () => {
             await expect(
                 mirrorStructuredReport(env, input(), {
                     openDatabase: vi.fn(() => db.sql),
+                    sleep: vi.fn(async () => undefined),
                 }),
             ).rejects.toBe(contention);
 
+            expect(
+                db.calls.filter((call) => call.query.includes('reserve_ingestion_site_release_v1')),
+            ).toHaveLength(3);
             expect(
                 db.calls.some((call) => call.query.includes('fail_ingestion_publication_attempt_v1')),
             ).toBe(false);

--- a/tests/worker/contentObservability.test.js
+++ b/tests/worker/contentObservability.test.js
@@ -43,7 +43,11 @@ function healthyInput() {
     ],
     database: {
       current: CURRENT,
-      outbox: { dead_letter_count: 0, stale_queued_count: 0 },
+      outbox: {
+        dead_letter_count: 0,
+        release_head_stale_count: 0,
+        stale_queued_count: 0,
+      },
       publication_attempts: due.map((batch) => ({
         ...batch,
         status: "succeeded",
@@ -84,7 +88,7 @@ describe("content observability evaluator", () => {
         }),
         expect.objectContaining({
           report_date: "2026-07-17",
-          batch_id: "lateNight",
+          batch_id: "lateNightSupplement",
           scheduled_at: "2026-07-17T19:00:00.000Z",
         }),
         expect.objectContaining({
@@ -199,6 +203,14 @@ describe("content observability production identity", () => {
     const result = evaluateContentObservability(input, NOW);
     expect(result.healthy).toBe(false);
     expect(result.reasons).toContain("api_analytics_sample_invalid");
+  });
+
+  it("alerts when a production release-head claim remains occupied", () => {
+    const input = healthyInput();
+    input.database.outbox.release_head_stale_count = 1;
+    const result = evaluateContentObservability(input, NOW);
+    expect(result.healthy).toBe(false);
+    expect(result.reasons).toContain("release_head_stale:1");
   });
 
   it("does not alert on a valid zero-traffic analytics window", () => {

--- a/workers/content/ingestion/mirror.ts
+++ b/workers/content/ingestion/mirror.ts
@@ -1,5 +1,6 @@
 import { canonicalJsonBytes, equalBytes, sha256Hex } from "../shared/canonical";
 import {
+  databaseErrorCode,
   failIngestionPublicationAttempt,
   finalizeSiteRelease,
   ingestReportSnapshot,
@@ -40,6 +41,49 @@ export type MirrorResult = {
   manifestSha256?: string;
 };
 
+const MAX_CONTENTION_ATTEMPTS = 3;
+const CONTENTION_RETRY_BASE_MS = 100;
+
+export function publicationBatchId(
+  batch: string,
+  triggerId?: string | null,
+): string {
+  if (batch !== "lateNight") return batch;
+  const scheduledAt = String(triggerId || "").match(/^scheduled:(\d{13})$/)?.[1];
+  if (!scheduledAt) return batch;
+  const timestamp = Number(scheduledAt);
+  const hour = Number(
+    new Intl.DateTimeFormat("en-US", {
+      hour: "2-digit",
+      hour12: false,
+      timeZone: "Asia/Shanghai",
+    }).format(new Date(timestamp)),
+  );
+  return hour === 3 ? "lateNightSupplement" : batch;
+}
+
+async function withContentionRetry<T>(
+  operation: () => Promise<T>,
+  label: string,
+  sleep: (milliseconds: number) => Promise<void>,
+): Promise<T> {
+  for (let attempt = 1; attempt <= MAX_CONTENTION_ATTEMPTS; attempt += 1) {
+    try {
+      return await operation();
+    } catch (error) {
+      if (!isRetryableReleaseContention(error) || attempt === MAX_CONTENTION_ATTEMPTS) {
+        throw error;
+      }
+      console.warn("[ContentMirror] transient database contention; retrying", {
+        attempt,
+        operation: label,
+      });
+      await sleep(CONTENTION_RETRY_BASE_MS * 2 ** (attempt - 1));
+    }
+  }
+  throw new Error("Content mirror retry loop exhausted");
+}
+
 export async function mirrorStructuredReport(
   env: MirrorEnv,
   input: {
@@ -49,7 +93,10 @@ export async function mirrorStructuredReport(
     batch: string;
     triggerId?: string | null;
   },
-  dependencies: { openDatabase?: typeof openContentDatabase } = {},
+  dependencies: {
+    openDatabase?: typeof openContentDatabase;
+    sleep?: (milliseconds: number) => Promise<void>;
+  } = {},
 ): Promise<MirrorResult> {
   if (String(env.CONTENT_DATABASE_MIRROR_ENABLED).toLowerCase() !== "true") {
     return { status: "disabled" };
@@ -78,6 +125,7 @@ export async function mirrorStructuredReport(
   const triggerKind =
     input.triggerId ||
     `structured:${input.report.date}:${input.batch}:${input.codeSha.toLowerCase()}`;
+  const publicationBatch = publicationBatchId(input.batch, input.triggerId);
   const workerVersion =
     env.DAILY_PRODUCER_VERSION ||
     env.BUILD_ENVIRONMENT_VERSION ||
@@ -87,6 +135,10 @@ export async function mirrorStructuredReport(
     env,
     "content-ingestor",
   );
+  const sleep =
+    dependencies.sleep ||
+    ((milliseconds: number) =>
+      new Promise<void>((resolve) => setTimeout(resolve, milliseconds)));
   try {
     const snapshot = await ingestReportSnapshot(sql, {
       document: parsed,
@@ -96,14 +148,19 @@ export async function mirrorStructuredReport(
       serializerVersion: env.DAILY_SERIALIZER_VERSION || "daily-json-c14n-v1",
       provenanceKind: "live_ingestion",
     });
-    const reservation = await reserveIngestionSiteRelease(sql, {
-      reportSnapshotId: String(snapshot.report_snapshot_id),
-      batchId: input.batch,
-      inputSha256: reportObject.sha256,
-      contentSha256: reportObject.sha256,
-      triggerKind,
-      workerVersion,
-    });
+    const reservation = await withContentionRetry(
+      () =>
+        reserveIngestionSiteRelease(sql, {
+          reportSnapshotId: String(snapshot.report_snapshot_id),
+          batchId: publicationBatch,
+          inputSha256: reportObject.sha256,
+          contentSha256: reportObject.sha256,
+          triggerKind,
+          workerVersion,
+        }),
+      "reserve",
+      sleep,
+    );
     const reports = Array.isArray(reservation.reports)
       ? reservation.reports
       : [];
@@ -160,22 +217,27 @@ export async function mirrorStructuredReport(
           ? "production"
           : "shadow",
     };
-    const release = await finalizeSiteRelease(sql, {
-      reservationId: String(reservation.reservation_id),
-      manifestObjectKey: manifestObject.key,
-      manifestByteLength: manifestObject.byteLength,
-      manifestSha256: manifestObject.sha256,
-      contentRootSha256,
-      schemaVersion: input.report.schema_version,
-      taxonomyVersion: input.report.taxonomy_version,
-      serializerVersion: contract.serializer_version,
-      searchContractVersion: contract.search_contract_version,
-      sourceContractVersion: contract.source_contract_version,
-      structuredCutoverDate: contract.structured_cutover_date,
-      noReportDays: contract.no_report_days,
-      dispatchId,
-      dispatchPayload,
-    });
+    const release = await withContentionRetry(
+      () =>
+        finalizeSiteRelease(sql, {
+          reservationId: String(reservation.reservation_id),
+          manifestObjectKey: manifestObject.key,
+          manifestByteLength: manifestObject.byteLength,
+          manifestSha256: manifestObject.sha256,
+          contentRootSha256,
+          schemaVersion: input.report.schema_version,
+          taxonomyVersion: input.report.taxonomy_version,
+          serializerVersion: contract.serializer_version,
+          searchContractVersion: contract.search_contract_version,
+          sourceContractVersion: contract.source_contract_version,
+          structuredCutoverDate: contract.structured_cutover_date,
+          noReportDays: contract.no_report_days,
+          dispatchId,
+          dispatchPayload,
+        }),
+      "finalize",
+      sleep,
+    );
     return {
       status: "mirrored",
       reportSnapshotId: String(snapshot.report_snapshot_id),
@@ -187,13 +249,14 @@ export async function mirrorStructuredReport(
   } catch (error) {
     if (isRetryableReleaseContention(error)) {
       console.warn(
-        "[ContentMirror] production release head is busy; retry later",
+        "[ContentMirror] database contention retries exhausted",
+        { errorCode: databaseErrorCode(error) },
       );
     } else {
       try {
         await failIngestionPublicationAttempt(sql, {
           reportDate: input.report.date,
-          batchId: input.batch,
+          batchId: publicationBatch,
           inputSha256: reportObject.sha256,
           triggerKind,
           workerVersion,


### PR DESCRIPTION
## Summary
- keep the four report presentation batches unchanged while assigning the scheduled 03:00 supplement its own database publication fence
- retry transient `55P03` and `40001` mirror contention up to three times with bounded backoff
- alert on stale production `preview_verified` outbox rows and long-held release-head claims

## Root cause
Both the Beijing 02:00 close and 03:00 supplement used the same `(report_date, lateNight)` CAS slot. The 02:00 payload claimed it first, so the intended 03:00 revision was deterministically rejected with `40001 Ingestion publication slot CAS conflict`.

## Validation
- `npm test` (38 files, 569 tests)
- `npm run worker:check`
- `bash scripts/test-supabase-local.sh`
- new migration applied twice consecutively
- pgTAP: 5 files, 268 tests