### PR TITLE
feat: log why editorial headlines fall back to the deterministic path

### DIFF
--- a/src/daily/editorial.js
+++ b/src/daily/editorial.js
@@ -141,20 +141,28 @@ function parseEditorialResponse(value) {
     return Array.isArray(parsed) ? parsed : Array.isArray(parsed?.items) ? parsed.items : [];
 }
 
-export function normalizeEditorialHeadline(value) {
+function editorialHeadlineRejectReasons(value) {
     const cleaned = cleanEditorialText(value)
         .replace(/^(?:标题|headline)\s*[:：]\s*/iu, '')
         .replace(/^[“”"']+|[“”"']+$/gu, '')
         .trim();
     const length = codePoints(cleaned).length;
+    const reasons = [];
     // No display-driven length cap (49-char Chinese headlines are fine), only
     // a schema guard: the report bounds titles at 500 chars, so pathological
     // output beyond the safety rail falls back to the deterministic path.
-    if (length < 10 || length > MAX_SOURCE_HEADLINE_LENGTH) return null;
-    if (!HAN_PATTERN.test(cleaned)) return null;
-    if (/^(?:RT|Re)\s+/iu.test(cleaned)) return null;
-    if (ELLIPSIS_PATTERN.test(cleaned) || INCOMPLETE_HEADLINE_ENDING.test(cleaned)) return null;
-    return cleaned;
+    if (length < 10) reasons.push('too_short');
+    if (length > MAX_SOURCE_HEADLINE_LENGTH) reasons.push('too_long');
+    if (!HAN_PATTERN.test(cleaned)) reasons.push('no_han');
+    if (/^(?:RT|Re)\s+/iu.test(cleaned)) reasons.push('rt_prefix');
+    if (ELLIPSIS_PATTERN.test(cleaned)) reasons.push('ellipsis');
+    if (INCOMPLETE_HEADLINE_ENDING.test(cleaned)) reasons.push('incomplete_ending');
+    return { cleaned, reasons };
+}
+
+export function normalizeEditorialHeadline(value) {
+    const { cleaned, reasons } = editorialHeadlineRejectReasons(value);
+    return reasons.length === 0 ? cleaned : null;
 }
 
 export function normalizeEditorialSummary(value) {
@@ -305,6 +313,20 @@ export async function applyEditorialEnrichment(
         const generatedItem = generatedById.get(item.id);
         const generatedTitle = normalizeEditorialHeadline(generatedItem?.title);
         const generatedSummary = normalizeEditorialSummary(generatedItem?.summary);
+        if (!generatedTitle) {
+            // Per-item validation failures are otherwise silent: log exactly
+            // which rule rejected the model's headline so production fallbacks
+            // can be diagnosed from worker logs.
+            const diagnosis = generatedItem
+                ? editorialHeadlineRejectReasons(generatedItem.title)
+                : { cleaned: '', reasons: ['missing_from_response'] };
+            console.warn('[StructuredDaily] editorial headline rejected; using deterministic fallback', {
+                itemId: item.id,
+                reasons: diagnosis.reasons,
+                rejectedTitle: codePoints(diagnosis.cleaned).slice(0, 160).join(''),
+                summaryAccepted: Boolean(generatedSummary),
+            });
+        }
         const fallbackTitle = compactEditorialTitle(item.title, item.summary)
             || String(item.title || '').trim();
         cache.set(item.id, {

--- a/tests/worker/editorial.test.js
+++ b/tests/worker/editorial.test.js
@@ -271,4 +271,37 @@ describe('structured daily editorial enrichment', () => {
         expect(bySource.aibase.title).toBe('A concise news headline');
         expect(result.metrics).toMatchObject({ editorial_ai_count: 0, editorial_fallback_count: 1 });
     });
+
+    it('logs the rejection reasons and the rejected headline on fallback', async () => {
+        const original = await build();
+        const id = original.report.items[0].id;
+        const generate = vi.fn(async () => JSON.stringify({
+            items: [{
+                id,
+                title: 'ChatGPT Work runs in the cloud from mobile',
+                summary: '任务在云端持续运行，用户合上电脑后仍能从手机继续处理。',
+            }],
+        }));
+        const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        try {
+            const result = await applyEditorialEnrichment(
+                { DAILY_EDITORIAL_ENRICHMENT_ENABLED: 'true' },
+                original,
+                { itemIds: [id], generate },
+            );
+
+            expect(result.metrics).toMatchObject({ editorial_ai_count: 0, editorial_fallback_count: 1 });
+            expect(warn).toHaveBeenCalledWith(
+                '[StructuredDaily] editorial headline rejected; using deterministic fallback',
+                expect.objectContaining({
+                    itemId: id,
+                    reasons: ['no_han'],
+                    rejectedTitle: 'ChatGPT Work runs in the cloud from mobile',
+                    summaryAccepted: true,
+                }),
+            );
+        } finally {
+            warn.mockRestore();
+        }
+    });
 });


### PR DESCRIPTION
## 背景

今天 4 条社交帖在改写后仍落回英文兜底（中文摘要合格、标题被判不合格）。本地用生产同构的提示词/输入/模型配置复现（2 条、4 条、19 条大批次）**全部通过**，无法复现失败——而代码里单条校验失败是完全静默的（只有 chunk 级错误有日志），生产上无从得知标题被哪条规则拒绝。

## 改动

- 兜底时输出诊断日志：条目 id、触犯的规则（`too_short` / `too_long` / `no_han` / `rt_prefix` / `ellipsis` / `incomplete_ending` / `missing_from_response`）、被拒绝的标题原文（截 160 字符）、摘要是否被接受
- `normalizeEditorialHeadline` 重构为复用同一个原因计算函数，校验器与诊断逻辑永不漂移

部署后，worker 日志里搜 `editorial headline rejected` 即可看到每条兜底的确切原因。

## 验证

- 新增测试断言日志内容（id / reasons / rejectedTitle / summaryAccepted）
- 根目录 578 tests 全绿；`worker:check` 干跑通过