### PR TITLE
fix: declutter the highlights archive header

### DIFF
--- a/astro/src/components/LegacyPage.astro
+++ b/astro/src/components/LegacyPage.astro
@@ -259,7 +259,7 @@ const libraryApi =
 					</p>
 				</header>
 
-				{MarkdownContent && (
+				{MarkdownContent && directoryKind !== 'highlights' && (
 					<div class="directory-intro">
 						<MarkdownContent />
 					</div>

--- a/astro/src/styles/legacy-pages.css
+++ b/astro/src/styles/legacy-pages.css
@@ -171,12 +171,54 @@
 	font-size: 0.6rem;
 }
 
-/* Highlights: plain ledger rows inside collapsible year groups, mirroring
+/* Highlights top section: drop the stacked hairlines — the hero ends with
+   whitespace instead of a rule, and the search becomes a quiet boxed field
+   with the icon inside, so the first month heading is the only rule left. */
+.directory-page[data-directory-page='highlights'] .directory-hero {
+	padding-bottom: 8px;
+	border-bottom: 0;
+}
+
+.directory-page[data-directory-page='highlights'] .directory-toolbar {
+	margin-top: 10px;
+	padding: 0;
+	border-block: 0;
+}
+
+.directory-page[data-directory-page='highlights'] .directory-toolbar > div {
+	position: relative;
+	display: block;
+	max-width: 320px;
+}
+
+.directory-page[data-directory-page='highlights'] .directory-toolbar i {
+	position: absolute;
+	top: 50%;
+	left: 10px;
+	transform: translateY(-50%);
+	pointer-events: none;
+}
+
+.directory-page[data-directory-page='highlights'] .directory-toolbar input {
+	min-height: 38px;
+	padding: 4px 10px 4px 32px;
+	border: 1px solid var(--rule);
+	border-radius: 2px;
+	background: var(--paper-raised);
+}
+
+.directory-page[data-directory-page='highlights'] .directory-toolbar input:focus {
+	outline: 1px solid var(--blue);
+	outline-offset: 0;
+}
+
+/* Highlights: plain ledger rows inside collapsible month groups, mirroring
    the daily archive. The `daily-archive` class on the list container supplies
    the month-group/summary styling; these rules cover the rows themselves.
    Scoped so the other directory sections keep the shared card layout. */
 .content-directory--highlights {
 	display: block;
+	margin-top: 22px;
 	border-left: 0;
 }
 


### PR DESCRIPTION
## 改动

精选阅读页上半部分减线重设计（仅作用于 highlights 页面）：

- 去掉引言块（"这里将陆续整理我亲自筛选的…"，其他栏目的引言保留）
- 头部区去掉底部分隔线，改用留白收尾
- 搜索工具条去掉上下边线和输入框下划线，改为盒式输入框（细边框 + 微抬底色，图标收进框内，聚焦蓝色描边）
- 列表容器与搜索框之间补 22px 间距；第一个月份标题的分隔线成为头部唯一横线

## 验证

- `astro check` / `eslint` / prettier / 构建全部通过
- 桌面 / 移动端 / 深色主题截图验证