### PR TITLE
feat: drop the 48-char cap on AI editorial headlines

### DIFF
--- a/astro/src/lib/structuredDaily.test.ts
+++ b/astro/src/lib/structuredDaily.test.ts
@@ -192,7 +192,7 @@ describe('timeline batch order', () => {
 });
 
 describe('timeline editorial compatibility', () => {
-	it('compacts legacy social posts and removes their duplicated raw summary', () => {
+	it('keeps Chinese social posts whole and removes their duplicated raw summary', () => {
 		const item = {
 			content_type: 'socialMedia',
 			title:
@@ -202,7 +202,8 @@ describe('timeline editorial compatibility', () => {
 		} as StructuredDailyItem;
 
 		expect(timelineDisplayText(item)).toEqual({
-			title: 'FDE 就是模型公司的阳谋：先让人去帮企业落地 Agent 卖 Token',
+			title:
+				'FDE 就是模型公司的阳谋：先让人去帮企业落地 Agent 卖 Token，把企业知识沉淀成 Skills，然后把这些 Skills 内化到模型。接下来企业就不需要那么多人了。',
 			summary: '',
 		});
 	});

--- a/src/daily/editorial.js
+++ b/src/daily/editorial.js
@@ -8,6 +8,11 @@ const SOCIAL_CONTENT_TYPE = 'socialMedia';
 const DEFAULT_BATCH_SIZE = 30;
 const MAX_BATCH_SIZE = 40;
 const MAX_HEADLINE_LENGTH = 48;
+// Safety rail, not a display limit: the report schema bounds titles at 500
+// chars, so fallback titles derived from long-form sources (X articles with
+// multi-thousand-char summaries) must stay inside that budget. Real AI
+// headlines are ~50 chars and never reach this.
+const MAX_SOURCE_HEADLINE_LENGTH = 480;
 const MAX_SUMMARY_LENGTH = 160;
 const MAX_EDITORIAL_CONCURRENCY = 3;
 const URL_PATTERN = /https?:\/\/\S+|www\.\S+/giu;
@@ -78,8 +83,10 @@ function compactLatinText(value, maxLength) {
 
 /**
  * Rendering-safe fallback for legacy social posts and model failures.
- * It deliberately chooses a complete leading clause instead of adding an
- * ellipsis, so the visible headline reads as a statement rather than a teaser.
+ * Latin-heavy (untranslated) text is clipped to a complete leading clause so
+ * the visible headline reads as a statement rather than a teaser; Chinese
+ * text passes through whole — validated AI headlines are complete statements
+ * and must not be cut mid-thought.
  */
 export function compactEditorialTitle(title, summary = '') {
     const source = sourceTextForHeadline(title, summary);
@@ -88,20 +95,21 @@ export function compactEditorialTitle(title, summary = '') {
 
     const mostlyLatin = (source.match(/[\u0000-\u024f]/gu)?.length || 0) / points.length > 0.72;
     if (mostlyLatin) return compactLatinText(source, 72);
-
-    const window = points.slice(0, MAX_HEADLINE_LENGTH + 1).join('');
+    if (points.length <= MAX_SOURCE_HEADLINE_LENGTH) return source;
+    // Extreme long-form sources: clip at the last full sentence in the window
+    // to stay within the schema's 500-char title budget.
+    const window = points.slice(0, MAX_SOURCE_HEADLINE_LENGTH + 1).join('');
     const sentenceBoundaries = [...window.matchAll(/[。！？!?]/gu)]
         .map(match => match.index + match[0].length)
         .filter(index => index >= 14);
     if (sentenceBoundaries.length > 0) {
         return window.slice(0, sentenceBoundaries.at(-1)).trim();
     }
-
-    const clauseBoundaries = [...window.matchAll(/[，,；;]/gu)]
-        .map(match => match.index)
-        .filter(index => index >= 24);
-    const end = clauseBoundaries.at(-1) || MAX_HEADLINE_LENGTH;
-    return points.slice(0, end).join('').replace(/[，,：:；;\s]+$/u, '').trim();
+    return points
+        .slice(0, MAX_SOURCE_HEADLINE_LENGTH)
+        .join('')
+        .replace(/[，,：:；;\s]+$/u, '')
+        .trim();
 }
 
 export function compactEditorialSummary(summary, maxLength = MAX_SUMMARY_LENGTH) {
@@ -139,7 +147,10 @@ export function normalizeEditorialHeadline(value) {
         .replace(/^[“”"']+|[“”"']+$/gu, '')
         .trim();
     const length = codePoints(cleaned).length;
-    if (length < 10 || length > MAX_HEADLINE_LENGTH) return null;
+    // No display-driven length cap (49-char Chinese headlines are fine), only
+    // a schema guard: the report bounds titles at 500 chars, so pathological
+    // output beyond the safety rail falls back to the deterministic path.
+    if (length < 10 || length > MAX_SOURCE_HEADLINE_LENGTH) return null;
     if (!HAN_PATTERN.test(cleaned)) return null;
     if (/^(?:RT|Re)\s+/iu.test(cleaned)) return null;
     if (ELLIPSIS_PATTERN.test(cleaned) || INCOMPLETE_HEADLINE_ENDING.test(cleaned)) return null;
@@ -173,7 +184,6 @@ export function editorialNeedsEnrichment(item) {
         || /^(?:RT|Re)\s+/iu.test(title)
         || ELLIPSIS_PATTERN.test(title)
         || INCOMPLETE_HEADLINE_ENDING.test(title)
-        || codePoints(title).length > MAX_HEADLINE_LENGTH
     );
 }
 

--- a/tests/worker/editorial.test.js
+++ b/tests/worker/editorial.test.js
@@ -37,11 +37,20 @@ async function build(rawItems = [socialItem()]) {
 }
 
 describe('structured daily editorial enrichment', () => {
-    it('turns a long social post into a complete one-line fallback', () => {
+    it('keeps Chinese social posts whole instead of truncating them', () => {
         const title = compactEditorialTitle(socialItem().title, socialItem().description);
-        expect(title).toBe('FDE 就是模型公司的阳谋：先让人去帮企业落地 Agent 卖 Token');
-        expect(Array.from(title).length).toBeLessThanOrEqual(48);
+        expect(title).toBe(socialItem().description);
         expect(title).not.toMatch(/[…,.，]$/u);
+    });
+
+    it('bounds extreme long-form sources within the schema title budget', () => {
+        const sentence = '这一句话用来填充长文内容，验证截断行为是否合规。';
+        const longText = `${sentence.repeat(20)}${'尾巴'.repeat(200)}`;
+        const title = compactEditorialTitle('', longText);
+        expect(Array.from(title).length).toBeLessThanOrEqual(480);
+        expect(title).toContain('验证截断行为是否合规');
+        expect(normalizeEditorialHeadline(`${'长'.repeat(481)}`)).toBeNull();
+        expect(normalizeEditorialHeadline(`${'长'.repeat(480)}`)).toBe('长'.repeat(480));
     });
 
     it('cleans RT prefixes, links, boilerplate, and long summaries', () => {
@@ -63,11 +72,15 @@ describe('structured daily editorial enrichment', () => {
     it('accepts complete Chinese output and rejects untranslated or teaser-shaped output', () => {
         expect(normalizeEditorialHeadline('FDE 的阳谋：借企业落地沉淀模型能力'))
             .toBe('FDE 的阳谋：借企业落地沉淀模型能力');
+        // Long Chinese headlines are accepted — no upper length cap.
+        expect(normalizeEditorialHeadline(
+            'OpenAI具备网络能力的模型通过发现并利用多个零日漏洞成功入侵了Hugging Face生产环境',
+        )).toBe('OpenAI具备网络能力的模型通过发现并利用多个零日漏洞成功入侵了Hugging Face生产环境');
+        expect(normalizeEditorialHeadline(`${'过'.repeat(73)}`)).toBe('过'.repeat(73));
         expect(normalizeEditorialHeadline('RT 作者：这是一条仍带转发前缀的标题')).toBeNull();
         expect(normalizeEditorialHeadline('ChatGPT Work runs in the cloud from mobile')).toBeNull();
         expect(normalizeEditorialHeadline('ChatGPT Work 可在云端运行…')).toBeNull();
         expect(normalizeEditorialHeadline('ChatGPT Work 的主要优势是：')).toBeNull();
-        expect(normalizeEditorialHeadline(`${'过'.repeat(73)}`)).toBeNull();
         expect(normalizeEditorialSummary('ChatGPT Work runs in the cloud from mobile.')).toBeNull();
         expect(normalizeEditorialSummary('ChatGPT Work 可在云端持续运行，用户合上电脑后仍能从手机继续任务。'))
             .not.toBeNull();
@@ -254,7 +267,7 @@ describe('structured daily editorial enrichment', () => {
         );
         const bySource = Object.fromEntries(result.report.items.map(item => [item.source_type, item]));
 
-        expect(bySource.twitter.title).toBe('FDE 就是模型公司的阳谋：先让人去帮企业落地 Agent 卖 Token');
+        expect(bySource.twitter.title).toBe(socialItem().description);
         expect(bySource.aibase.title).toBe('A concise news headline');
         expect(result.metrics).toMatchObject({ editorial_ai_count: 0, editorial_fallback_count: 1 });
     });


### PR DESCRIPTION
## 问题

改写校验器把超过 48 码点的中文标题整条拒绝，但提示词要求「18-38 个汉字」——密集的英文产品名（OpenAI、Hugging Face、MiaoYan）让合规标题轻易达到 49-56 码点。每次拒绝都把好端端的译文打回英文截断兜底，且无反馈的重试只会再次超长——这就是部分 X 帖子停留在英文的原因（今晨 16 条社交帖中 3 条因此残留英文）。

复现确认（同款提示词 + 同款模型）：三条失败条目返回的均为合格中文标题，仅超 1-2 个码点被拒；重试反而更长。

## 改动

- `normalizeEditorialHeadline`：去掉长度上限（保留下限 10、必须含汉字、禁省略号、禁不完整结尾）
- `editorialNeedsEnrichment`：同步去掉长度条件，避免已接受的长标题被反复重写
- `compactEditorialTitle`：中文标题完整展示（与 news 标题一致）；英文原文 72 字符截断保留
- 新增 480 字符安全轨（对应 schema 标题 500 上限），防止超长源文本（X 长文数千字符摘要）在兜底路径顶破 schema 导致整批改写降级

## 验证

- 根目录 577 tests + astro 74 tests 全绿；`worker:check` 干跑通过
- 真实模型回归：今晨 3 条失败条目在新规则下首轮全部通过，标题完整

注：worker 已由仓库所有者本地 `wrangler deploy` 部署过本改动的前身（无 480 安全轨版本）；合并后建议重新 deploy 一次以带上安全轨。