### PR TITLE
fix: bundle legacy directory script from astro/src

### DIFF
--- a/astro/eslint.config.js
+++ b/astro/eslint.config.js
@@ -17,6 +17,12 @@ export default [
 		},
 	},
 	{
+		files: ['src/scripts/**/*.js'],
+		languageOptions: {
+			globals: globals.browser,
+		},
+	},
+	{
 		files: ['scripts/**/*.mjs', '*.config.js'],
 		languageOptions: {
 			globals: globals.node,

--- a/astro/src/components/LegacyPage.astro
+++ b/astro/src/components/LegacyPage.astro
@@ -419,4 +419,11 @@ const libraryApi =
 	}
 </BaseLayout>
 
-{directoryKind && <script is:inline src="/js/legacy-directory.js" />}
+{
+	/* Bundled from astro/src/scripts (see the header note there); the script
+    no-ops on pages without [data-directory-page], so it can load on every
+    legacy page. */
+}
+<script>
+	import '../scripts/legacy-directory.js';
+</script>

--- a/astro/src/scripts/legacy-directory.js
+++ b/astro/src/scripts/legacy-directory.js
@@ -1,0 +1,232 @@
+// Astro-owned copy of the legacy directory script, bundled by Astro via the
+// <script> import in LegacyPage.astro. The production deployer does not allow
+// releasing static/js/legacy-directory.js, so the Astro site maintains its
+// own copy here; the static/ copy remains for the legacy Hugo renderer only.
+(() => {
+	const root = document.querySelector('[data-directory-page]');
+	if (!(root instanceof HTMLElement)) return;
+	const input = root.querySelector('[data-directory-query]');
+	const empty = root.querySelector('[data-directory-empty]');
+	const list = root.querySelector('[data-directory-list]');
+	const count = root.querySelector('[data-directory-count]');
+	const kind = root.dataset.directoryPage;
+	if (!(input instanceof HTMLInputElement)) return;
+
+	const locale = document.documentElement.lang || 'zh-CN';
+	const apply = () => {
+		const query = input.value.trim().toLocaleLowerCase(locale);
+		let visible = 0;
+		for (const item of root.querySelectorAll('[data-directory-item]')) {
+			const match = !query || (item.getAttribute('data-search') || '').includes(query);
+			item.hidden = !match;
+			if (match) visible += 1;
+		}
+		if (empty instanceof HTMLElement) empty.hidden = visible !== 0;
+		// Grouped lists (highlights year groups) collapse a group once every
+		// row inside it has been filtered out.
+		for (const group of root.querySelectorAll('details.month-group')) {
+			const anyVisible = [...group.querySelectorAll('[data-directory-item]')].some(
+				(item) => !item.hidden,
+			);
+			group.hidden = !anyVisible;
+		}
+	};
+	input.addEventListener('input', apply);
+
+	const api = root.dataset.libraryApi;
+	if (!api || !(list instanceof HTMLElement)) return;
+
+	const text = (value) => (typeof value === 'string' ? value : '');
+	const safeHref = (value) => {
+		if (typeof value !== 'string' || !value) return null;
+		if (value.startsWith('/')) return value;
+		try {
+			const url = new URL(value);
+			return url.protocol === 'https:' ? url.href : null;
+		} catch {
+			return null;
+		}
+	};
+	const safeTags = (value) =>
+		Array.isArray(value) ? value.filter((tag) => typeof tag === 'string' && tag) : [];
+
+	// Highlights carry no explicit date. Recover one from dated detail routes,
+	// falling back to the cover upload timestamp in the thumb URL, which marks
+	// when the entry was curated.
+	const highlightDate = (record) => {
+		const fromDetail = /\/highlights\/(\d{4}-\d{2}-\d{2})/.exec(text(record.detailUrl));
+		if (fromDetail) return fromDetail[1];
+		const fromThumb = /\/(\d{4})(\d{2})(\d{2})\d{9}\.png/.exec(text(record.thumb));
+		return fromThumb ? `${fromThumb[1]}-${fromThumb[2]}-${fromThumb[3]}` : null;
+	};
+
+	const addImage = (article, value, contain = false) => {
+		const imageUrl = safeHref(value);
+		if (!imageUrl) return;
+		const image = document.createElement('img');
+		image.src = imageUrl;
+		image.alt = '';
+		image.loading = 'lazy';
+		image.referrerPolicy = 'no-referrer';
+		if (contain) image.style.objectFit = 'contain';
+		article.append(image);
+	};
+
+	const addHeading = (body, title, href) => {
+		const heading = document.createElement('h2');
+		const safe = safeHref(href);
+		if (safe) {
+			const anchor = document.createElement('a');
+			anchor.href = safe;
+			anchor.textContent = title;
+			if (safe.startsWith('https://')) {
+				anchor.target = '_blank';
+				anchor.rel = 'noopener noreferrer';
+			}
+			heading.append(anchor);
+		} else {
+			heading.textContent = title;
+		}
+		body.append(heading);
+	};
+
+	const renderRecord = (record) => {
+		if (!record || typeof record !== 'object') return null;
+		const title = kind === 'model-evals' ? text(record.name) : text(record.title);
+		if (!title) return null;
+		const tags = safeTags(record.tags);
+		const description = text(record.description);
+		const article = document.createElement('article');
+		article.dataset.directoryItem = '';
+
+		let meta = '';
+		let href = null;
+		if (kind === 'highlights') {
+			meta =
+				highlightDate(record) ?? (record.kind === 'highlight_article' ? 'ARTICLE' : 'BOOKMARK');
+			href = safeHref(record.detailUrl) || safeHref(record.originalUrl);
+			addImage(article, record.thumb);
+		} else if (kind === 'prompts') {
+			meta = [text(record.model), text(record.date)].filter(Boolean).join(' · ');
+			href = safeHref(record.detailUrl);
+		} else if (kind === 'model-evals') {
+			meta = [text(record.company), text(record.releaseDate)].filter(Boolean).join(' · ');
+			addImage(article, record.logo, true);
+		} else {
+			return null;
+		}
+
+		article.dataset.search = [title, description, meta, ...tags]
+			.join(' ')
+			.toLocaleLowerCase(locale);
+		const body = document.createElement('div');
+		const metaNode = document.createElement('p');
+		metaNode.className = 'directory-item-meta';
+		metaNode.textContent = meta;
+		body.append(metaNode);
+		addHeading(body, title, href);
+		if (description) {
+			const detail = document.createElement('p');
+			detail.textContent = description;
+			body.append(detail);
+		}
+		if (tags.length) {
+			const tagList = document.createElement('ul');
+			for (const tag of tags) {
+				const item = document.createElement('li');
+				item.textContent = tag;
+				tagList.append(item);
+			}
+			body.append(tagList);
+		}
+		article.append(body);
+		return article;
+	};
+
+	// Highlights are grouped into collapsible year sections, mirroring the
+	// server-rendered daily-archive markup.
+	const renderHighlights = (records) => {
+		const isZh = locale.toLowerCase().startsWith('zh');
+		const monthFormatter = new Intl.DateTimeFormat(locale, {
+			year: 'numeric',
+			month: 'long',
+			timeZone: 'Asia/Shanghai',
+		});
+		const byMonth = new Map();
+		let rendered = 0;
+		for (const record of records) {
+			const article = renderRecord(record);
+			if (!article) continue;
+			const monthKey = (highlightDate(record) || '').slice(0, 7) || null;
+			if (!byMonth.has(monthKey)) byMonth.set(monthKey, []);
+			byMonth.get(monthKey).push({ article, date: highlightDate(record) || '' });
+			rendered += 1;
+		}
+		const monthKeys = [...byMonth.keys()].sort((a, b) => {
+			if (a === null) return 1;
+			if (b === null) return -1;
+			return b.localeCompare(a);
+		});
+		const fragment = document.createDocumentFragment();
+		monthKeys.forEach((monthKey, index) => {
+			const group = document.createElement('details');
+			group.className = 'month-group';
+			if (monthKey !== null && index < 3) group.open = true;
+			const summary = document.createElement('summary');
+			summary.className = 'month-heading';
+			const heading = document.createElement('h2');
+			heading.textContent = monthKey
+				? monthFormatter.format(new Date(`${monthKey}-01T00:00:00+08:00`))
+				: isZh
+					? '未注明日期'
+					: 'Undated';
+			const counter = document.createElement('span');
+			counter.className = 'count';
+			const entries = byMonth.get(monthKey).sort((a, b) => b.date.localeCompare(a.date));
+			counter.textContent = isZh ? `${entries.length} 条` : `${entries.length} items`;
+			summary.append(heading, counter);
+			if (monthKey !== null) {
+				const range = document.createElement('span');
+				range.className = 'range';
+				range.textContent = `${entries.at(-1).date.slice(5)} — ${entries[0].date.slice(5)}`;
+				summary.append(range);
+			}
+			group.append(summary);
+			for (const entry of entries) group.append(entry.article);
+			fragment.append(group);
+		});
+		list.replaceChildren(fragment);
+		if (count) count.textContent = String(rendered);
+		apply();
+	};
+
+	const render = (records) => {
+		if (kind === 'highlights') {
+			renderHighlights(records);
+			return;
+		}
+		const fragment = document.createDocumentFragment();
+		let rendered = 0;
+		for (const record of records) {
+			const article = renderRecord(record);
+			if (!article) continue;
+			fragment.append(article);
+			rendered += 1;
+		}
+		list.replaceChildren(fragment);
+		if (count) count.textContent = String(rendered);
+		apply();
+	};
+
+	fetch(api, { headers: { Accept: 'application/json' } })
+		.then((response) => {
+			if (!response.ok) throw new Error('content library unavailable');
+			return response.json();
+		})
+		.then((payload) => {
+			if (Array.isArray(payload.items)) render(payload.items);
+		})
+		.catch(() => {
+			// Server-rendered legacy content remains the no-JS and outage fallback.
+		});
+})();

--- a/static/js/legacy-directory.js
+++ b/static/js/legacy-directory.js
@@ -19,14 +19,6 @@
       if (match) visible += 1;
     }
     if (empty instanceof HTMLElement) empty.hidden = visible !== 0;
-    // Grouped lists (highlights year groups) collapse a group once every
-    // row inside it has been filtered out.
-    for (const group of root.querySelectorAll("details.month-group")) {
-      const anyVisible = [
-        ...group.querySelectorAll("[data-directory-item]"),
-      ].some((item) => !item.hidden);
-      group.hidden = !anyVisible;
-    }
   };
   input.addEventListener("input", apply);
 
@@ -48,20 +40,6 @@
     Array.isArray(value)
       ? value.filter((tag) => typeof tag === "string" && tag)
       : [];
-
-  // Highlights carry no explicit date. Recover one from dated detail routes,
-  // falling back to the cover upload timestamp in the thumb URL, which marks
-  // when the entry was curated.
-  const highlightDate = (record) => {
-    const fromDetail = /\/highlights\/(\d{4}-\d{2}-\d{2})/.exec(
-      text(record.detailUrl),
-    );
-    if (fromDetail) return fromDetail[1];
-    const fromThumb = /\/(\d{4})(\d{2})(\d{2})\d{9}\.png/.exec(
-      text(record.thumb),
-    );
-    return fromThumb ? `${fromThumb[1]}-${fromThumb[2]}-${fromThumb[3]}` : null;
-  };
 
   const addImage = (article, value, contain = false) => {
     const imageUrl = safeHref(value);
@@ -106,9 +84,7 @@
     let meta = "";
     let href = null;
     if (kind === "highlights") {
-      meta =
-        highlightDate(record) ??
-        (record.kind === "highlight_article" ? "ARTICLE" : "BOOKMARK");
+      meta = record.kind === "highlight_article" ? "ARTICLE" : "BOOKMARK";
       href = safeHref(record.detailUrl) || safeHref(record.originalUrl);
       addImage(article, record.thumb);
     } else if (kind === "prompts") {
@@ -152,74 +128,7 @@
     return article;
   };
 
-  // Highlights are grouped into collapsible year sections, mirroring the
-  // server-rendered daily-archive markup.
-  const renderHighlights = (records) => {
-    const isZh = locale.toLowerCase().startsWith("zh");
-    const monthFormatter = new Intl.DateTimeFormat(locale, {
-      year: "numeric",
-      month: "long",
-      timeZone: "Asia/Shanghai",
-    });
-    const byMonth = new Map();
-    let rendered = 0;
-    for (const record of records) {
-      const article = renderRecord(record);
-      if (!article) continue;
-      const monthKey = (highlightDate(record) || "").slice(0, 7) || null;
-      if (!byMonth.has(monthKey)) byMonth.set(monthKey, []);
-      byMonth
-        .get(monthKey)
-        .push({ article, date: highlightDate(record) || "" });
-      rendered += 1;
-    }
-    const monthKeys = [...byMonth.keys()].sort((a, b) => {
-      if (a === null) return 1;
-      if (b === null) return -1;
-      return b.localeCompare(a);
-    });
-    const fragment = document.createDocumentFragment();
-    monthKeys.forEach((monthKey, index) => {
-      const group = document.createElement("details");
-      group.className = "month-group";
-      if (monthKey !== null && index < 3) group.open = true;
-      const summary = document.createElement("summary");
-      summary.className = "month-heading";
-      const heading = document.createElement("h2");
-      heading.textContent = monthKey
-        ? monthFormatter.format(new Date(`${monthKey}-01T00:00:00+08:00`))
-        : isZh
-          ? "未注明日期"
-          : "Undated";
-      const counter = document.createElement("span");
-      counter.className = "count";
-      const entries = byMonth
-        .get(monthKey)
-        .sort((a, b) => b.date.localeCompare(a.date));
-      counter.textContent = isZh
-        ? `${entries.length} 条`
-        : `${entries.length} items`;
-      summary.append(heading, counter);
-      if (monthKey !== null) {
-        const range = document.createElement("span");
-        range.className = "range";
-        range.textContent = `${entries.at(-1).date.slice(5)} — ${entries[0].date.slice(5)}`;
-        summary.append(range);
-      }
-      group.append(summary);
-      for (const entry of entries) group.append(entry.article);
-      fragment.append(group);
-    });
-    list.replaceChildren(fragment);
-    if (count) count.textContent = String(rendered);
-    apply();
-  };
-
   const render = (records) => {
-    if (kind === "highlights") {
-      renderHighlights(records);
-      return;
-    }
     const fragment = document.createDocumentFragment();
     let rendered = 0;
     for (const record of records) {


### PR DESCRIPTION
## 背景

PR #118（精选阅读月份分组归档）合并后，Automatic Code Release 被部署器拒绝：

```
unsafe_code_release: Code release contains forbidden or unknown path: static/js/legacy-directory.js
```

`static/js/legacy-directory.js` 不在 content-deployer 的可发布路径白名单里（同目录只有 daily-timeline.js 等 5 个文件被显式放行）。

## 改动

不碰生产 Worker 白名单，改为把 Astro 侧脚本移入可发布路径：

- `astro/src/scripts/legacy-directory.js`：Astro 站点专用副本（含月份分组逻辑），由 `LegacyPage.astro` 通过 `<script>import` 交给 Astro 打包（`astro/src/scripts/` 在白名单前缀内）
- `static/js/legacy-directory.js`：恢复为未改动版本，仅留给 Hugo 旧渲染器（与上次发布基线的净 diff 为零，不会再触发拒绝）
- `astro/eslint.config.js`：为 `src/scripts/**/*.js` 补充 browser globals（该文件在部署器 inert 清单内）

行为不变：月份分组、搜索过滤、空组隐藏均与 #118 一致。

## 验证

- `astro check` / `eslint` / vitest（74）/ prettier / 构建全部通过
- 浏览器实测：打包后的 `/_astro/LegacyPage.*.js` 正常加载执行，4 个月份分组渲染、首个展开、搜索过滤正常