### PR TITLE
fix: drop the external-link arrow after timeline titles

### DIFF
--- a/astro/src/components/DailyTimeline.astro
+++ b/astro/src/components/DailyTimeline.astro
@@ -284,7 +284,7 @@ const olderKey = hrefDateKey(olderHref);
 											<h3 title={title}>
 												{item.canonical_url ? (
 													<a href={item.canonical_url} target="_blank" rel="noopener noreferrer">
-														{title} <span class="ext">↗</span>
+														{title}
 													</a>
 												) : (
 													title

--- a/astro/src/components/QuietIndexHome.astro
+++ b/astro/src/components/QuietIndexHome.astro
@@ -225,7 +225,7 @@ const previousDays = (
 										<h3>
 											{item.canonical_url ? (
 												<a href={item.canonical_url} target="_blank" rel="noopener noreferrer">
-													{title} <span class="ext">↗</span>
+													{title}
 												</a>
 											) : (
 												title

--- a/astro/src/styles/quiet-index.css
+++ b/astro/src/styles/quiet-index.css
@@ -265,11 +265,6 @@
 	text-decoration: none;
 }
 
-.quiet-home .feed-item h3 .ext {
-	color: var(--ink-faint);
-	font-size: 0.72em;
-}
-
 .quiet-home .feed-item p {
 	display: -webkit-box;
 	overflow: hidden;


### PR DESCRIPTION
## 概述

首页「今日流」每一行、日报详情页时间线每一条，标题末尾都带一个 ↗ 外链图标。整个标题本身就是出站链接，重复的符号纯属视觉噪音，全部去除。

## 改动

- `DailyTimeline.astro` / `QuietIndexHome.astro`：删除标题后的 `<span class="ext">↗</span>`
- `quiet-index.css`：清理不再使用的 `.ext` 规则

链接行为不变（`<h3>` 整行仍是 `target="_blank"` 外链）。

## 验证

- `astro check` / `eslint` 全绿
- `verify:renderers` 214 条日报路由 parity 通过
- 首页与日报详情页截图确认标题行无残留图标