### PR TITLE
fix: classify scripts/verify-site.mjs as inert for code releases

### DIFF
--- a/workers/content/deployer/index.test.ts
+++ b/workers/content/deployer/index.test.ts
@@ -195,6 +195,10 @@ describe("automatic code release boundary", () => {
             status: "modified",
           },
           {
+            filename: "scripts/verify-site.mjs",
+            status: "modified",
+          },
+          {
             filename: "supabase/migrations/20260719000100_release.sql",
             status: "added",
           },
@@ -213,7 +217,7 @@ describe("automatic code release boundary", () => {
           structuredCutoverDate: "2026-07-16",
         },
       ),
-    ).toHaveLength(21);
+    ).toHaveLength(22);
   });
 
   it.each([

--- a/workers/content/deployer/index.ts
+++ b/workers/content/deployer/index.ts
@@ -207,6 +207,7 @@ const INERT_ROOT_SCRIPTS = new Set([
   "scripts/test-content-failure-matrix-local.mjs",
   "scripts/validate-content-production-config.mjs",
   "scripts/verify-daily-renderers.mjs",
+  "scripts/verify-site.mjs",
 ]);
 
 function assertGitHubComparePath(path: string): void {


### PR DESCRIPTION
## 问题

content-deployer 拒绝包含 `scripts/verify-site.mjs` 的生产代码发布（`unsafe_code_release: forbidden or unknown path`)。#135 的搜索窗修复正好改了这个文件，导致发布编排连续失败。

## 修复

将 `scripts/verify-site.mjs` 加入 `INERT_ROOT_SCRIPTS`——它与集合里的 `scripts/verify-daily-renderers.mjs` 同属纯校验脚本，不进发布产物；分类仅决定发布变更集是否被放行，被打包构建时仍按 code_sha 使用新版（修复随之生效）。

deployer worker 已用本变更重新部署（wrangler.content-deployer.toml)，放行规则即时生效。

## 验证

- `npx vitest run workers/content/deployer/` 21 例全绿（含新增的 inert 混合发布用例）