### PR TITLE
feat: rebuild daily archive as calendar with month and year views

### DIFF
--- a/astro/src/components/DailyArchive.astro
+++ b/astro/src/components/DailyArchive.astro
@@ -9,6 +9,7 @@ import {
 	type DailyEntryIdentity,
 	type DailyLocale,
 } from '../lib/daily';
+import { buildMonthGrid, heatScale, longestIssueStreak, pad2 } from '../lib/dailyCalendar';
 import { taxonomyLabel, topicsById } from '../lib/knowledge';
 import {
 	cleanTimelineSummary,
@@ -49,7 +50,7 @@ await Promise.all(
 		}),
 );
 
-const topTopicLabels = (report: StructuredDailyReport, limit: number): string[] => {
+const topTopicIds = (report: StructuredDailyReport, limit: number): string[] => {
 	const counts = new Map<string, number>();
 	for (const item of report.items) {
 		for (const topicId of item.topic_ids) {
@@ -58,15 +59,11 @@ const topTopicLabels = (report: StructuredDailyReport, limit: number): string[] 
 	}
 	return [...counts.entries()]
 		.sort((a, b) => b[1] - a[1])
-		.map(([id]) => topicsById.get(id))
-		.filter((topic) => topic !== undefined)
-		.slice(0, limit)
-		.map((topic) => taxonomyLabel(topic, locale));
+		.map(([id]) => id)
+		.filter((id) => topicsById.has(id))
+		.slice(0, limit);
 };
 
-const latestRow = rows[0] ?? null;
-const latestReport = latestRow ? (reportByDate.get(latestRow.identity.dateKey) ?? null) : null;
-const latestDate = latestRow ? dailyDateFromKey(latestRow.identity.dateKey) : null;
 const monthDayFormatter = new Intl.DateTimeFormat(locale, {
 	month: 'long',
 	day: 'numeric',
@@ -77,17 +74,107 @@ const monthFormatter = new Intl.DateTimeFormat(locale, {
 	month: 'long',
 	timeZone: 'Asia/Shanghai',
 });
+const shortMonthFormatter = new Intl.DateTimeFormat(locale, {
+	month: 'short',
+	timeZone: 'Asia/Shanghai',
+});
+const numberFormatter = new Intl.NumberFormat(locale);
 
-const heroTopics = latestReport ? topTopicLabels(latestReport, 4) : [];
-const heroLead = latestReport
-	? (latestReport.items.find((item) => item.featured) ?? latestReport.items[0] ?? null)
-	: null;
-const firstCompletedAt = latestReport
-	? (latestReport.batches
-			.filter((batch) => batch.status === 'completed' && batch.generated_at)
-			.map((batch) => batch.generated_at!)
-			.sort()[0] ?? latestReport.generated_at)
-	: null;
+/* ---------- per-day view model ---------- */
+
+interface DayInfo {
+	dateKey: string;
+	href: string;
+	count: number | null;
+	topicIds: string[];
+	topicLabels: string[];
+	headline: string;
+	meta: string | null;
+	dateLabel: string;
+	weekdayLong: string;
+}
+
+const infoByDate = new Map<string, DayInfo>();
+for (const row of rows) {
+	const { dateKey } = row.identity;
+	const report = reportByDate.get(dateKey) ?? null;
+	const date = dailyDateFromKey(dateKey);
+	const lead = report ? (report.items.find((item) => item.featured) ?? report.items[0] ?? null) : null;
+	const topicIds = report ? topTopicIds(report, 4) : [];
+	const firstCompletedAt = report
+		? (report.batches
+				.filter((batch) => batch.status === 'completed' && batch.generated_at)
+				.map((batch) => batch.generated_at!)
+				.sort()[0] ?? report.generated_at)
+		: null;
+	infoByDate.set(dateKey, {
+		dateKey,
+		href: row.href,
+		count: report ? report.items.length : null,
+		topicIds,
+		topicLabels: topicIds.map((id) => taxonomyLabel(topicsById.get(id)!, locale)),
+		headline:
+			report && lead ? cleanTimelineSummary(lead.title) || lead.title : row.entry.data.title,
+		meta: report
+			? isEnglish
+				? `${report.items.length} items · published ${formatDailyTime(firstCompletedAt!, locale)}`
+				: `${report.items.length} 条收录 · ${formatDailyTime(firstCompletedAt!, locale)} 发布`
+			: null,
+		dateLabel: monthDayFormatter.format(date),
+		weekdayLong: formatDailyWeekday(date, locale, 'long'),
+	});
+}
+
+/* ---------- calendar models ---------- */
+
+const todayKey =
+	process.env.SITE_DISPLAY_DATE && /^\d{4}-\d{2}-\d{2}$/.test(process.env.SITE_DISPLAY_DATE)
+		? process.env.SITE_DISPLAY_DATE
+		: null;
+const latestKey = rows[0]?.identity.dateKey ?? null;
+const selectedKey = latestKey;
+const initialMonthKey = latestKey ? latestKey.slice(0, 7) : null;
+const initialYear = initialMonthKey ? initialMonthKey.slice(0, 4) : null;
+
+interface CellVM {
+	kind: 'adjacent' | 'day';
+	day: number;
+	dateKey: string | null;
+	info: DayInfo | null;
+	heat: number;
+	isToday: boolean;
+	isFuture: boolean;
+	isSelected: boolean;
+}
+
+const cellVM = (dateKey: string | null, day: number, kind: CellVM['kind'], heat: number): CellVM => ({
+	kind,
+	day,
+	dateKey,
+	info: dateKey ? (infoByDate.get(dateKey) ?? null) : null,
+	heat,
+	isToday: dateKey !== null && dateKey === todayKey,
+	isFuture: todayKey !== null && dateKey !== null && dateKey > todayKey,
+	isSelected: dateKey !== null && dateKey === selectedKey,
+});
+
+const statsLabel = (issueCount: number, total: number | null): string => {
+	if (isEnglish) {
+		return total !== null
+			? `${issueCount} issues · ${numberFormatter.format(total)} items`
+			: `${issueCount} issues`;
+	}
+	return total !== null
+		? `${issueCount} 期 · 共 ${numberFormatter.format(total)} 条`
+		: `${issueCount} 期`;
+};
+
+// Rows are newest-first; totals are only meaningful when every issue in the
+// scope has a structured count (the pre-cutover archive has none).
+const countedTotal = (infos: DayInfo[]): number | null =>
+	infos.length > 0 && infos.every((info) => info.count !== null)
+		? infos.reduce((sum, info) => sum + (info.count ?? 0), 0)
+		: null;
 
 interface MonthGroup {
 	monthKey: string;
@@ -101,17 +188,165 @@ for (const row of rows) {
 	else groups.push({ monthKey, rows: [row] });
 }
 
-// Every month renders as a <details> group so it can be collapsed/expanded;
-// the latest three default to open, older ones start collapsed.
-const shiftMonth = (monthKey: string, delta: number): string => {
-	const [year, month] = monthKey.split('-').map(Number);
-	const total = year * 12 + (month - 1) + delta;
-	return `${Math.floor(total / 12)}-${String((total % 12) + 1).padStart(2, '0')}`;
+interface MonthVM {
+	key: string;
+	title: string;
+	stats: string;
+	cells: CellVM[];
+	hidden: boolean;
+}
+
+// Month view normalizes heat within each month so a slow month still reads.
+const monthVMs: MonthVM[] = groups.map((group) => {
+	const [year, month] = group.monthKey.split('-').map(Number);
+	const infos = group.rows.map((row) => infoByDate.get(row.identity.dateKey)!);
+	const heat = heatScale(infos.map((info) => info.count));
+	return {
+		key: group.monthKey,
+		title: monthFormatter.format(dailyDateFromKey(`${group.monthKey}-01`)),
+		stats: statsLabel(infos.length, countedTotal(infos)),
+		cells: buildMonthGrid(year, month).map((cell) =>
+			cellVM(cell.dateKey, cell.day, cell.kind, cell.dateKey ? heat(infoByDate.get(cell.dateKey)?.count ?? null) : 0),
+		),
+		hidden: group.monthKey !== initialMonthKey,
+	};
+});
+
+interface MiniVM {
+	key: string;
+	name: string;
+	issueCount: number;
+	hasData: boolean;
+	cells: CellVM[];
+}
+
+interface YearVM {
+	year: string;
+	title: string;
+	stats: string;
+	minis: MiniVM[];
+	longestStreak: number;
+	biggestCount: number | null;
+	biggestLabel: string | null;
+	hidden: boolean;
+}
+
+// Year view uses one scale per year so months stay comparable (the "global
+// ruler" rule from the design notes; month view uses per-month scaling).
+const yearKeys = [...new Set(groups.map((group) => group.monthKey.slice(0, 4)))];
+const yearVMs: YearVM[] = yearKeys.map((year) => {
+	const yearInfos = rows
+		.filter((row) => row.identity.dateKey.startsWith(`${year}-`))
+		.map((row) => infoByDate.get(row.identity.dateKey)!);
+	const heat = heatScale(yearInfos.map((info) => info.count));
+	const minis: MiniVM[] = [];
+	for (let month = 1; month <= 12; month++) {
+		const key = `${year}-${pad2(month)}`;
+		const issueCount = yearInfos.filter((info) => info.dateKey.startsWith(key)).length;
+		minis.push({
+			key,
+			name: shortMonthFormatter.format(dailyDateFromKey(`${key}-01`)),
+			issueCount,
+			hasData: issueCount > 0,
+			cells: buildMonthGrid(Number(year), month).map((cell) =>
+				cellVM(
+					cell.dateKey,
+					cell.day,
+					cell.kind,
+					cell.dateKey ? heat(infoByDate.get(cell.dateKey)?.count ?? null) : 0,
+				),
+			),
+		});
+	}
+	let biggest: { count: number; label: string } | null = null;
+	for (const info of yearInfos) {
+		if (info.count !== null && (biggest === null || info.count > biggest.count)) {
+			biggest = { count: info.count, label: info.dateLabel };
+		}
+	}
+	return {
+		year,
+		title: isEnglish ? year : `${year}年`,
+		stats: statsLabel(yearInfos.length, countedTotal(yearInfos)),
+		minis,
+		longestStreak: longestIssueStreak(yearInfos.map((info) => info.dateKey)),
+		biggestCount: biggest?.count ?? null,
+		biggestLabel: biggest?.label ?? null,
+		hidden: year !== initialYear,
+	};
+});
+
+/* ---------- topic colors + JSON payload ---------- */
+
+const TOPIC_DOT_CLASS: Record<string, string> = {
+	topic_models: 'cat-models',
+	topic_agents: 'cat-agents',
+	topic_research: 'cat-research',
+	topic_products: 'cat-products',
+	topic_business: 'cat-business',
+	topic_policy: 'cat-policy',
+	topic_open_source: 'cat-oss',
+	topic_other: 'cat-other',
 };
-const expandedCutoff = latestRow ? shiftMonth(latestRow.identity.dateKey.slice(0, 7), -2) : null;
+const dotClass = (topicId: string): string => TOPIC_DOT_CLASS[topicId] ?? 'cat-other';
+const legendTopics = [...topicsById.values()].filter((topic) => topic.status === 'active');
+
+const dowLabels = isEnglish
+	? ['M', 'T', 'W', 'T', 'F', 'S', 'S']
+	: ['一', '二', '三', '四', '五', '六', '日'];
+
+const labels = isEnglish
+	? {
+			latestKicker: 'Latest issue',
+			issueKicker: 'Selected issue',
+			noIssueKicker: 'Selected date',
+			topStory: 'Top story',
+			readIssue: 'Read this issue →',
+			noIssue: 'No issue was published on this day.',
+			goLatest: 'View the latest issue →',
+		}
+	: {
+			latestKicker: '最新一期 · Latest',
+			issueKicker: '所选一期 · Issue',
+			noIssueKicker: '所选日期',
+			topStory: '今日头条',
+			readIssue: '阅读本期 →',
+			noIssue: '这一天没有发布日报。',
+			goLatest: '查看最近一期 →',
+		};
+
+const payload = {
+	today: todayKey,
+	latest: latestKey,
+	selected: selectedKey,
+	initialMonth: initialMonthKey,
+	initialYear,
+	labels,
+	months: Object.fromEntries(monthVMs.map((vm) => [vm.key, { title: vm.title, stats: vm.stats }])),
+	years: Object.fromEntries(yearVMs.map((vm) => [vm.year, { title: vm.title, stats: vm.stats }])),
+	issues: Object.fromEntries(
+		[...infoByDate.values()].map((info) => [
+			info.dateKey,
+			{
+				href: info.href,
+				dateLabel: info.dateLabel,
+				weekday: info.weekdayLong,
+				topics: info.topicLabels,
+				headline: info.headline,
+				meta: info.meta,
+			},
+		]),
+	),
+};
+// `</script>` inside headlines must not be able to close the data block.
+const payloadJson = JSON.stringify(payload).replace(/</g, '\\u003c');
+
+const selectedInfo = selectedKey ? (infoByDate.get(selectedKey) ?? null) : null;
+const countTitle = (count: number): string =>
+	isEnglish ? `${count} items` : `${count} 条收录`;
 ---
 
-<section class="page-shell daily-archive">
+<section class="page-shell daily-archive" data-daily-calendar data-locale={locale}>
 	<header class="page-heading">
 		<h1>{isEnglish ? 'Daily Brief' : '资讯日报'}</h1>
 		<p>
@@ -123,86 +358,224 @@ const expandedCutoff = latestRow ? shiftMonth(latestRow.identity.dateKey.slice(0
 		</p>
 	</header>
 
-	{
-		latestRow && latestDate && (
-			<a class="archive-hero" href={latestRow.href}>
-				<p class="archive-hero-label">{isEnglish ? 'Latest issue' : '最新一期 · Latest'}</p>
-				<p class="archive-hero-date">
-					{monthDayFormatter.format(latestDate)}
-					<span class="weekday">{formatDailyWeekday(latestDate, locale)}</span>
-				</p>
-				{latestReport ? (
-					<>
-						{heroTopics.length > 0 && (
-							<ul class="archive-hero-topics">
-								{heroTopics.map((label) => (
-									<li>{label}</li>
-								))}
-							</ul>
-						)}
-						{heroLead && (
-							<p class="archive-hero-headline">
-								<strong>{isEnglish ? 'Top story: ' : '今日头条：'}</strong>
-								{cleanTimelineSummary(heroLead.title) || heroLead.title}
-							</p>
-						)}
-						<p class="archive-hero-meta">
-							{isEnglish
-								? `${latestReport.items.length} items · published ${formatDailyTime(firstCompletedAt!, locale)}`
-								: `${latestReport.items.length} 条收录 · ${formatDailyTime(firstCompletedAt!, locale)} 发布`}
-						</p>
-					</>
-				) : (
-					<p class="archive-hero-headline">{latestRow.entry.data.title}</p>
-				)}
-			</a>
-		)
-	}
-
-	{
-		groups.map((group) => {
-			const expanded = expandedCutoff !== null && group.monthKey >= expandedCutoff;
-			const monthLabel = monthFormatter.format(dailyDateFromKey(`${group.monthKey}-01`));
-			const countLabel = isEnglish
-				? `${group.rows.length} issues`
-				: `${group.rows.length} 期`;
-			const dayRows = group.rows.map((row) => {
-				const report = reportByDate.get(row.identity.dateKey) ?? null;
-				const date = dailyDateFromKey(row.identity.dateKey);
-				const summary = report ? topTopicLabels(report, 3).join(' · ') : '';
-				return (
-					<a
-						class:list={['day-row', { today: row === latestRow }]}
-						href={row.href}
+	<div class="archive-layout">
+		<div class="archive-main">
+			<div class="cal-head">
+				<div class="cal-title">
+					<h2 data-cal-title>{monthVMs.find((vm) => !vm.hidden)?.title ?? ''}</h2>
+					<span class="cal-stats" data-cal-stats>
+						{monthVMs.find((vm) => !vm.hidden)?.stats ?? ''}
+					</span>
+				</div>
+				<div class="cal-nav">
+					<div class="cal-seg" role="group" aria-label={isEnglish ? 'View' : '视图'}>
+						<button type="button" data-view="month" aria-pressed="true">
+							{isEnglish ? 'Month' : '月'}
+						</button>
+						<button type="button" data-view="year" aria-pressed="false">
+							{isEnglish ? 'Year' : '年'}
+						</button>
+					</div>
+					<button
+						type="button"
+						class="cal-arrow"
+						data-nav="prev"
+						aria-label={isEnglish ? 'Previous' : '上一页'}>‹</button
 					>
-						<span class="day-num">{row.identity.dateKey.slice(8)}</span>
-						<span class="weekday">
-							{formatDailyWeekday(date, locale, 'short')}
-							{row === latestRow && (
-								<span class="today-pill">{isEnglish ? 'Today' : '今天'}</span>
-							)}
-						</span>
-						<span class="topics">{summary || row.entry.data.title}</span>
-						{report && (
-							<span class="items">
-								{isEnglish ? `${report.items.length} items` : `${report.items.length} 条`}
+					<button
+						type="button"
+						class="cal-arrow"
+						data-nav="next"
+						aria-label={isEnglish ? 'Next' : '下一页'}
+						disabled>›</button
+					>
+					<button type="button" class="cal-today" data-nav="today">
+						{isEnglish ? 'Today' : '回到今天'}
+					</button>
+				</div>
+			</div>
+
+			<div class="cal-months" data-cal-months>
+				{
+					monthVMs.map((vm) => (
+						<section class="cal-month" data-month={vm.key} hidden={vm.hidden}>
+							<div class="dow-row">
+								{dowLabels.map((label, index) => (
+									<span class:list={[{ wknd: index >= 5 }]}>{label}</span>
+								))}
+							</div>
+							<div class="cal-grid">
+								{vm.cells.map((cell) =>
+									cell.kind === 'adjacent' ? (
+										<span class="cell adjacent">
+											<span class="day">{cell.day}</span>
+										</span>
+									) : cell.info ? (
+										<a
+											class:list={[
+												'cell',
+												'has-issue',
+												{ today: cell.isToday, selected: cell.isSelected },
+											]}
+											href={cell.info.href}
+											data-date={cell.dateKey}
+											style={`--heat:${cell.heat.toFixed(2)}`}
+											title={cell.info.count !== null ? countTitle(cell.info.count) : undefined}
+										>
+											<span class="day">{cell.day}</span>
+											{cell.isToday && (
+												<span class="today-flag">{isEnglish ? 'Today' : '今天'}</span>
+											)}
+											{(cell.info.topicIds.length > 0 || cell.info.count !== null) && (
+												<span class="cell-meta">
+													<span class="dots">
+														{cell.info.topicIds.map((id) => (
+															<i class:list={['dot', dotClass(id)]} />
+														))}
+													</span>
+													{cell.info.count !== null && (
+														<span class="count">
+															{isEnglish ? cell.info.count : `${cell.info.count} 条`}
+														</span>
+													)}
+												</span>
+											)}
+										</a>
+									) : (
+										<span
+											class:list={['cell', { future: cell.isFuture, today: cell.isToday }]}
+											data-date={cell.dateKey}
+										>
+											<span class="day">{cell.day}</span>
+											{cell.isToday && (
+												<span class="today-flag">{isEnglish ? 'Today' : '今天'}</span>
+											)}
+										</span>
+									),
+								)}
+							</div>
+						</section>
+					))
+				}
+			</div>
+
+			<div class="cal-years" data-cal-years hidden>
+				{
+					yearVMs.map((vm) => (
+						<section class="cal-year" data-year={vm.year} hidden={vm.hidden}>
+							<div class="year-grid">
+								{vm.minis.map((mini) => (
+									<div
+										class:list={['mini-month', { empty: !mini.hasData }]}
+										data-month={mini.key}
+									>
+										<div class="mm-title">
+											<span class="mm-name">{mini.name}</span>
+											<span class="mm-stat">
+												{mini.issueCount > 0 &&
+													(isEnglish ? `${mini.issueCount} issues` : `${mini.issueCount} 期`)}
+											</span>
+										</div>
+										<div class="mini-cells">
+											{mini.cells.map((cell) =>
+												cell.kind === 'adjacent' ? (
+													<span class="mc slot" />
+												) : cell.info ? (
+													<a
+														class:list={['mc', 'has', { today: cell.isToday }]}
+														href={cell.info.href}
+														data-date={cell.dateKey}
+														style={`--heat:${cell.heat.toFixed(2)}`}
+														title={
+															cell.info.count !== null
+																? `${cell.dateKey} · ${countTitle(cell.info.count)}`
+																: (cell.dateKey ?? undefined)
+														}
+													/>
+												) : (
+													<span
+														class:list={['mc', { future: cell.isFuture, today: cell.isToday }]}
+													/>
+												),
+											)}
+										</div>
+									</div>
+								))}
+							</div>
+							<div class="year-stats">
+								<span>
+									{isEnglish ? 'Longest streak ' : '最长连发 '}
+									<b>{vm.longestStreak}</b>
+									{isEnglish ? ' days' : ' 天'}
+								</span>
+								{
+									vm.biggestCount !== null && (
+										<span>
+											{isEnglish ? 'Biggest issue ' : '最厚一期 '}
+											<b>{vm.biggestCount}</b>
+											{isEnglish ? ' items' : ' 条'}（{vm.biggestLabel}）
+										</span>
+									)
+								}
+							</div>
+						</section>
+					))
+				}
+			</div>
+
+			<div class="cal-legend">
+				<div class="legend-cats">
+					{
+						legendTopics.map((topic) => (
+							<span>
+								<i class:list={['dot', dotClass(topic.id)]} />
+								{taxonomyLabel(topic, locale)}
 							</span>
-						)}
-					</a>
-				);
-			});
-			return (
-				<details class="month-group" open={expanded || undefined}>
-					<summary class="month-heading">
-						<h2>{monthLabel}</h2>
-						<span class="count">{countLabel}</span>
-						<span class="range">
-							{`${group.rows.at(-1)!.identity.dateKey.slice(5)} — ${group.rows[0].identity.dateKey.slice(5)}`}
-						</span>
-					</summary>
-					{dayRows}
-				</details>
-			);
-		})
-	}
+						))
+					}
+				</div>
+				<div class="legend-note">
+					{isEnglish ? 'Cell depth follows the day’s item count' : '底色深浅对应当日收录量'}
+				</div>
+			</div>
+		</div>
+
+		<aside class="archive-rail">
+			<div class="detail-card" data-detail-card>
+				{
+					selectedInfo ? (
+						<>
+							<p class="detail-kicker">{labels.latestKicker}</p>
+							<p class="detail-date">
+								{selectedInfo.dateLabel}
+								<span class="weekday">{selectedInfo.weekdayLong}</span>
+							</p>
+							{selectedInfo.topicLabels.length > 0 && (
+								<ul class="detail-topics">
+									{selectedInfo.topicLabels.map((label) => (
+										<li>{label}</li>
+									))}
+								</ul>
+							)}
+							<div class="detail-body">
+								<p class="detail-label">{labels.topStory}</p>
+								<p class="detail-headline">{selectedInfo.headline}</p>
+								{selectedInfo.meta && <p class="detail-meta">{selectedInfo.meta}</p>}
+								<a class="detail-cta" href={selectedInfo.href}>
+									{labels.readIssue}
+								</a>
+							</div>
+						</>
+					) : (
+						<p class="detail-empty">{isEnglish ? 'No issues yet.' : '暂无期刊。'}</p>
+					)
+				}
+			</div>
+		</aside>
+	</div>
+	<script is:inline type="application/json" data-calendar-json set:html={payloadJson} />
 </section>
+
+<script>
+	import '../scripts/dailyCalendar';
+</script>

--- a/astro/src/lib/dailyCalendar.test.ts
+++ b/astro/src/lib/dailyCalendar.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+	buildMonthGrid,
+	daysInMonth,
+	heatScale,
+	longestIssueStreak,
+	mondayFirstLead,
+} from './dailyCalendar';
+
+describe('daysInMonth', () => {
+	it('handles 31/30/28/29-day months', () => {
+		expect(daysInMonth(2026, 7)).toBe(31);
+		expect(daysInMonth(2026, 6)).toBe(30);
+		expect(daysInMonth(2026, 2)).toBe(28);
+		expect(daysInMonth(2024, 2)).toBe(29);
+	});
+});
+
+describe('mondayFirstLead', () => {
+	it('is timezone-independent weekday math', () => {
+		// 2026-07-01 is a Wednesday → two leading blanks (Mon, Tue).
+		expect(mondayFirstLead(2026, 7)).toBe(2);
+		// 2026-06-01 is a Monday → no leading blanks.
+		expect(mondayFirstLead(2026, 6)).toBe(0);
+		// 2026-02-01 is a Sunday → six leading blanks.
+		expect(mondayFirstLead(2026, 2)).toBe(6);
+	});
+});
+
+describe('buildMonthGrid', () => {
+	it('produces full weeks with adjacent-month fillers', () => {
+		const cells = buildMonthGrid(2026, 7);
+		expect(cells.length % 7).toBe(0);
+		expect(cells.length).toBe(35);
+		expect(cells[0]).toEqual({ kind: 'adjacent', day: 29, dateKey: null });
+		expect(cells[1]).toEqual({ kind: 'adjacent', day: 30, dateKey: null });
+		expect(cells[2]).toEqual({ kind: 'day', day: 1, dateKey: '2026-07-01' });
+		expect(cells.at(-1)).toEqual({ kind: 'adjacent', day: 2, dateKey: null });
+	});
+
+	it('covers every day of the month exactly once', () => {
+		const days = buildMonthGrid(2026, 2)
+			.filter((cell) => cell.kind === 'day')
+			.map((cell) => cell.day);
+		expect(days).toEqual(Array.from({ length: 28 }, (_, i) => i + 1));
+	});
+});
+
+describe('heatScale', () => {
+	it('normalizes against the peak count', () => {
+		const scale = heatScale([65, 295, null]);
+		expect(scale(295)).toBe(1);
+		expect(scale(65)).toBeCloseTo(65 / 295);
+		expect(scale(null)).toBe(0);
+	});
+
+	it('degrades to zero when every count is unknown', () => {
+		const scale = heatScale([null, null]);
+		expect(scale(null)).toBe(0);
+	});
+});
+
+describe('longestIssueStreak', () => {
+	it('counts consecutive calendar days across month boundaries', () => {
+		expect(
+			longestIssueStreak(['2026-07-01', '2026-06-29', '2026-06-30', '2026-07-15']),
+		).toBe(3);
+	});
+
+	it('resets after a gap and tolerates duplicates', () => {
+		expect(
+			longestIssueStreak(['2026-07-02', '2026-07-01', '2026-07-01', '2026-07-04', '2026-07-05']),
+		).toBe(2);
+	});
+
+	it('handles empty input', () => {
+		expect(longestIssueStreak([])).toBe(0);
+	});
+});

--- a/astro/src/lib/dailyCalendar.ts
+++ b/astro/src/lib/dailyCalendar.ts
@@ -1,0 +1,75 @@
+/**
+ * Grid math behind the daily archive calendar views. Pure date utilities,
+ * shared by the server-rendered markup (DailyArchive.astro) and covered by
+ * unit tests; no DOM or Astro APIs involved.
+ */
+
+export const pad2 = (value: number): string => String(value).padStart(2, '0');
+
+/** Days in a Gregorian month; `month` is 1-based. UTC math keeps the build
+ * machine's timezone out of the grid. */
+export const daysInMonth = (year: number, month: number): number =>
+	new Date(Date.UTC(year, month, 0)).getUTCDate();
+
+/** Leading blanks before the 1st of the month in a Monday-first grid. */
+export const mondayFirstLead = (year: number, month: number): number =>
+	(new Date(Date.UTC(year, month - 1, 1)).getUTCDay() + 6) % 7;
+
+export interface GridCell {
+	kind: 'adjacent' | 'day';
+	day: number;
+	/** YYYY-MM-DD for `day` cells, null for adjacent-month filler cells. */
+	dateKey: string | null;
+}
+
+/** Full Monday-first month grid: leading/trailing adjacent-month filler
+ * cells included, length always a multiple of 7. */
+export function buildMonthGrid(year: number, month: number): GridCell[] {
+	const lead = mondayFirstLead(year, month);
+	const total = daysInMonth(year, month);
+	const prevTotal = daysInMonth(year, month - 1);
+	const cells: GridCell[] = [];
+	for (let i = lead - 1; i >= 0; i--) {
+		cells.push({ kind: 'adjacent', day: prevTotal - i, dateKey: null });
+	}
+	for (let day = 1; day <= total; day++) {
+		cells.push({ kind: 'day', day, dateKey: `${year}-${pad2(month)}-${pad2(day)}` });
+	}
+	const trailing = (7 - (cells.length % 7)) % 7;
+	for (let day = 1; day <= trailing; day++) {
+		cells.push({ kind: 'adjacent', day, dateKey: null });
+	}
+	return cells;
+}
+
+/** Normalizes item counts to a 0–1 heat value. `null` (unknown count) maps
+ * to 0; when every count is unknown the scale is uniformly 0. */
+export function heatScale(counts: (number | null)[]): (count: number | null) => number {
+	let peak = 0;
+	for (const count of counts) {
+		if (count !== null && count > peak) peak = count;
+	}
+	return (count) => (count === null || peak <= 0 ? 0 : count / peak);
+}
+
+/** Longest run of consecutive calendar days in a list of YYYY-MM-DD keys
+ * (any order, duplicates tolerated). */
+export function longestIssueStreak(dateKeys: string[]): number {
+	let best = 0;
+	let streak = 0;
+	let previous: string | null = null;
+	for (const key of [...dateKeys].sort()) {
+		if (key === previous) continue;
+		if (previous !== null) {
+			const expected = new Date(Date.parse(`${previous}T00:00:00Z`) + 86_400_000)
+				.toISOString()
+				.slice(0, 10);
+			streak = key === expected ? streak + 1 : 1;
+		} else {
+			streak = 1;
+		}
+		if (streak > best) best = streak;
+		previous = key;
+	}
+	return best;
+}

--- a/astro/src/scripts/dailyCalendar.ts
+++ b/astro/src/scripts/dailyCalendar.ts
@@ -1,0 +1,257 @@
+/**
+ * Client behaviour for the daily archive calendar (DailyArchive.astro).
+ *
+ * The calendar itself is server-rendered for every month and year; this
+ * module only toggles visibility, moves the selection, and re-renders the
+ * detail card from the embedded JSON payload. Without JavaScript the day
+ * cells remain plain links to each issue.
+ */
+
+interface CalendarLabels {
+	latestKicker: string;
+	issueKicker: string;
+	noIssueKicker: string;
+	topStory: string;
+	readIssue: string;
+	noIssue: string;
+	goLatest: string;
+}
+
+interface CalendarIssue {
+	href: string;
+	dateLabel: string;
+	weekday: string;
+	topics: string[];
+	headline: string;
+	meta: string | null;
+}
+
+interface CalendarPayload {
+	today: string | null;
+	latest: string | null;
+	selected: string | null;
+	initialMonth: string | null;
+	initialYear: string | null;
+	labels: CalendarLabels;
+	months: Record<string, { title: string; stats: string }>;
+	years: Record<string, { title: string; stats: string }>;
+	issues: Record<string, CalendarIssue>;
+}
+
+const ESCAPES: Record<string, string> = {
+	'&': '&amp;',
+	'<': '&lt;',
+	'>': '&gt;',
+	'"': '&quot;',
+	"'": '&#39;',
+};
+const esc = (value: string): string => value.replace(/[&<>"']/g, (char) => ESCAPES[char]!);
+
+const plainClick = (event: MouseEvent): boolean =>
+	event.button === 0 && !event.metaKey && !event.ctrlKey && !event.shiftKey && !event.altKey;
+
+function initDailyCalendar(): void {
+	const root = document.querySelector<HTMLElement>('[data-daily-calendar]');
+	if (!root) return;
+	const dataEl = root.querySelector('script[data-calendar-json]');
+	if (!dataEl?.textContent) return;
+
+	let data: CalendarPayload;
+	try {
+		data = JSON.parse(dataEl.textContent) as CalendarPayload;
+	} catch {
+		return;
+	}
+
+	const titleEl = root.querySelector<HTMLElement>('[data-cal-title]');
+	const statsEl = root.querySelector<HTMLElement>('[data-cal-stats]');
+	const monthsWrap = root.querySelector<HTMLElement>('[data-cal-months]');
+	const yearsWrap = root.querySelector<HTMLElement>('[data-cal-years]');
+	const detail = root.querySelector<HTMLElement>('[data-detail-card]');
+	const prevBtn = root.querySelector<HTMLButtonElement>('[data-nav="prev"]');
+	const nextBtn = root.querySelector<HTMLButtonElement>('[data-nav="next"]');
+	const todayBtn = root.querySelector<HTMLButtonElement>('[data-nav="today"]');
+	const segButtons = [...root.querySelectorAll<HTMLButtonElement>('[data-view]')];
+	if (
+		!titleEl ||
+		!statsEl ||
+		!monthsWrap ||
+		!yearsWrap ||
+		!detail ||
+		!prevBtn ||
+		!nextBtn ||
+		!todayBtn
+	) {
+		return;
+	}
+
+	const monthKeys = Object.keys(data.months).sort();
+	const yearKeys = Object.keys(data.years).sort();
+	if (monthKeys.length === 0) return;
+
+	let view: 'month' | 'year' = 'month';
+	let curMonth = data.initialMonth ?? monthKeys[monthKeys.length - 1]!;
+	let curYear = data.initialYear ?? yearKeys[yearKeys.length - 1] ?? curMonth.slice(0, 4);
+	let selected = data.selected;
+	// The server pre-renders the selected card, so the first user-triggered
+	// render is the one that animates.
+	let painted = true;
+
+	const locale = root.dataset.locale === 'en' ? 'en' : 'zh-CN';
+	const monthDayFmt = new Intl.DateTimeFormat(locale, {
+		month: 'long',
+		day: 'numeric',
+		timeZone: 'Asia/Shanghai',
+	});
+	const weekdayFmt = new Intl.DateTimeFormat(locale, {
+		weekday: 'long',
+		timeZone: 'Asia/Shanghai',
+	});
+
+	function markSelected(): void {
+		root!.querySelectorAll('.cell.selected').forEach((el) => el.classList.remove('selected'));
+		if (view !== 'month' || !selected) return;
+		monthsWrap!.querySelector(`.cell[data-date="${selected}"]`)?.classList.add('selected');
+	}
+
+	function syncChrome(): void {
+		const meta = view === 'month' ? data.months[curMonth] : data.years[curYear];
+		if (meta) {
+			titleEl!.textContent = meta.title;
+			statsEl!.textContent = meta.stats;
+		}
+		prevBtn!.disabled =
+			view === 'month' ? curMonth === monthKeys[0] : curYear === yearKeys[0];
+		nextBtn!.disabled =
+			view === 'month'
+				? curMonth === monthKeys[monthKeys.length - 1]
+				: curYear === yearKeys[yearKeys.length - 1];
+		monthsWrap!.hidden = view !== 'month';
+		yearsWrap!.hidden = view !== 'year';
+		monthsWrap!.querySelectorAll<HTMLElement>('[data-month]').forEach((el) => {
+			el.hidden = view !== 'month' || el.dataset.month !== curMonth;
+		});
+		yearsWrap!.querySelectorAll<HTMLElement>('[data-year]').forEach((el) => {
+			el.hidden = view !== 'year' || el.dataset.year !== curYear;
+		});
+		segButtons.forEach((btn) =>
+			btn.setAttribute('aria-pressed', String((btn.dataset.view ?? 'month') === view)),
+		);
+		markSelected();
+	}
+
+	function cardHtml(dateKey: string): string {
+		const issue = data.issues[dateKey];
+		if (!issue) {
+			const date = new Date(`${dateKey}T00:00:00+08:00`);
+			return `<p class="detail-kicker">${esc(data.labels.noIssueKicker)}</p>
+				<p class="detail-date">${esc(monthDayFmt.format(date))}<span class="weekday">${esc(weekdayFmt.format(date))}</span></p>
+				<div class="detail-body">
+					<p class="detail-empty">${esc(data.labels.noIssue)}</p>
+					<button type="button" class="detail-cta" data-go-latest>${esc(data.labels.goLatest)}</button>
+				</div>`;
+		}
+		const kicker =
+			dateKey === data.latest ? data.labels.latestKicker : data.labels.issueKicker;
+		const topics = issue.topics.length
+			? `<ul class="detail-topics">${issue.topics.map((topic) => `<li>${esc(topic)}</li>`).join('')}</ul>`
+			: '';
+		const meta = issue.meta ? `<p class="detail-meta">${esc(issue.meta)}</p>` : '';
+		return `<p class="detail-kicker">${esc(kicker)}</p>
+			<p class="detail-date">${esc(issue.dateLabel)}<span class="weekday">${esc(issue.weekday)}</span></p>
+			${topics}
+			<div class="detail-body">
+				<p class="detail-label">${esc(data.labels.topStory)}</p>
+				<p class="detail-headline">${esc(issue.headline)}</p>
+				${meta}
+				<a class="detail-cta" href="${issue.href}">${esc(data.labels.readIssue)}</a>
+			</div>`;
+	}
+
+	function renderDetail(dateKey: string): void {
+		const paint = () => {
+			detail!.innerHTML = cardHtml(dateKey);
+			detail!.classList.remove('fading');
+			painted = true;
+		};
+		if (painted) {
+			detail!.classList.add('fading');
+			window.setTimeout(paint, 120);
+		} else {
+			paint();
+		}
+	}
+
+	function select(dateKey: string): void {
+		selected = dateKey;
+		markSelected();
+		renderDetail(dateKey);
+	}
+
+	monthsWrap.addEventListener('click', (event) => {
+		const target = event.target as HTMLElement;
+		const link = target.closest<HTMLAnchorElement>('a.cell[data-date]');
+		if (link) {
+			if (!plainClick(event)) return;
+			event.preventDefault();
+			select(link.dataset.date!);
+			return;
+		}
+		const cell = target.closest<HTMLElement>('span.cell[data-date]');
+		if (cell) select(cell.dataset.date!);
+	});
+
+	yearsWrap.addEventListener('click', (event) => {
+		const target = event.target as HTMLElement;
+		const mini = target.closest<HTMLElement>('.mini-month[data-month]');
+		if (!mini || mini.classList.contains('empty') || !mini.dataset.month) return;
+		const mc = target.closest<HTMLAnchorElement>('a.mc[data-date]');
+		if (mc && !plainClick(event)) return;
+		if (mc) event.preventDefault();
+		curMonth = mini.dataset.month;
+		view = 'month';
+		if (mc?.dataset.date) selected = mc.dataset.date;
+		syncChrome();
+		if (mc?.dataset.date) renderDetail(selected!);
+	});
+
+	segButtons.forEach((btn) =>
+		btn.addEventListener('click', () => {
+			const nextView = btn.dataset.view === 'year' ? 'year' : 'month';
+			if (nextView === view) return;
+			view = nextView;
+			if (view === 'year') curYear = curMonth.slice(0, 4);
+			syncChrome();
+		}),
+	);
+
+	const shift = (delta: number): void => {
+		if (view === 'month') {
+			const index = monthKeys.indexOf(curMonth);
+			if (monthKeys[index + delta]) curMonth = monthKeys[index + delta]!;
+		} else {
+			const index = yearKeys.indexOf(curYear);
+			if (yearKeys[index + delta]) curYear = yearKeys[index + delta]!;
+		}
+		syncChrome();
+	};
+	prevBtn.addEventListener('click', () => shift(-1));
+	nextBtn.addEventListener('click', () => shift(1));
+
+	const jumpToLatest = (): void => {
+		view = 'month';
+		curMonth = data.initialMonth ?? curMonth;
+		curYear = data.initialYear ?? curYear;
+		selected = data.selected;
+		syncChrome();
+		if (selected) renderDetail(selected);
+	};
+	todayBtn.addEventListener('click', jumpToLatest);
+	detail.addEventListener('click', (event) => {
+		if ((event.target as HTMLElement).closest('[data-go-latest]')) jumpToLatest();
+	});
+
+	syncChrome();
+}
+
+document.addEventListener('astro:page-load', initDailyCalendar);

--- a/astro/src/styles/migration.css
+++ b/astro/src/styles/migration.css
@@ -23,6 +23,15 @@
 	--serif: 'Songti SC', 'STSong', 'Noto Serif CJK SC', ui-serif, Georgia, serif;
 	--mono: 'SFMono-Regular', Consolas, 'Liberation Mono', monospace;
 	--rail-width: 216px;
+	--rule-soft: color-mix(in srgb, var(--rule) 55%, var(--paper));
+	--cat-models: #254f99;
+	--cat-products: #2f653d;
+	--cat-research: #6a4a8c;
+	--cat-agents: #9a6220;
+	--cat-oss: #2f6560;
+	--cat-business: #9e332b;
+	--cat-policy: #5b6270;
+	--cat-other: #7a7668;
 }
 
 :root[data-theme='dark'] {
@@ -41,6 +50,14 @@
 	--green: #83b894;
 	--green-soft: #253529;
 	--focus: #9dbcf1;
+	--cat-models: #8caee8;
+	--cat-products: #83b894;
+	--cat-research: #b39ddb;
+	--cat-agents: #d9a05b;
+	--cat-oss: #7fb8b2;
+	--cat-business: #df8275;
+	--cat-policy: #9aa3b5;
+	--cat-other: #8f8b7c;
 	background: var(--paper);
 	color: var(--ink);
 }
@@ -431,56 +448,479 @@ h1 {
 	color: var(--ink-soft);
 }
 
-.daily-archive .archive-hero {
-	display: block;
-	margin-bottom: clamp(40px, 6vw, 56px);
-	padding: clamp(24px, 4vw, 40px);
-	border: 1px solid var(--rule);
-	border-radius: 6px;
-	background: var(--paper-raised);
-	text-decoration: none;
-	transition: border-color 0.15s ease;
+.daily-archive .archive-layout {
+	display: grid;
+	grid-template-columns: minmax(0, 1fr) 318px;
+	gap: clamp(28px, 4vw, 48px);
+	align-items: start;
 }
 
-.daily-archive .archive-hero:hover {
-	border-color: var(--blue);
+.daily-archive .archive-rail {
+	position: sticky;
+	top: 32px;
+}
+
+.daily-archive .cal-head {
+	display: flex;
+	flex-wrap: wrap;
+	align-items: baseline;
+	justify-content: space-between;
+	gap: 12px 16px;
+	margin-bottom: 16px;
+}
+
+.daily-archive .cal-title {
+	display: flex;
+	align-items: baseline;
+	gap: 14px;
+}
+
+.daily-archive .cal-title h2 {
+	margin: 0;
+	font-family: var(--serif);
+	font-size: 1.65rem;
+	font-weight: 700;
+}
+
+.daily-archive .cal-stats {
+	color: var(--ink-faint);
+	font-family: var(--mono);
+	font-size: 0.72rem;
+}
+
+.daily-archive .cal-nav {
+	display: flex;
+	align-items: center;
+	gap: 10px;
+}
+
+.daily-archive .cal-seg {
+	display: flex;
+	margin-right: 4px;
+	overflow: hidden;
+	border: 1px solid var(--rule);
+	border-radius: 8px;
+}
+
+.daily-archive .cal-seg button {
+	padding: 5px 13px;
+	border: 0;
+	background: transparent;
+	color: var(--ink-faint);
+	font-family: inherit;
+	font-size: 0.78rem;
+	cursor: pointer;
+	transition:
+		background 0.15s ease,
+		color 0.15s ease;
+}
+
+.daily-archive .cal-seg button[aria-pressed='true'] {
+	background: var(--ink);
+	color: var(--paper);
+}
+
+.daily-archive .cal-arrow {
+	display: grid;
+	place-items: center;
+	width: 30px;
+	height: 30px;
+	border: 1px solid var(--rule);
+	border-radius: 7px;
+	background: transparent;
+	color: var(--ink-soft);
+	font-family: var(--mono);
+	font-size: 0.95rem;
+	cursor: pointer;
+	transition:
+		background 0.15s ease,
+		color 0.15s ease,
+		opacity 0.15s ease;
+}
+
+.daily-archive .cal-arrow:hover:not(:disabled) {
+	background: var(--paper-raised);
+	color: var(--ink);
+}
+
+.daily-archive .cal-arrow:disabled {
+	opacity: 0.3;
+	cursor: default;
+}
+
+.daily-archive .cal-today {
+	padding: 0 2px;
+	border: 0;
+	background: none;
+	color: var(--blue);
+	font-family: inherit;
+	font-size: 0.82rem;
+	cursor: pointer;
+}
+
+.daily-archive .cal-today:hover {
+	text-decoration: underline;
+}
+
+.daily-archive .dow-row,
+.daily-archive .cal-grid {
+	display: grid;
+	grid-template-columns: repeat(7, minmax(0, 1fr));
+}
+
+.daily-archive .dow-row {
+	overflow: hidden;
+	border: 1px solid var(--rule);
+	border-bottom: 0;
+	border-radius: 10px 10px 0 0;
+}
+
+.daily-archive .dow-row span {
+	padding: 7px 12px;
+	background: var(--paper-raised);
+	color: var(--ink-faint);
+	font-size: 0.68rem;
+	letter-spacing: 0.16em;
+}
+
+.daily-archive .dow-row span.wknd {
+	opacity: 0.75;
+}
+
+.daily-archive .cal-grid {
+	gap: 1px;
+	overflow: hidden;
+	border: 1px solid var(--rule);
+	border-radius: 0 0 10px 10px;
+	background: var(--rule-soft);
+}
+
+.daily-archive .cell {
+	position: relative;
+	display: flex;
+	flex-direction: column;
+	justify-content: space-between;
+	min-height: clamp(84px, 8.5vw, 108px);
+	padding: 10px 12px;
+	background: var(--paper);
+	color: inherit;
+	text-decoration: none;
+	transition:
+		background 0.15s ease,
+		box-shadow 0.15s ease;
+}
+
+.daily-archive .cell .day {
+	color: var(--ink-soft);
+	font-family: var(--serif);
+	font-size: 1.05rem;
+	font-weight: 600;
+	line-height: 1;
+}
+
+.daily-archive .cell.adjacent .day {
+	color: var(--ink-faint);
+	opacity: 0.38;
+}
+
+.daily-archive .cell.future .day {
+	color: var(--ink-faint);
+}
+
+.daily-archive .cell.has-issue {
+	background:
+		linear-gradient(
+			rgba(37, 79, 153, calc(0.08 + var(--heat, 0) * 0.09)),
+			rgba(37, 79, 153, calc(0.08 + var(--heat, 0) * 0.09))
+		),
+		var(--paper);
+}
+
+:root[data-theme='dark'] .daily-archive .cell.has-issue {
+	background:
+		linear-gradient(
+			rgba(140, 174, 232, calc(0.09 + var(--heat, 0) * 0.1)),
+			rgba(140, 174, 232, calc(0.09 + var(--heat, 0) * 0.1))
+		),
+		var(--paper);
+}
+
+.daily-archive .cell.has-issue .day {
+	color: var(--ink);
+}
+
+.daily-archive .cell.has-issue:hover {
+	background:
+		linear-gradient(
+			rgba(37, 79, 153, calc(0.12 + var(--heat, 0) * 0.09)),
+			rgba(37, 79, 153, calc(0.12 + var(--heat, 0) * 0.09))
+		),
+		var(--paper-raised);
 	color: inherit;
 }
 
-.daily-archive .archive-hero-label {
-	margin: 0 0 14px;
+:root[data-theme='dark'] .daily-archive .cell.has-issue:hover {
+	background:
+		linear-gradient(
+			rgba(140, 174, 232, calc(0.13 + var(--heat, 0) * 0.1)),
+			rgba(140, 174, 232, calc(0.13 + var(--heat, 0) * 0.1))
+		),
+		var(--paper-raised);
+}
+
+.daily-archive .cell.selected {
+	z-index: 1;
+	box-shadow: inset 0 0 0 1.5px var(--blue);
+}
+
+.daily-archive .cell.today .day {
+	color: var(--blue);
+}
+
+.daily-archive .today-flag {
+	position: absolute;
+	top: 9px;
+	right: 10px;
+	padding: 1px 7px;
+	border: 1px solid var(--blue);
+	border-radius: 999px;
+	color: var(--blue);
+	font-size: 0.6rem;
+	letter-spacing: 0.1em;
+}
+
+.daily-archive .cell-meta {
+	display: flex;
+	align-items: flex-end;
+	justify-content: space-between;
+	gap: 6px;
+}
+
+.daily-archive .dots {
+	display: flex;
+	gap: 4px;
+	padding-bottom: 2px;
+}
+
+.daily-archive .dot {
+	width: 5px;
+	height: 5px;
+	border-radius: 50%;
+}
+
+.daily-archive .dot.cat-models {
+	background: var(--cat-models);
+}
+
+.daily-archive .dot.cat-products {
+	background: var(--cat-products);
+}
+
+.daily-archive .dot.cat-research {
+	background: var(--cat-research);
+}
+
+.daily-archive .dot.cat-agents {
+	background: var(--cat-agents);
+}
+
+.daily-archive .dot.cat-oss {
+	background: var(--cat-oss);
+}
+
+.daily-archive .dot.cat-business {
+	background: var(--cat-business);
+}
+
+.daily-archive .dot.cat-policy {
+	background: var(--cat-policy);
+}
+
+.daily-archive .dot.cat-other {
+	background: var(--cat-other);
+}
+
+.daily-archive .count {
+	color: var(--ink-soft);
+	font-family: var(--mono);
+	font-size: 0.68rem;
+	white-space: nowrap;
+}
+
+.daily-archive .cal-legend {
+	display: flex;
+	flex-wrap: wrap;
+	align-items: center;
+	justify-content: space-between;
+	gap: 8px 12px;
+	margin-top: 14px;
+}
+
+.daily-archive .legend-cats {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 14px;
+}
+
+.daily-archive .legend-cats span {
+	display: inline-flex;
+	align-items: center;
+	gap: 6px;
+	color: var(--ink-soft);
+	font-size: 0.75rem;
+}
+
+.daily-archive .legend-note {
+	color: var(--ink-faint);
+	font-size: 0.72rem;
+}
+
+.daily-archive .year-grid {
+	display: grid;
+	grid-template-columns: repeat(4, minmax(0, 1fr));
+	gap: 14px;
+}
+
+.daily-archive .mini-month {
+	padding: 13px 14px;
+	border: 1px solid var(--rule);
+	border-radius: 10px;
+	cursor: pointer;
+	transition:
+		box-shadow 0.15s ease,
+		opacity 0.15s ease;
+}
+
+.daily-archive .mini-month:not(.empty):hover {
+	box-shadow: inset 0 0 0 1.5px var(--blue);
+}
+
+.daily-archive .mini-month:not(.empty):hover .mm-name {
+	color: var(--blue);
+}
+
+.daily-archive .mini-month.empty {
+	opacity: 0.38;
+	cursor: default;
+}
+
+.daily-archive .mm-title {
+	display: flex;
+	align-items: baseline;
+	justify-content: space-between;
+	margin-bottom: 10px;
+}
+
+.daily-archive .mm-name {
+	font-family: var(--serif);
+	font-size: 1rem;
+	font-weight: 700;
+	transition: color 0.15s ease;
+}
+
+.daily-archive .mm-stat {
+	color: var(--ink-faint);
+	font-family: var(--mono);
+	font-size: 0.62rem;
+}
+
+.daily-archive .mini-cells {
+	display: grid;
+	grid-template-columns: repeat(7, minmax(0, 1fr));
+	gap: 3px;
+}
+
+.daily-archive .mc {
+	display: block;
+	aspect-ratio: 1;
+	border-radius: 2px;
+	background: var(--rule-soft);
+	opacity: 0.45;
+}
+
+.daily-archive .mc.slot {
+	background: transparent;
+	opacity: 0;
+}
+
+.daily-archive .mc.future {
+	opacity: 0.15;
+}
+
+.daily-archive .mc.has {
+	opacity: 1;
+	background: rgba(37, 79, 153, calc(0.3 + var(--heat, 0) * 0.5));
+}
+
+:root[data-theme='dark'] .daily-archive .mc.has {
+	background: rgba(140, 174, 232, calc(0.32 + var(--heat, 0) * 0.55));
+}
+
+.daily-archive .mc.today {
+	outline: 1.5px solid var(--blue);
+}
+
+.daily-archive .year-stats {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 8px 26px;
+	margin-top: 16px;
+	color: var(--ink-faint);
+	font-family: var(--mono);
+	font-size: 0.74rem;
+}
+
+.daily-archive .year-stats b {
+	color: var(--ink);
+	font-weight: 600;
+}
+
+.daily-archive .detail-card {
+	padding: 26px;
+	border: 1px solid var(--rule);
+	border-radius: 12px;
+	background: var(--paper-raised);
+	transition: opacity 0.18s ease;
+}
+
+.daily-archive .detail-card.fading {
+	opacity: 0;
+}
+
+.daily-archive .detail-kicker {
+	margin: 0 0 16px;
 	color: var(--blue);
 	font-family: var(--mono);
-	font-size: 0.72rem;
-	letter-spacing: 0.14em;
+	font-size: 0.68rem;
+	letter-spacing: 0.22em;
 	text-transform: uppercase;
 }
 
-.daily-archive .archive-hero-date {
+.daily-archive .detail-date {
 	margin: 0;
 	font-family: var(--serif);
-	font-size: clamp(1.8rem, 3.2vw, 2.5rem);
+	font-size: 2.2rem;
 	font-weight: 700;
-	line-height: 1.15;
+	line-height: 1.1;
 }
 
-.daily-archive .archive-hero-date .weekday {
+.daily-archive .detail-date .weekday {
 	margin-left: 10px;
 	color: var(--ink-faint);
-	font-size: 0.55em;
+	font-size: 0.9rem;
 	font-weight: 400;
 }
 
-.daily-archive .archive-hero-topics {
+.daily-archive .detail-topics {
 	display: flex;
 	flex-wrap: wrap;
 	gap: 8px;
-	margin: 18px 0 0;
+	margin: 16px 0 0;
 	padding: 0;
 	list-style: none;
 }
 
-.daily-archive .archive-hero-topics li {
+.daily-archive .detail-topics li {
 	padding: 3px 12px;
 	border-radius: 999px;
 	background: var(--blue-soft);
@@ -488,144 +928,60 @@ h1 {
 	font-size: 0.78rem;
 }
 
-.daily-archive .archive-hero-headline {
-	max-width: 60ch;
-	margin: 20px 0 0;
-	color: var(--ink-soft);
-	font-size: 0.92rem;
+.daily-archive .detail-body {
+	margin-top: 20px;
+	padding-top: 16px;
+	border-top: 1px solid var(--rule-soft);
 }
 
-.daily-archive .archive-hero-headline strong {
-	color: var(--ink);
+.daily-archive .detail-label {
+	margin: 0 0 8px;
+	color: var(--ink-faint);
+	font-size: 0.68rem;
+	letter-spacing: 0.18em;
+}
+
+.daily-archive .detail-headline {
+	margin: 0;
+	font-family: var(--serif);
+	font-size: 1rem;
 	font-weight: 600;
+	line-height: 1.6;
 }
 
-.daily-archive .archive-hero-meta {
-	margin: 22px 0 0;
+.daily-archive .detail-meta {
+	margin: 18px 0 20px;
 	color: var(--ink-faint);
 	font-family: var(--mono);
 	font-size: 0.74rem;
 }
 
-.daily-archive .month-group {
-	margin-bottom: clamp(32px, 5vw, 48px);
-}
-
-.daily-archive .month-heading {
-	display: flex;
-	align-items: baseline;
-	gap: 14px;
-	margin-bottom: 4px;
-	padding-bottom: 10px;
-	border-bottom: 1px solid var(--rule);
-}
-
-.daily-archive .month-heading h2 {
-	margin: 0;
-	font-family: var(--serif);
-	font-size: 1.15rem;
-	font-weight: 700;
-}
-
-.daily-archive .month-heading .count {
-	color: var(--ink-faint);
-	font-family: var(--mono);
-	font-size: 0.72rem;
-}
-
-.daily-archive .month-heading .range {
-	margin-left: auto;
-	color: var(--ink-faint);
-	font-family: var(--mono);
-	font-size: 0.72rem;
-}
-
-.daily-archive .day-row {
-	display: grid;
-	grid-template-columns: 56px 74px minmax(0, 1fr) auto;
-	align-items: baseline;
-	gap: 18px;
-	padding: 11px 6px;
-	border-bottom: 1px solid color-mix(in srgb, var(--rule) 45%, transparent);
-	border-radius: 3px;
-	text-decoration: none;
-	transition: background 0.12s ease;
-}
-
-.daily-archive .day-row:hover {
-	background: var(--paper-raised);
-	color: inherit;
-}
-
-.daily-archive .day-row:hover .day-num {
-	color: var(--blue);
-}
-
-.daily-archive .day-row .day-num {
-	font-family: var(--serif);
-	font-size: 1.5rem;
-	font-weight: 700;
-	line-height: 1;
-	text-align: right;
-}
-
-.daily-archive .day-row .weekday {
-	color: var(--ink-faint);
-	font-size: 0.76rem;
-}
-
-.daily-archive .day-row .topics {
-	overflow: hidden;
-	color: var(--ink-soft);
+.daily-archive .detail-cta {
+	display: inline-flex;
+	align-items: center;
+	gap: 8px;
+	padding: 10px 18px;
+	border: 0;
+	border-radius: 8px;
+	background: var(--ink);
+	color: var(--paper);
+	font-family: inherit;
 	font-size: 0.82rem;
-	text-overflow: ellipsis;
-	white-space: nowrap;
-}
-
-.daily-archive .day-row .items {
-	color: var(--ink-faint);
-	font-family: var(--mono);
-	font-size: 0.72rem;
-	white-space: nowrap;
-}
-
-.daily-archive .day-row.today .day-num {
-	color: var(--blue);
-}
-
-.daily-archive .day-row .today-pill {
-	margin-left: 8px;
-	padding: 1px 7px;
-	border-radius: 999px;
-	background: var(--blue-soft);
-	color: var(--blue);
-	font-size: 0.66rem;
-}
-
-.daily-archive details.month-group .month-heading {
-	border-bottom-style: dashed;
+	text-decoration: none;
 	cursor: pointer;
-	list-style: none;
+	transition: background 0.15s ease;
 }
 
-.daily-archive details.month-group .month-heading::-webkit-details-marker {
-	display: none;
+.daily-archive .detail-cta:hover {
+	background: var(--blue);
+	color: var(--paper);
 }
 
-.daily-archive details.month-group .month-heading::after {
-	margin-left: 12px;
-	color: var(--ink-faint);
-	content: '+';
-	font-family: var(--mono);
-	font-size: 0.8rem;
-}
-
-.daily-archive details.month-group[open] .month-heading {
-	border-bottom-style: solid;
-}
-
-.daily-archive details.month-group[open] .month-heading::after {
-	content: '–';
+.daily-archive .detail-empty {
+	margin: 0 0 20px;
+	color: var(--ink-soft);
+	font-size: 0.9rem;
+	line-height: 1.8;
 }
 
 .article-shell {
@@ -840,6 +1196,18 @@ h1 {
 	.site-footer {
 		width: min(100% - 40px, 1180px);
 	}
+
+	.daily-archive .archive-layout {
+		grid-template-columns: 1fr;
+	}
+
+	.daily-archive .archive-rail {
+		position: static;
+	}
+
+	.daily-archive .year-grid {
+		grid-template-columns: repeat(3, minmax(0, 1fr));
+	}
 }
 
 @media (max-width: 560px) {
@@ -863,17 +1231,21 @@ h1 {
 		letter-spacing: -0.02em;
 	}
 
-	.daily-archive .archive-hero {
+	.daily-archive .detail-card {
 		padding: 24px;
 	}
 
-	.daily-archive .day-row {
-		grid-template-columns: 44px minmax(0, 1fr) auto;
-		gap: 12px;
+	.daily-archive .year-grid {
+		grid-template-columns: repeat(2, minmax(0, 1fr));
 	}
 
-	.daily-archive .day-row .weekday {
-		display: none;
+	.daily-archive .cell {
+		min-height: 76px;
+		padding: 8px 9px;
+	}
+
+	.daily-archive .cell .day {
+		font-size: 0.95rem;
 	}
 
 	.site-footer {


### PR DESCRIPTION
## 概述

将 `/daily/`（及 `/en/daily/`）归档页从倒序列表重构为**日历视图**：月份即版面，日期即期刊。

- **月视图**：7 列月历，有刊日显示分类圆点 + 收录条数，底色深浅随当日条数（按月归一）；今天蓝圈标记
- **年视图**：4×3 迷你月历矩阵（GitHub contributions 式），热力按**年**全局归一，跨月可比；附「最长连发 / 最厚一期」年度统计
- **详情卡**：右侧吸顶，承载原「最新一期」hero 信息，点选任意有刊日即时切换；无刊日显示「这一天没有发布日报」

## 实现

- `DailyArchive.astro`：全量服务端渲染月/年网格 + JSON 数据块；有刊日为真实链接，无 JS 也可逐期跳转；中英文双语
- `scripts/dailyCalendar.ts`：视图切换 / 翻页 / 选中 / 详情卡重渲染（`astro:page-load` 初始化，无内联处理器，CSP 安全）
- `lib/dailyCalendar.ts`：网格、热力、连发纯函数，9 个单测
- `migration.css`：日历样式 + 8 个分类色 token（含暗色变体）

## 验证

- `astro check` 0 错误；`vitest` 全绿；`eslint` 通过
- 根 `npm test`（578 例）与 `verify:renderers`（214 条日报路由 parity）通过
- `npm run verify --prefix astro` 全量通过（641 路由契约 + CSP + site contract）
- CDP 截图核验 月/年 × 浅/深 × 中/英 六种渲染组合

设计稿与说明：`artifacts/daily-calendar/`（本地，未入库）