### PR TITLE
feat: merge social posts into the news category at display level

### DIFF
--- a/astro/src/components/DailyTimeline.astro
+++ b/astro/src/components/DailyTimeline.astro
@@ -6,12 +6,14 @@ import { resolve } from 'node:path';
 import { dailyDateFromKey, formatDailyWeekday, type DailyLocale } from '../lib/daily';
 import {
 	cleanTimelineSummary,
+	displayContentType,
 	formatDailyTime,
 	formatTimelineTime,
 	orderTimelineBatches,
 	timelineDisplayText,
 	timelineSourceDisplay,
 	type DailyContentType,
+	type DailyDisplayContentType,
 	type StructuredDailyReport,
 } from '../lib/structuredDaily';
 import { entitiesById, taxonomyLabel, topicsById } from '../lib/knowledge';
@@ -42,16 +44,11 @@ const itemById = new Map(report.items.map((item) => [item.id, item]));
 const typeLabels: Record<'all' | DailyContentType, string> = isEnglish
 	? { all: 'All', news: 'News', project: 'Projects', paper: 'Papers', socialMedia: 'Social' }
 	: { all: '全部', news: '资讯', project: '项目', paper: '论文', socialMedia: '社交' };
-const typeOrder: Array<'all' | DailyContentType> = [
-	'all',
-	'news',
-	'project',
-	'paper',
-	'socialMedia',
-];
-const typeCounts = new Map<DailyContentType, number>();
+const typeOrder: Array<'all' | DailyDisplayContentType> = ['all', 'news', 'project', 'paper'];
+const typeCounts = new Map<DailyDisplayContentType, number>();
 for (const item of report.items) {
-	typeCounts.set(item.content_type, (typeCounts.get(item.content_type) ?? 0) + 1);
+	const displayType = displayContentType(item);
+	typeCounts.set(displayType, (typeCounts.get(displayType) ?? 0) + 1);
 }
 
 const orderedBatches = orderTimelineBatches(report.batches);
@@ -223,6 +220,7 @@ const olderKey = hrefDateKey(olderHref);
 							items.map((item, index) => {
 								const displayText = timelineDisplayText(item);
 								const source = timelineSourceDisplay(item);
+								const displayType = displayContentType(item);
 								const summary = displayText.summary;
 								const rawSummary = cleanTimelineSummary(item.summary);
 								const sourceSearchTerms = [
@@ -256,7 +254,7 @@ const olderKey = hrefDateKey(olderHref);
 										class={`timeline-item item${item.featured ? ' featured' : ''}`}
 										data-timeline-item
 										data-item-id={item.id}
-										data-content-type={item.content_type}
+										data-content-type={displayType}
 										data-search={searchText}
 										style={`--timeline-index: ${Math.min(index, 10)}`}
 									>
@@ -271,8 +269,8 @@ const olderKey = hrefDateKey(olderHref);
 													)}
 													<span>{source.name}</span>
 												</span>
-												{item.content_type !== 'socialMedia' && (
-													<span class="badge">{typeLabels[item.content_type]}</span>
+												{displayType !== 'news' && (
+													<span class="badge">{typeLabels[displayType]}</span>
 												)}
 												{item.featured && (
 													<span class="badge featured-badge">

--- a/astro/src/components/KnowledgeResults.astro
+++ b/astro/src/components/KnowledgeResults.astro
@@ -1,6 +1,7 @@
 ---
 import type { KnowledgeSearchItem } from '../lib/searchIndex';
 import { entitiesById, taxonomyLabel, topicsById } from '../lib/knowledge';
+import { displayContentType } from '../lib/structuredDaily';
 
 interface Props {
 	items: KnowledgeSearchItem[];
@@ -12,7 +13,7 @@ const typeLabels = {
 	news: '资讯',
 	project: '项目',
 	paper: '论文',
-	socialMedia: '社交',
+	socialMedia: '资讯',
 };
 ---
 
@@ -29,7 +30,7 @@ const typeLabels = {
 				<article
 					class="knowledge-result"
 					data-knowledge-search-item={filterable ? '' : undefined}
-					data-content-type={filterable ? item.content_type : undefined}
+					data-content-type={filterable ? displayContentType(item) : undefined}
 					data-topics={filterable ? item.topic_ids.join(' ') : undefined}
 					data-entities={filterable ? item.entity_ids.join(' ') : undefined}
 					data-search={filterable ? item.search_text : undefined}

--- a/astro/src/components/QuietIndexHome.astro
+++ b/astro/src/components/QuietIndexHome.astro
@@ -11,6 +11,7 @@ import {
 import { taxonomyLabel, topicsById } from '../lib/knowledge';
 import {
 	cleanTimelineSummary,
+	displayContentType,
 	formatDailyTime,
 	formatTimelineTime,
 	homepageFeedItems,
@@ -217,7 +218,7 @@ const previousDays = (
 												)}
 												<span>{source.name}</span>
 											</span>
-											{item.content_type !== 'socialMedia' && (
+											{displayContentType(item) !== 'news' && (
 												<span class="badge">{typeLabels[item.content_type]}</span>
 											)}
 										</div>

--- a/astro/src/lib/structuredDaily.ts
+++ b/astro/src/lib/structuredDaily.ts
@@ -13,6 +13,16 @@ import { validateDailyReportSchemaForAstro } from './dailySchema';
 export type DailyBatchId = 'morning' | 'afternoon' | 'night' | 'lateNight';
 export type DailyContentType = 'news' | 'project' | 'paper' | 'socialMedia';
 
+// Display-level taxonomy: socialMedia merges into news (X posts are largely news
+// content), so the site only distinguishes news / project / paper.
+export type DailyDisplayContentType = 'news' | 'project' | 'paper';
+
+export function displayContentType(
+	item: Pick<StructuredDailyItem, 'content_type'>,
+): DailyDisplayContentType {
+	return item.content_type === 'socialMedia' ? 'news' : item.content_type;
+}
+
 export interface StructuredDailyItem {
 	id: string;
 	event_id: string;

--- a/astro/src/pages/search/index.astro
+++ b/astro/src/pages/search/index.astro
@@ -48,7 +48,6 @@ const entities = activeTaxonomyRecords(knowledgeTaxonomy.entities);
 					<option value="news">资讯</option>
 					<option value="project">项目</option>
 					<option value="paper">论文</option>
-					<option value="socialMedia">社交</option>
 				</select>
 			</div>
 			<div class="knowledge-filter-field">

--- a/static/js/daily-timeline.js
+++ b/static/js/daily-timeline.js
@@ -1,4 +1,4 @@
-const VALID_TYPES = new Set(["all", "news", "project", "paper", "socialMedia"]);
+const VALID_TYPES = new Set(["all", "news", "project", "paper"]);
 
 export function parseTimelineState(search = "") {
   const params = new URLSearchParams(search);

--- a/static/js/knowledge-search.js
+++ b/static/js/knowledge-search.js
@@ -1,4 +1,4 @@
-const VALID_TYPES = new Set(["all", "news", "project", "paper", "socialMedia"]);
+const VALID_TYPES = new Set(["all", "news", "project", "paper"]);
 
 function normalized(value) {
   return String(value || "").normalize("NFKC").trim().toLocaleLowerCase();
@@ -45,6 +45,7 @@ export function normalizeHistoricalSearchResult(result) {
   const sourceName = String(item.source?.name || item.source_name || "");
   const topicIds = Array.isArray(item.topic_ids) ? item.topic_ids.map(String) : [];
   const entityIds = Array.isArray(item.entity_ids) ? item.entity_ids.map(String) : [];
+  const rawContentType = String(item.content_type || "news");
   return {
     id,
     date,
@@ -52,7 +53,8 @@ export function normalizeHistoricalSearchResult(result) {
     title: String(item.title || ""),
     summary: String(item.summary || ""),
     sourceName,
-    contentType: String(item.content_type || "news"),
+    // socialMedia merges into news at display level.
+    contentType: rawContentType === "socialMedia" ? "news" : rawContentType,
     topicIds,
     entityIds,
     searchText: [item.title, item.summary, sourceName].map(String).join(" "),
@@ -140,7 +142,6 @@ function initKnowledgeSearch(root) {
       news: "资讯",
       project: "项目",
       paper: "论文",
-      socialMedia: "社交",
     };
     for (const value of values) {
       const article = document.createElement("article");


### PR DESCRIPTION
## 改动

X 上很多帖子本质就是资讯，读者关心内容而非载体。本次在**展示层**把 `socialMedia` 合并进 `news`，数据管线与历史报告保持原样（随时可逆）。

- 日报页筛选条：去掉「社交」，「资讯」计数 = news + socialMedia（今日 82 = 49 + 33）
- 徽章只为「项目 / 论文」保留；资讯（含 X 帖子）不再戴徽章（日报时间线 + 首页今日流一致）
- 搜索页：类型筛选去掉「社交」，选「资讯」同时命中静态索引与 release-pinned API 结果里的 X 帖子
- 旧链接 `?type=socialMedia` 优雅回落到「全部」

## 验证

- `astro check` 0 错误；eslint 通过；astro 74 tests + 根目录 576 tests 全绿
- 本地构建 + 浏览器实测：点「资讯」筛选显示 82 条，其中 33 条 X 帖子正确并入；搜索页标签列正确

🤖 Generated with Kimi Code