### PR TITLE
fix: pin delayed content builds to safe main SHA

### DIFF
--- a/.github/workflows/content-release.yml
+++ b/.github/workflows/content-release.yml
@@ -21,6 +21,9 @@ on:
       code_sha:
         required: true
         type: string
+      source_code_sha:
+        required: false
+        type: string
       build_environment_version:
         required: true
         type: string
@@ -50,6 +53,7 @@ jobs:
       EXPECTED_PREDECESSOR_ID: ${{ github.event.inputs.expected_predecessor_id }}
       CONTENT_ROOT_SHA256: ${{ github.event.inputs.expected_content_sha }}
       EXACT_CODE_SHA: ${{ github.event.inputs.code_sha }}
+      SOURCE_CODE_SHA: ${{ github.event.inputs.source_code_sha }}
       BUILD_ENVIRONMENT_VERSION: ${{ github.event.inputs.build_environment_version }}
       DEPLOYMENT_MODE: ${{ github.event.inputs.mode }}
       CONTENT_BUILD_API_ORIGIN: ${{ vars.CONTENT_DEPLOYER_ORIGIN }}
@@ -75,6 +79,9 @@ jobs:
           [[ "$CONTENT_RELEASE_SEQUENCE" =~ ^[1-9][0-9]*$ ]]
           [[ "$CONTENT_ROOT_SHA256" =~ ^[0-9a-f]{64}$ ]]
           [[ "$EXACT_CODE_SHA" =~ ^[0-9a-f]{40}$ ]]
+          if [[ -n "$SOURCE_CODE_SHA" ]]; then
+            [[ "$SOURCE_CODE_SHA" =~ ^[0-9a-f]{40}$ ]]
+          fi
           [[ "$BUILD_ENVIRONMENT_VERSION" == "node22.17-astro7-hugo0.147.9-v1" ]]
 
       - name: Checkout exact code SHA
@@ -84,7 +91,11 @@ jobs:
           fetch-depth: 0
 
       - name: Verify checkout identity
-        run: test "$(git rev-parse HEAD)" = "$EXACT_CODE_SHA"
+        run: |
+          test "$(git rev-parse HEAD)" = "$EXACT_CODE_SHA"
+          if [[ -n "$SOURCE_CODE_SHA" ]]; then
+            git merge-base --is-ancestor "$SOURCE_CODE_SHA" "$EXACT_CODE_SHA"
+          fi
 
       - name: Setup Node.js 22.17.0
         uses: actions/setup-node@v4
@@ -212,7 +223,7 @@ jobs:
         run: |
           artifact_fingerprint="$(jq -r '.build.artifact_sha256' astro/dist/release-manifests/site-route-manifest.json)"
           [[ "$artifact_fingerprint" =~ ^[0-9a-f]{64}$ ]]
-          evidence="$(jq -nc --arg object_key "$ARTIFACT_OBJECT_KEY" --arg hash "$ARTIFACT_SHA256" --arg fingerprint "$artifact_fingerprint" --arg algorithm "$ARTIFACT_HASH_ALGORITHM" --arg code "$EXACT_CODE_SHA" --arg env "$BUILD_ENVIRONMENT_VERSION" --argjson bytes "$ARTIFACT_BYTES" '{object_key:$object_key,byte_length:$bytes,artifact_sha256:$hash,artifact_fingerprint_sha256:$fingerprint,hash_algorithm:$algorithm,code_sha:$code,build_environment_version:$env}')"
+          evidence="$(jq -nc --arg object_key "$ARTIFACT_OBJECT_KEY" --arg hash "$ARTIFACT_SHA256" --arg fingerprint "$artifact_fingerprint" --arg algorithm "$ARTIFACT_HASH_ALGORITHM" --arg code "$EXACT_CODE_SHA" --arg source_code "$SOURCE_CODE_SHA" --arg env "$BUILD_ENVIRONMENT_VERSION" --argjson bytes "$ARTIFACT_BYTES" '{object_key:$object_key,byte_length:$bytes,artifact_sha256:$hash,artifact_fingerprint_sha256:$fingerprint,hash_algorithm:$algorithm,code_sha:$code,source_code_sha:($source_code | if length > 0 then . else null end),build_environment_version:$env}')"
           node scripts/send-content-deployment-callback.mjs artifact_registered "$evidence"
 
       - name: Deploy exact files to Pages Preview

--- a/tests/worker/contentMirror.test.js
+++ b/tests/worker/contentMirror.test.js
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 import {
     mirrorStructuredReport,
     publicationBatchId,
+    resolveForwardBuildCodeSha,
 } from '../../workers/content/ingestion/mirror.ts';
 import { canonicalJsonBytes } from '../../workers/content/shared/canonical.ts';
 
@@ -128,6 +129,42 @@ function input(value = report()) {
 }
 
 describe('structured content database mirror', () => {
+    it('pins a delayed mirror to current main when the source commit is its ancestor', async () => {
+        const mainSha = 'b'.repeat(40);
+        const api = vi
+            .fn()
+            .mockResolvedValueOnce({ object: { sha: mainSha } })
+            .mockResolvedValueOnce({
+                status: 'ahead',
+                base_commit: { sha: codeSha.toLowerCase() },
+                merge_base_commit: { sha: codeSha.toLowerCase() },
+            });
+
+        await expect(resolveForwardBuildCodeSha({}, codeSha, api)).resolves.toBe(mainSha);
+        expect(api).toHaveBeenNthCalledWith(1, expect.anything(), '/git/ref/heads/main');
+        expect(api).toHaveBeenNthCalledWith(
+            2,
+            expect.anything(),
+            `/compare/${codeSha.toLowerCase()}...${mainSha}`,
+        );
+    });
+
+    it('does not replace a source SHA that is not contained by current main', async () => {
+        const mainSha = 'b'.repeat(40);
+        const api = vi
+            .fn()
+            .mockResolvedValueOnce({ object: { sha: mainSha } })
+            .mockResolvedValueOnce({
+                status: 'diverged',
+                base_commit: { sha: codeSha.toLowerCase() },
+                merge_base_commit: { sha: 'c'.repeat(40) },
+            });
+
+        await expect(resolveForwardBuildCodeSha({}, codeSha, api)).resolves.toBe(
+            codeSha.toLowerCase(),
+        );
+    });
+
     it('uses a separate publication fence for the scheduled 03:00 supplement', () => {
         expect(publicationBatchId('lateNight', `scheduled:${Date.parse('2026-07-20T18:00:00.000Z')}`))
             .toBe('lateNight');
@@ -229,10 +266,41 @@ describe('structured content database mirror', () => {
             expect(finalize.values.at(-1)).toMatchObject({
                 mode: expectedMode,
                 code_sha: codeSha.toLowerCase(),
+                source_code_sha: codeSha.toLowerCase(),
             });
             expect(db.sql.end).toHaveBeenCalledWith({ timeout: 2 });
         },
     );
+
+    it('persists the forward-selected build SHA before the immutable outbox is created', async () => {
+        const env = {
+            ...enabledEnv('true'),
+            GITHUB_TOKEN: 'test-token',
+            GITHUB_REPO_OWNER: 'owner',
+            GITHUB_REPO_NAME: 'repo',
+        };
+        const db = database();
+        const mainSha = 'b'.repeat(40);
+        const api = vi
+            .fn()
+            .mockResolvedValueOnce({ object: { sha: mainSha } })
+            .mockResolvedValueOnce({
+                status: 'ahead',
+                base_commit: { sha: codeSha.toLowerCase() },
+                merge_base_commit: { sha: codeSha.toLowerCase() },
+            });
+
+        await mirrorStructuredReport(env, input(), {
+            openDatabase: vi.fn(() => db.sql),
+            api,
+        });
+
+        const finalize = db.calls.find((call) => call.query.includes('finalize_site_release_v1'));
+        expect(finalize.values.at(-1)).toMatchObject({
+            code_sha: mainSha,
+            source_code_sha: codeSha.toLowerCase(),
+        });
+    });
 
     it('reuses exact R2 bytes and the deterministic reservation after a committed finalize loses its response', async () => {
         const env = enabledEnv();

--- a/workers/content/ingestion/mirror.ts
+++ b/workers/content/ingestion/mirror.ts
@@ -1,4 +1,5 @@
 import { canonicalJsonBytes, equalBytes, sha256Hex } from "../shared/canonical";
+import { callGitHubApi } from "../../../src/github.js";
 import {
   databaseErrorCode,
   failIngestionPublicationAttempt,
@@ -24,6 +25,10 @@ type MirrorEnv = {
   DAILY_SERIALIZER_VERSION?: string;
   DAILY_PRODUCER_VERSION?: string;
   SEARCH_CONTRACT_VERSION?: string;
+  GITHUB_TOKEN?: string;
+  GITHUB_REPO_OWNER?: string;
+  GITHUB_REPO_NAME?: string;
+  GITHUB_BRANCH?: string;
 };
 
 type DailyReport = Record<string, unknown> & {
@@ -43,6 +48,35 @@ export type MirrorResult = {
 
 const MAX_CONTENTION_ATTEMPTS = 3;
 const CONTENTION_RETRY_BASE_MS = 100;
+
+export async function resolveForwardBuildCodeSha(
+  env: MirrorEnv,
+  sourceCodeSha: string,
+  api: typeof callGitHubApi = callGitHubApi,
+): Promise<string> {
+  if (!/^[a-f0-9]{40}$/i.test(sourceCodeSha))
+    throw new Error("Mirror requires an exact source code SHA");
+  const branch = env.GITHUB_BRANCH || "main";
+  const ref = await api(
+    env,
+    `/git/ref/heads/${branch.split("/").map(encodeURIComponent).join("/")}`,
+  );
+  const mainSha = String(ref?.object?.sha || "").toLowerCase();
+  const normalizedSource = sourceCodeSha.toLowerCase();
+  if (!/^[a-f0-9]{40}$/.test(mainSha))
+    throw new Error("GitHub main ref is malformed");
+  if (mainSha === normalizedSource) return normalizedSource;
+
+  const comparison = await api(
+    env,
+    `/compare/${normalizedSource}...${mainSha}`,
+  );
+  const sourceIsAncestor =
+    comparison?.status === "ahead" &&
+    comparison?.base_commit?.sha === normalizedSource &&
+    comparison?.merge_base_commit?.sha === normalizedSource;
+  return sourceIsAncestor ? mainSha : normalizedSource;
+}
 
 export function publicationBatchId(
   batch: string,
@@ -96,6 +130,7 @@ export async function mirrorStructuredReport(
   dependencies: {
     openDatabase?: typeof openContentDatabase;
     sleep?: (milliseconds: number) => Promise<void>;
+    api?: typeof callGitHubApi;
   } = {},
 ): Promise<MirrorResult> {
   if (String(env.CONTENT_DATABASE_MIRROR_ENABLED).toLowerCase() !== "true") {
@@ -115,6 +150,15 @@ export async function mirrorStructuredReport(
   if (!equalBytes(canonicalJsonBytes(input.report), reportBytes)) {
     throw new Error("Canonical report bytes do not match the in-memory report");
   }
+  const sourceCodeSha = input.codeSha.toLowerCase();
+  const buildCodeSha =
+    env.GITHUB_TOKEN && env.GITHUB_REPO_OWNER && env.GITHUB_REPO_NAME
+      ? await resolveForwardBuildCodeSha(
+          env,
+          sourceCodeSha,
+          dependencies.api || callGitHubApi,
+        )
+      : sourceCodeSha;
   const reportObject = await putVerifiedImmutable(
     env.REPORT_SNAPSHOTS,
     "report-snapshots",
@@ -208,7 +252,8 @@ export async function mirrorStructuredReport(
       site_release_sequence: reservation.site_release_sequence,
       expected_predecessor_id: reservation.expected_predecessor_id,
       expected_content_sha: contentRootSha256,
-      code_sha: input.codeSha.toLowerCase(),
+      code_sha: buildCodeSha,
+      source_code_sha: sourceCodeSha,
       build_environment_version:
         env.BUILD_ENVIRONMENT_VERSION || "node22.17-astro7-hugo0.147.9-v1",
       mode:


### PR DESCRIPTION
## Summary
- resolve delayed content source commits to current main only after proving fast-forward ancestry
- persist both source and build SHAs before immutable outbox creation
- verify source ancestry in the exact release workflow and record it with artifact evidence

## Why
Release #89 was created from an older source commit after main had already advanced. The old checkout could not render the newer database-fixed content set, causing RSS parity verification to fail. Resolving only at dispatch time would break exact-tuple retry semantics, so the selected build SHA is frozen when the release is finalized.

## Validation
- npm test (38 files, 573 tests)
- npm run check --prefix astro
- npm run lint --prefix astro
- npm run test --prefix astro (11 files, 74 tests)