### PR TITLE
style: remove taxonomy links from primary navigation

### DIFF
--- a/astro/src/layouts/BaseLayout.astro
+++ b/astro/src/layouts/BaseLayout.astro
@@ -45,8 +45,6 @@ const navLinks = isEnglish
 	: [
 			{ href: '/daily/', label: '资讯日报' },
 			{ href: '/highlights/', label: '精选阅读' },
-			{ href: '/topics/', label: '主题' },
-			{ href: '/entities/', label: '实体' },
 			{ href: '/model-evals/', label: '模型评测' },
 			{ href: '/prompts/', label: 'Prompt' },
 			{ href: '/my-publish/', label: '我的文章' },


### PR DESCRIPTION
## Summary\n\n- remove the Topic and Entity links from the Chinese primary navigation\n- retain taxonomy routes and data so existing deep links continue to work\n\n## Validation\n\n- npm run check\n- npm run lint\n- npm run test (74 tests)\n- SITE_DISPLAY_DATE=2026-07-21 npx astro build (311 pages)