### PR TITLE
fix: drop production route from astro worker config

### DIFF
--- a/astro/wrangler.jsonc
+++ b/astro/wrangler.jsonc
@@ -7,10 +7,6 @@
 		{
 			"pattern": "astro-preview.bubblenews.today",
 			"custom_domain": true
-		},
-		{
-			"pattern": "bubblenews.today/*",
-			"zone_name": "bubblenews.today"
 		}
 	],
 	"kv_namespaces": [


### PR DESCRIPTION
## Why

The `bubblenews.today/*` route in `astro/wrangler.jsonc` meant any manual `wrangler deploy` of the Astro worker hijacked the production domain ahead of the Pages custom domain (Workers routes take precedence). This froze the fenced release pipeline on 2026-07-23: every promotion after 16:04 UTC failed with broker 503 (production verification could never converge against the worker's stale baked manifest), accumulating 4 dead letters and halting release dispatch.

Per `astro/CLAUDE.md`, Hugo/Pages remains the production renderer until an explicit cutover decision. The route has already been removed from the live zone via API; this change keeps a future worker deploy from re-attaching it.

## What

- Remove the `bubblenews.today/*` zone route from the Astro worker config
- Keep the `astro-preview.bubblenews.today` custom domain for verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)