### PR TITLE
fix: recover stalled content and code releases

### DIFF
--- a/scripts/request-production-promotion.mjs
+++ b/scripts/request-production-promotion.mjs
@@ -22,9 +22,13 @@ const response = await fetch(new URL("/v1/promote", brokerUrl), {
   },
   body,
 });
+const responseBody = await response.text();
 if (!response.ok) {
+  const diagnosticBody = responseBody.trim().slice(0, 4096);
   throw new Error(
-    `Production Broker rejected promotion with ${response.status}`,
+    `Production Broker rejected promotion with ${response.status}${
+      diagnosticBody ? `: ${diagnosticBody}` : ""
+    }`,
   );
 }
-process.stdout.write(await response.text());
+process.stdout.write(responseBody);

--- a/workers/content/broker/index.test.ts
+++ b/workers/content/broker/index.test.ts
@@ -1,12 +1,14 @@
 import { createHash } from "node:crypto";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
+  deploymentMatchesContext,
   handleRollbackRequest,
   isCommittedPromotionContext,
   pagesAssetHash,
   parseContentAddressedArtifact,
   parseDeterministicTar,
   purgeContentCaches,
+  reconcileProduction,
   uploadPages,
   verifyDeployment,
 } from "./index";
@@ -26,6 +28,111 @@ describe("promotion commit recovery", () => {
     expect(isCommittedPromotionContext(context, "target-release", 8)).toBe(
       false,
     );
+  });
+
+  it("recognizes the exact last-known-good Pages deployment", () => {
+    const context = {
+      code_sha: "a".repeat(40),
+      site_release_sequence: 111,
+    } as never;
+    expect(
+      deploymentMatchesContext(
+        {
+          id: "123e4567-e89b-42d3-a456-426614174000",
+          url: "https://release.pages.dev",
+          commitHash: "a".repeat(40),
+          commitMessage: "content release 111",
+        },
+        context,
+      ),
+    ).toBe(true);
+    expect(
+      deploymentMatchesContext(
+        {
+          id: "123e4567-e89b-42d3-a456-426614174000",
+          url: "https://release.pages.dev",
+          commitHash: "a".repeat(40),
+          commitMessage: "content release 110",
+        },
+        context,
+      ),
+    ).toBe(false);
+  });
+
+  it("reuses an already restored deployment instead of uploading it again", async () => {
+    const target = {
+      site_release_id: "123e4567-e89b-42d3-a456-426614174001",
+      site_release_sequence: 112,
+      code_sha: "b".repeat(40),
+    };
+    const current = {
+      site_release_id: "123e4567-e89b-42d3-a456-426614174000",
+      site_release_sequence: 111,
+      code_sha: "a".repeat(40),
+    };
+    const queries: string[] = [];
+    const sql = vi.fn(async (strings: TemplateStringsArray) => {
+      const query = strings.join("?");
+      queries.push(query);
+      if (query.includes("begin_production_reconcile_v1")) {
+        return [
+          {
+            result: {
+              slot: {
+                operation: "forward",
+                fencing_token: 7,
+                expected_pointer_generation: 49,
+              },
+              target,
+              current,
+            },
+          },
+        ];
+      }
+      if (query.includes("finish_production_recovery_v1")) return [];
+      throw new Error(`Unexpected SQL: ${query}`);
+    });
+    const end = vi.fn(async () => undefined);
+    Object.assign(sql, {
+      json: vi.fn((value: unknown) => value),
+      end,
+    });
+    const verify = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("target is not current"))
+      .mockResolvedValueOnce({ multi_edge_verified: true });
+    const upload = vi.fn();
+    const latest = {
+      id: "123e4567-e89b-42d3-a456-426614174010",
+      url: "https://release.pages.dev",
+      commitHash: current.code_sha,
+      commitMessage: "content release 111",
+    };
+
+    await expect(
+      reconcileProduction({} as never, {
+        openDatabase: vi.fn(() => sql as never),
+        loadArtifact: vi.fn(async () => ({ kind: "tar", files: [] }) as never),
+        upload,
+        verify,
+        latestDeployment: vi.fn(async () => latest),
+        purge: vi.fn(),
+      }),
+    ).resolves.toBe("restored");
+
+    expect(upload).not.toHaveBeenCalled();
+    expect(verify).toHaveBeenNthCalledWith(
+      2,
+      current,
+      latest.url,
+      expect.anything(),
+      expect.anything(),
+      undefined,
+    );
+    expect(
+      queries.some((query) => query.includes("finish_production_recovery_v1")),
+    ).toBe(true);
+    expect(end).toHaveBeenCalledWith({ timeout: 2 });
   });
 });
 

--- a/workers/content/broker/index.ts
+++ b/workers/content/broker/index.ts
@@ -144,11 +144,9 @@ async function hmacHex(secret: string, bytes: Uint8Array): Promise<string> {
 }
 
 function base64(bytes: Uint8Array): string {
-  return Buffer.from(
-    bytes.buffer,
-    bytes.byteOffset,
-    bytes.byteLength,
-  ).toString("base64");
+  return Buffer.from(bytes.buffer, bytes.byteOffset, bytes.byteLength).toString(
+    "base64",
+  );
 }
 
 function tarText(bytes: Uint8Array, start: number, length: number): string {
@@ -1330,7 +1328,14 @@ async function promote(request: Request, env: Env): Promise<Response> {
         stage: promotionStage,
         ...errorDiagnostics(error),
       });
-      return json({ error: "promotion_commit_ambiguous" }, 503);
+      return json(
+        {
+          error: "promotion_commit_ambiguous",
+          stage: promotionStage,
+          diagnostics: errorDiagnostics(error),
+        },
+        503,
+      );
     }
     if (authorization && context) {
       const token = Number(authorization.fencing_token);
@@ -1373,7 +1378,14 @@ async function promote(request: Request, env: Env): Promise<Response> {
       stage: promotionStage,
       ...errorDiagnostics(error),
     });
-    return json({ error: "promotion_failed" }, 503);
+    return json(
+      {
+        error: "promotion_failed",
+        stage: promotionStage,
+        diagnostics: errorDiagnostics(error),
+      },
+      503,
+    );
   } finally {
     await sql.end({ timeout: 2 });
   }
@@ -1466,9 +1478,16 @@ export async function handleRollbackRequest(
   }
 }
 
+type ProductionDeployment = {
+  id: string;
+  url: string;
+  commitHash: string;
+  commitMessage: string;
+};
+
 async function latestProductionDeployment(
   env: Env,
-): Promise<{ id: string; url: string }> {
+): Promise<ProductionDeployment> {
   const api = "https://api.cloudflare.com/client/v4";
   const result = await cfApi<JsonRecord[]>(
     `${api}/accounts/${encodeURIComponent(env.CLOUDFLARE_ACCOUNT_ID)}/pages/projects/${encodeURIComponent(env.PAGES_PROJECT)}/deployments?env=production&page=1&per_page=1`,
@@ -1477,15 +1496,53 @@ async function latestProductionDeployment(
   );
   const id = String(result[0]?.id || "");
   const url = String(result[0]?.url || "");
-  if (!UUID.test(id) || !/^https:\/\//.test(url))
+  const trigger = result[0]?.deployment_trigger as JsonRecord | undefined;
+  const metadata = trigger?.metadata as JsonRecord | undefined;
+  const commitHash = String(metadata?.commit_hash || "");
+  const commitMessage = String(metadata?.commit_message || "");
+  if (
+    !UUID.test(id) ||
+    !/^https:\/\//.test(url) ||
+    !SHA1.test(commitHash) ||
+    !commitMessage
+  ) {
     throw new Error("No production Pages deployment is available");
-  return { id, url };
+  }
+  return { id, url, commitHash, commitMessage };
 }
+
+export function deploymentMatchesContext(
+  deployment: ProductionDeployment,
+  context: ArtifactContext,
+): boolean {
+  return (
+    deployment.commitHash === context.code_sha &&
+    deployment.commitMessage ===
+      `content release ${context.site_release_sequence}`
+  );
+}
+
+type ReconcileDependencies = {
+  openDatabase?: typeof openContentDatabase;
+  loadArtifact?: typeof artifactFiles;
+  upload?: typeof uploadPages;
+  verify?: typeof verifyDeployment;
+  latestDeployment?: typeof latestProductionDeployment;
+  purge?: typeof purgeContentCaches;
+};
 
 export async function reconcileProduction(
   env: Env,
+  dependencies: ReconcileDependencies = {},
 ): Promise<"empty" | "committed" | "restored"> {
-  const sql = openContentDatabase(env, "content-production-reconciler");
+  const sql = (dependencies.openDatabase || openContentDatabase)(
+    env,
+    "content-production-reconciler",
+  );
+  const loadArtifact = dependencies.loadArtifact || artifactFiles;
+  const upload = dependencies.upload || uploadPages;
+  const verify = dependencies.verify || verifyDeployment;
+  const purge = dependencies.purge || purgeContentCaches;
   try {
     const rows = await sql<
       JsonRecord[]
@@ -1495,13 +1552,15 @@ export async function reconcileProduction(
     const slot = reconciliation.slot as JsonRecord;
     const target = reconciliation.target as unknown as ArtifactContext;
     const current = reconciliation.current as unknown as ArtifactContext | null;
-    const deployment = await latestProductionDeployment(env);
+    const deployment = await (
+      dependencies.latestDeployment || latestProductionDeployment
+    )(env);
     try {
-      const targetFiles = await artifactFiles(target, env);
+      const targetFiles = await loadArtifact(target, env);
       // Recovery runs on the Free-plan 50-subrequest budget. Probe the
       // interrupted target once; if it has not already converged, preserve the
       // rest of this invocation for restoring and verifying last-known-good.
-      const evidence = await verifyDeployment(
+      const evidence = await verify(
         target,
         deployment.url,
         env,
@@ -1509,7 +1568,7 @@ export async function reconcileProduction(
         undefined,
         { maximumAttempts: 1 },
       );
-      await purgeContentCaches(env);
+      await purge(env);
       if (slot.operation === "forward") {
         await rpc(
           sql,
@@ -1551,10 +1610,23 @@ export async function reconcileProduction(
         )`;
         return "restored";
       }
-      const currentFiles = await artifactFiles(current, env);
-      const restorationStartedAt = Date.now();
-      const restored = await uploadPages(currentFiles, current, env);
-      const evidence = await verifyDeployment(
+      const currentFiles = await loadArtifact(current, env);
+      const reuseLatest = deploymentMatchesContext(deployment, current);
+      const restorationStartedAt = reuseLatest ? undefined : Date.now();
+      const restored = reuseLatest
+        ? deployment
+        : await upload(currentFiles, current, env);
+      if (reuseLatest) {
+        console.info(
+          "[ContentBroker] reusing latest last-known-good deployment during recovery",
+          {
+            deploymentId: deployment.id,
+            siteReleaseId: current.site_release_id,
+            siteReleaseSequence: current.site_release_sequence,
+          },
+        );
+      }
+      const evidence = await verify(
         current,
         restored.url,
         env,

--- a/workers/content/deployer/index.test.ts
+++ b/workers/content/deployer/index.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import { createHash } from "node:crypto";
 import {
   dispatchOne,
+  diffGitHubTrees,
   handleBuildContentRequest,
   handleCodeReleaseRequest,
   handleRecoveryHealthCallback,
@@ -206,6 +207,20 @@ describe("automatic code release boundary", () => {
             filename: "data/daily/2026-07-19.json",
             status: "modified",
           },
+          {
+            filename: "astro/scripts/generate-site-contract.mjs",
+            status: "modified",
+          },
+          { filename: "astro/wrangler.jsonc", status: "added" },
+          { filename: "cloudflare-pages.toml", status: "modified" },
+          { filename: "themes/hextra/theme.toml", status: "removed" },
+          { filename: "layouts/index.html", status: "removed" },
+          { filename: "i18n/en.toml", status: "removed" },
+          { filename: "hugo.toml", status: "removed" },
+          {
+            filename: "scripts/sync-daily-to-hugo.sh",
+            status: "removed",
+          },
         ]),
         {
           baseCodeSha,
@@ -213,11 +228,105 @@ describe("automatic code release boundary", () => {
           structuredCutoverDate: "2026-07-16",
         },
       ),
-    ).toHaveLength(21);
+    ).toHaveLength(29);
   });
 
   it.each([
-    "astro/scripts/generate-static-data.mjs",
+    "themes/hextra/theme.toml",
+    "layouts/index.html",
+    "i18n/en.toml",
+    "hugo.toml",
+    "scripts/sync-daily-to-hugo.sh",
+  ])("rejects reintroducing retired Hugo path %s", (retiredPath) => {
+    expect(() =>
+      validateCodeReleaseChangeSet(
+        comparison([
+          { filename: "astro/src/pages/index.astro", status: "modified" },
+          { filename: retiredPath, status: "added" },
+        ]),
+        {
+          baseCodeSha,
+          targetCodeSha,
+          structuredCutoverDate: "2026-07-16",
+        },
+      ),
+    ).toThrow(`Code release may only remove retired Hugo path: ${retiredPath}`);
+  });
+
+  it("accepts a complete classified change set above the compare API file cap", () => {
+    const files = Array.from({ length: 301 }, (_, index) => ({
+      filename: `workers/generated/file-${String(index).padStart(3, "0")}.ts`,
+      status: "modified",
+    }));
+    expect(
+      validateCodeReleaseChangeSet(comparison(files), {
+        baseCodeSha,
+        targetCodeSha,
+        structuredCutoverDate: "2026-07-16",
+      }),
+    ).toHaveLength(301);
+  });
+
+  it("derives a complete deterministic change set from Git trees", () => {
+    const unchanged = {
+      path: "workers/unchanged.ts",
+      mode: "100644",
+      type: "blob",
+      sha: "1".repeat(40),
+    };
+    expect(
+      diffGitHubTrees(
+        [
+          unchanged,
+          {
+            path: "workers/removed.ts",
+            mode: "100644",
+            type: "blob",
+            sha: "2".repeat(40),
+          },
+          {
+            path: "workers/modified.ts",
+            mode: "100644",
+            type: "blob",
+            sha: "3".repeat(40),
+          },
+        ],
+        [
+          unchanged,
+          {
+            path: "workers/added.ts",
+            mode: "100644",
+            type: "blob",
+            sha: "4".repeat(40),
+          },
+          {
+            path: "workers/modified.ts",
+            mode: "100755",
+            type: "blob",
+            sha: "5".repeat(40),
+          },
+        ],
+      ),
+    ).toEqual([
+      {
+        filename: "workers/added.ts",
+        status: "added",
+        sha: "4".repeat(40),
+      },
+      {
+        filename: "workers/modified.ts",
+        status: "modified",
+        sha: "5".repeat(40),
+      },
+      {
+        filename: "workers/removed.ts",
+        status: "removed",
+        sha: "2".repeat(40),
+      },
+    ]);
+  });
+
+  it.each([
     "static/highlights.json",
     "content/about/index.md",
     "data/daily/2026-07-15.json",

--- a/workers/content/deployer/index.ts
+++ b/workers/content/deployer/index.ts
@@ -171,8 +171,16 @@ type GitHubCompare = {
   status: string;
   base_commit?: { sha?: string };
   merge_base_commit?: { sha?: string };
+  head_commit?: { sha?: string };
   commits?: Array<{ sha?: string }>;
   files?: GitHubFile[];
+};
+
+type GitHubTreeEntry = {
+  path: string;
+  mode: string;
+  type: string;
+  sha: string;
 };
 
 async function githubJson(
@@ -203,11 +211,29 @@ type CodeReleasePathClass = "publishable" | "inert" | "db_owned";
 const INERT_ROOT_SCRIPTS = new Set([
   "scripts/check-content-observability.mjs",
   "scripts/check-content-observation-window.mjs",
+  "scripts/pull-daily-content.sh",
   "scripts/request-code-release.mjs",
   "scripts/test-content-failure-matrix-local.mjs",
   "scripts/validate-content-production-config.mjs",
   "scripts/verify-site.mjs",
 ]);
+
+const RETIRED_HUGO_PATHS = new Set([
+  "archetypes/daily.md",
+  "hugo.toml",
+  "scripts/auto-sync-and-cleanup.sh",
+  "scripts/fix-github-dirs.sh",
+  "scripts/migrate-to-cf-pages.sh",
+  "scripts/setup-domain.sh",
+  "scripts/sync-daily-to-hugo.js",
+  "scripts/sync-daily-to-hugo.sh",
+  "scripts/test-future-content.sh",
+  "scripts/test-hugo-build.sh",
+  "scripts/verify-daily-renderers.mjs",
+  "view-site.sh",
+]);
+
+const RETIRED_HUGO_PREFIXES = ["i18n/", "layouts/", "themes/"];
 
 function assertGitHubComparePath(path: string): void {
   if (
@@ -233,12 +259,21 @@ function structuredDateFromPath(path: string): string | null {
 function classifyCodeReleasePath(
   path: string,
   structuredCutoverDate: string,
+  status: string,
 ): CodeReleasePathClass {
   assertGitHubComparePath(path);
 
   const structuredDate = structuredDateFromPath(path);
   if (structuredDate && structuredDate >= structuredCutoverDate)
     return "db_owned";
+
+  if (
+    RETIRED_HUGO_PATHS.has(path) ||
+    RETIRED_HUGO_PREFIXES.some((prefix) => path.startsWith(prefix))
+  ) {
+    if (status === "removed") return "inert";
+    throw new Error(`Code release may only remove retired Hugo path: ${path}`);
+  }
 
   if (
     /(?:^|\/)\w[^/]*\.test\.[cm]?[jt]sx?$/.test(path) ||
@@ -262,6 +297,8 @@ function classifyCodeReleasePath(
       "astro/eslint.config.js",
       "astro/prettier.config.mjs",
       "astro/vitest.config.ts",
+      "package.json",
+      "start.sh",
       "wrangler.content-deployer.toml",
       "wrangler.toml",
       "wrangler.staging.toml",
@@ -273,6 +310,7 @@ function classifyCodeReleasePath(
 
   if (
     [
+      "astro/scripts/",
       "astro/src/pages/",
       "astro/src/components/",
       "astro/src/layouts/",
@@ -290,6 +328,8 @@ function classifyCodeReleasePath(
       "astro/raw-html-policy.json",
       "astro/route-ownership.json",
       "astro/tsconfig.json",
+      "astro/wrangler.jsonc",
+      "cloudflare-pages.toml",
       "data/knowledge/taxonomy.json",
       "static/css/daily-timeline.css",
       "static/js/ai-infographic.js",
@@ -314,15 +354,15 @@ export function validateCodeReleaseChangeSet(
   },
 ): GitHubFile[] {
   const files = compare.files;
+  const headSha =
+    compare.head_commit?.sha || compare.commits?.at(-1)?.sha || "";
   if (
     compare.status !== "ahead" ||
     compare.base_commit?.sha !== input.baseCodeSha ||
     compare.merge_base_commit?.sha !== input.baseCodeSha ||
-    !Array.isArray(compare.commits) ||
-    compare.commits.at(-1)?.sha !== input.targetCodeSha ||
+    headSha !== input.targetCodeSha ||
     !Array.isArray(files) ||
     files.length === 0 ||
-    files.length >= 300 ||
     !DATE.test(input.structuredCutoverDate)
   ) {
     throw new Error("GitHub compare is not a complete fast-forward change set");
@@ -335,17 +375,90 @@ export function validateCodeReleaseChangeSet(
     ) {
       throw new Error("Malformed GitHub compare file");
     }
-    classifyCodeReleasePath(file.filename, input.structuredCutoverDate);
+    classifyCodeReleasePath(
+      file.filename,
+      input.structuredCutoverDate,
+      file.status,
+    );
     if (file.previous_filename !== undefined) {
       if (typeof file.previous_filename !== "string")
         throw new Error("Malformed GitHub compare file");
       classifyCodeReleasePath(
         file.previous_filename,
         input.structuredCutoverDate,
+        "removed",
       );
     }
   }
   return files;
+}
+
+function parseGitHubTree(value: Record<string, unknown>): GitHubTreeEntry[] {
+  if (value.truncated !== false || !Array.isArray(value.tree)) {
+    throw new Error("GitHub tree is incomplete");
+  }
+  const entries: GitHubTreeEntry[] = [];
+  const paths = new Set<string>();
+  for (const candidate of value.tree) {
+    if (!candidate || typeof candidate !== "object" || Array.isArray(candidate))
+      throw new Error("GitHub tree entry is malformed");
+    const entry = candidate as Record<string, unknown>;
+    const path = String(entry.path || "");
+    const mode = String(entry.mode || "");
+    const type = String(entry.type || "");
+    const sha = String(entry.sha || "");
+    if (type === "tree") continue;
+    assertGitHubComparePath(path);
+    if (
+      paths.has(path) ||
+      !/^[0-7]{6}$/.test(mode) ||
+      !["blob", "commit"].includes(type) ||
+      !SHA1.test(sha)
+    ) {
+      throw new Error("GitHub tree entry is malformed");
+    }
+    paths.add(path);
+    entries.push({ path, mode, type, sha });
+  }
+  return entries;
+}
+
+export function diffGitHubTrees(
+  baseTree: GitHubTreeEntry[],
+  targetTree: GitHubTreeEntry[],
+): GitHubFile[] {
+  const base = new Map(baseTree.map((entry) => [entry.path, entry]));
+  const target = new Map(targetTree.map((entry) => [entry.path, entry]));
+  return [...new Set([...base.keys(), ...target.keys()])]
+    .sort()
+    .flatMap((path): GitHubFile[] => {
+      const before = base.get(path);
+      const after = target.get(path);
+      if (!before && after)
+        return [{ filename: path, status: "added", sha: after.sha }];
+      if (before && !after)
+        return [{ filename: path, status: "removed", sha: before.sha }];
+      if (
+        before &&
+        after &&
+        (before.sha !== after.sha ||
+          before.mode !== after.mode ||
+          before.type !== after.type)
+      ) {
+        return [{ filename: path, status: "modified", sha: after.sha }];
+      }
+      return [];
+    });
+}
+
+async function completeTree(env: Env, sha: string): Promise<GitHubTreeEntry[]> {
+  const result = await githubJson(
+    env,
+    `git/trees/${encodeURIComponent(sha)}?recursive=1`,
+  );
+  if (String(result.sha || "") !== sha)
+    throw new Error("GitHub tree identity mismatch");
+  return parseGitHubTree(result);
 }
 
 async function currentMainSha(env: Env): Promise<string> {
@@ -374,7 +487,16 @@ async function compareCodeRelease(
     env,
     `compare/${baseCodeSha}...${targetCodeSha}`,
   )) as GitHubCompare;
-  const files = validateCodeReleaseChangeSet(result, {
+  const compareFiles = result.files;
+  const files =
+    Array.isArray(compareFiles) && compareFiles.length < 300
+      ? compareFiles
+      : diffGitHubTrees(
+          await completeTree(env, baseCodeSha),
+          await completeTree(env, targetCodeSha),
+        );
+  const completeResult = { ...result, files };
+  validateCodeReleaseChangeSet(completeResult, {
     baseCodeSha,
     targetCodeSha,
     structuredCutoverDate,
@@ -391,12 +513,16 @@ async function compareCodeRelease(
     files,
     publishableFileCount: files.filter(
       (file) =>
-        classifyCodeReleasePath(file.filename, structuredCutoverDate) ===
-          "publishable" ||
+        classifyCodeReleasePath(
+          file.filename,
+          structuredCutoverDate,
+          file.status,
+        ) === "publishable" ||
         (file.previous_filename !== undefined &&
           classifyCodeReleasePath(
             file.previous_filename,
             structuredCutoverDate,
+            "removed",
           ) === "publishable"),
     ).length,
     changeSetSha256: await sha256Hex(
@@ -858,12 +984,16 @@ export async function handleCodeReleaseRequest(
       comparison.publishableFileCount ??
       comparison.files.filter(
         (file) =>
-          classifyCodeReleasePath(file.filename, structuredCutoverDate) ===
-            "publishable" ||
+          classifyCodeReleasePath(
+            file.filename,
+            structuredCutoverDate,
+            file.status,
+          ) === "publishable" ||
           (file.previous_filename !== undefined &&
             classifyCodeReleasePath(
               file.previous_filename,
               structuredCutoverDate,
+              "removed",
             ) === "publishable"),
       ).length;
     if (publishableFileCount === 0) {
@@ -900,8 +1030,7 @@ export async function handleCodeReleaseRequest(
       ) as result
     `;
     const reservation = reservationRows[0]?.result as
-      | Record<string, unknown>
-      | undefined;
+      Record<string, unknown> | undefined;
     if (
       !reservation ||
       !UUID.test(String(reservation.reservation_id || "")) ||


### PR DESCRIPTION
## Summary

- fall back to complete recursive Git trees when GitHub Compare reaches its 300-file cap
- safely classify the one-time Hugo-to-Astro migration while rejecting legacy-path reintroduction
- reuse an already restored last-known-good Pages deployment during recovery instead of uploading it every five minutes
- surface bounded Broker diagnostics in production-promotion workflow failures

## Root cause

Production was stuck on content release 111. Release 112 failed convergence and recovery repeatedly uploaded the same release 111 deployment. Independently, automatic code release failed closed because GitHub Compare returned exactly 300 files and the validator treated that cap as an incomplete change set.

## Validation

- `npm test` — 39 files / 595 tests passed
- `npm run content:deployer:check`
- `npm run content:broker:check`
- `npm run verify --prefix astro` — 428 routes verified
- production SHA to current main migration — all 393 changed paths classified
- Prettier and `git diff --check` passed