### PR TITLE
fix: scope search coverage invariants to the static index window

### DIFF
--- a/scripts/verify-site.mjs
+++ b/scripts/verify-site.mjs
@@ -365,6 +365,16 @@ if (pinnedContentBuild) {
 const expectedSearchDates = dailyDataNames.map((name) =>
   name.slice(0, -".json".length),
 );
+// The static search index intentionally covers only the most recent report
+// days (STATIC_SEARCH_MAX_REPORT_DAYS in astro/src/lib/searchIndex.ts — keep
+// this value in sync). Search coverage invariants below apply to that window;
+// JSON route and rendered-HTML checks still cover every published day.
+const STATIC_SEARCH_MAX_REPORT_DAYS = 7;
+const expectedSearchWindow = new Set(
+  [...expectedSearchDates]
+    .sort((left, right) => right.localeCompare(left))
+    .slice(0, STATIC_SEARCH_MAX_REPORT_DAYS),
+);
 const pinnedEnglishDailyRssIdentities = new Set(
   pinnedContentBuild
     ? expectedSearchDates.map((date) => {
@@ -392,34 +402,36 @@ for (const name of dailyDataNames) {
   );
   const report = JSON.parse(source.toString("utf8"));
   const date = name.slice(0, -".json".length);
-  expectedSearchItemCount += report.items.length;
-  const searchItems = searchIndex.items.filter((item) => item.date === date);
-  const expectedSearchItems = new Map(
-    report.items.map((item) => [
-      `${date}:${item.id}`,
-      `/daily/${date.slice(0, 4)}/${date.slice(5, 7)}/${date}/#news-${item.id}`,
-    ]),
-  );
-  invariant(
-    searchIndex.report_dates.includes(date) &&
-      searchItems.length === report.items.length &&
-      expectedSearchItems.size === report.items.length,
-    `Structured daily search coverage drifted: ${date}`,
-  );
-  const seenSearchKeys = new Set();
-  for (const item of searchItems) {
-    invariant(
-      !seenSearchKeys.has(item.key) &&
-        expectedSearchItems.get(item.key) === item.href,
-      `Structured daily search item drifted: ${item.key}`,
+  if (expectedSearchWindow.has(date)) {
+    expectedSearchItemCount += report.items.length;
+    const searchItems = searchIndex.items.filter((item) => item.date === date);
+    const expectedSearchItems = new Map(
+      report.items.map((item) => [
+        `${date}:${item.id}`,
+        `/daily/${date.slice(0, 4)}/${date.slice(5, 7)}/${date}/#news-${item.id}`,
+      ]),
     );
-    seenSearchKeys.add(item.key);
+    invariant(
+      searchIndex.report_dates.includes(date) &&
+        searchItems.length === report.items.length &&
+        expectedSearchItems.size === report.items.length,
+      `Structured daily search coverage drifted: ${date}`,
+    );
+    const seenSearchKeys = new Set();
+    for (const item of searchItems) {
+      invariant(
+        !seenSearchKeys.has(item.key) &&
+          expectedSearchItems.get(item.key) === item.href,
+        `Structured daily search item drifted: ${item.key}`,
+      );
+      seenSearchKeys.add(item.key);
+    }
+    invariant(
+      seenSearchKeys.size === expectedSearchItems.size &&
+        [...expectedSearchItems.keys()].every((key) => seenSearchKeys.has(key)),
+      `Structured daily search keys drifted: ${date}`,
+    );
   }
-  invariant(
-    seenSearchKeys.size === expectedSearchItems.size &&
-      [...expectedSearchItems.keys()].every((key) => seenSearchKeys.has(key)),
-    `Structured daily search keys drifted: ${date}`,
-  );
   const [year, month] = date.split("-");
   const dailyHtml = await readFile(
     resolve(distRoot, "daily", year, month, date, "index.html"),
@@ -434,8 +446,8 @@ for (const name of dailyDataNames) {
 }
 invariant(
   new Set(searchIndex.report_dates).size === searchIndex.report_dates.length &&
-    searchIndex.report_dates.length === expectedSearchDates.length &&
-    expectedSearchDates.every((date) =>
+    searchIndex.report_dates.length === expectedSearchWindow.size &&
+    [...expectedSearchWindow].every((date) =>
       searchIndex.report_dates.includes(date),
     ),
   "Structured daily search report dates drifted",


### PR DESCRIPTION
## 问题

静态搜索索引设计上只覆盖**最近 7 天**的报告（`STATIC_SEARCH_MAX_REPORT_DAYS = 7`)，但 `verify-site.mjs` 的覆盖校验要求**每一天**结构化报告都完整入索引。结构化切换（07-16）以来的第 8 天——今天的 2026-07-23——使该契约不可满足，自动化日报 PR #134 的 build-and-deploy 与 renderer-parity 双双失败（`Structured daily search coverage drifted: 2026-07-16`)，且此后每天的日报 PR 都会被堵。

## 修复

校验逻辑与产品行为对齐：

- 搜索覆盖相关断言（coverage / keys / report_dates / item_count）只作用于**最近 7 天窗口**（按日期降序取前 7，常量与 `searchIndex.ts` 保持同步并注明）
- 其余不变量（JSON 路由、字节一致、渲染 HTML 条目齐全）仍覆盖**每一天**，不放松真实契约

## 验证

- 本地以 8 天完整数据（含 PR #134 的 07-23 三件套）跑 `npm run verify --prefix astro` 通过
- 窗口内（≤7 天）行为与之前完全一致