### PR TITLE
fix: classify production promotion helper

### DIFF
--- a/workers/content/deployer/index.test.ts
+++ b/workers/content/deployer/index.test.ts
@@ -196,6 +196,10 @@ describe("automatic code release boundary", () => {
             status: "modified",
           },
           {
+            filename: "scripts/request-production-promotion.mjs",
+            status: "modified",
+          },
+          {
             filename: "supabase/migrations/20260719000100_release.sql",
             status: "added",
           },
@@ -228,7 +232,7 @@ describe("automatic code release boundary", () => {
           structuredCutoverDate: "2026-07-16",
         },
       ),
-    ).toHaveLength(29);
+    ).toHaveLength(30);
   });
 
   it.each([

--- a/workers/content/deployer/index.ts
+++ b/workers/content/deployer/index.ts
@@ -213,6 +213,7 @@ const INERT_ROOT_SCRIPTS = new Set([
   "scripts/check-content-observation-window.mjs",
   "scripts/pull-daily-content.sh",
   "scripts/request-code-release.mjs",
+  "scripts/request-production-promotion.mjs",
   "scripts/test-content-failure-matrix-local.mjs",
   "scripts/validate-content-production-config.mjs",
   "scripts/verify-site.mjs",


### PR DESCRIPTION
## Summary

Classify `scripts/request-production-promotion.mjs` as inert release infrastructure so the fail-closed code release validator can accept the complete production-to-main migration.

## Evidence

The retried Automatic Code Release reached the full Git-tree classifier and rejected only this helper path:

`Code release contains forbidden or unknown path: scripts/request-production-promotion.mjs`

## Validation

- deployer tests: 27 passed
- observed production SHA → current main: all 396 paths classified
- deployer Wrangler dry-run bundled successfully
- Prettier and `git diff --check` passed