### PR TITLE
fix: keep recent daily archive months collapsible

### DIFF
--- a/astro/src/components/DailyArchive.astro
+++ b/astro/src/components/DailyArchive.astro
@@ -101,8 +101,8 @@ for (const row of rows) {
 	else groups.push({ monthKey, rows: [row] });
 }
 
-// Months within the latest three stay expanded; older ones collapse into a
-// <details> summary line so the archive stays a single static page.
+// Every month renders as a <details> group so it can be collapsed/expanded;
+// the latest three default to open, older ones start collapsed.
 const shiftMonth = (monthKey: string, delta: number): string => {
 	const [year, month] = monthKey.split('-').map(Number);
 	const total = year * 12 + (month - 1) + delta;
@@ -191,16 +191,8 @@ const expandedCutoff = latestRow ? shiftMonth(latestRow.identity.dateKey.slice(0
 					</a>
 				);
 			});
-			return expanded ? (
-				<section class="month-group">
-					<div class="month-heading">
-						<h2>{monthLabel}</h2>
-						<span class="count">{countLabel}</span>
-					</div>
-					{dayRows}
-				</section>
-			) : (
-				<details class="month-group">
+			return (
+				<details class="month-group" open={expanded || undefined}>
 					<summary class="month-heading">
 						<h2>{monthLabel}</h2>
 						<span class="count">{countLabel}</span>


### PR DESCRIPTION
## 问题

日报归档页（/daily/）中最近三个月（当前为 5/6/7 月）被渲染成固定展开的 `<section>`，缺少 +/– 折叠图标且无法收起；只有更早的月份渲染为 `<details>` 才有折叠功能。

## 修改

`astro/src/components/DailyArchive.astro`：所有月份统一渲染为 `<details class="month-group">`，最近三个月默认带 `open`（展开、显示 – 图标），更早月份默认收起（显示 + 图标），每个月份都可自由展开/收起。

## 验证

- `astro check`：0 errors
- `npm run lint` / `npm run test`（astro）：全部通过（74 tests）
- `npm run verify:renderers`：213 条日报路由 parity 通过
- 本地构建确认 `dist/daily/index.html` 中最近三月为 `<details open>`，其余为 `<details>`