### PR TITLE
fix: drop ordering hint from today stream heading

### DIFF
--- a/astro/src/components/QuietIndexHome.astro
+++ b/astro/src/components/QuietIndexHome.astro
@@ -195,9 +195,7 @@ const previousDays = (
 							<h2>{isEnglish ? "Today's stream" : '今日流'}</h2>
 							<span class="h-line" />
 							<span class="h-meta">
-								{isEnglish
-									? `${items.length} items · latest additions first`
-									: `${items.length} 条 · 最新收录在前`}
+								{isEnglish ? `${items.length} items` : `${items.length} 条`}
 							</span>
 						</div>
 


### PR DESCRIPTION
## 修改

首页「今日流」标题右侧的「最新收录在前 / latest additions first」提示文字按需求去除，只保留收录数量（如 `41 条` / `41 items`）。

改动文件：`astro/src/components/QuietIndexHome.astro`

## 验证

- `astro check` / `eslint`：0 errors
- 本地构建确认 `dist/index.html` 中该处渲染为 `<span class="h-meta">41 条</span>`