### PR TITLE
fix: restore static Pages content releases

### DIFF
--- a/.github/workflows/content-editorial-preview.yml
+++ b/.github/workflows/content-editorial-preview.yml
@@ -108,8 +108,8 @@ jobs:
 
       - name: Verify embedded draft identity
         run: |
-          node -e "const m=require('./astro/dist/release-manifests/site-route-manifest.json');const b=m.build;if(b.code_sha!==process.env.EXACT_CODE_SHA||b.source_sha!==process.env.EXACT_CODE_SHA||b.site_release_id!==process.env.SITE_RELEASE_ID||b.editorial_preview_sha256!==process.env.EDITORIAL_PREVIEW_SHA256||b.node_version!=='v22.17.0'||b.npm_version!=='10.9.2'||b.hugo_version!=='0.147.9'||b.build_timezone!=='UTC'||b.build_locale!=='C.UTF-8'||![b.content_schema_version,b.content_taxonomy_version,b.content_serializer_version,b.content_search_contract_version,b.content_source_contract_version].every(Boolean))process.exit(1)"
-          artifact_sha="$(node -e "process.stdout.write(require('./astro/dist/release-manifests/site-route-manifest.json').build.artifact_sha256)")"
+          node -e "const m=require('./astro/dist/client/release-manifests/site-route-manifest.json');const b=m.build;if(b.code_sha!==process.env.EXACT_CODE_SHA||b.source_sha!==process.env.EXACT_CODE_SHA||b.site_release_id!==process.env.SITE_RELEASE_ID||b.editorial_preview_sha256!==process.env.EDITORIAL_PREVIEW_SHA256||b.node_version!=='v22.17.0'||b.npm_version!=='10.9.2'||b.hugo_version!=='0.147.9'||b.build_timezone!=='UTC'||b.build_locale!=='C.UTF-8'||![b.content_schema_version,b.content_taxonomy_version,b.content_serializer_version,b.content_search_contract_version,b.content_source_contract_version].every(Boolean))process.exit(1)"
+          artifact_sha="$(node -e "process.stdout.write(require('./astro/dist/client/release-manifests/site-route-manifest.json').build.artifact_sha256)")"
           [[ "$artifact_sha" =~ ^[0-9a-f]{64}$ ]]
           echo "ARTIFACT_SHA256=$artifact_sha" >> "$GITHUB_ENV"
 
@@ -118,13 +118,13 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_PREVIEW_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         run: |
-          npx wrangler pages deploy astro/dist --project-name bubble-content-preview --branch "draft-$DRAFT_ID" --commit-hash "$EXACT_CODE_SHA" --commit-dirty=false | tee preview-deploy.log
+          npx wrangler pages deploy astro/dist/client --project-name bubble-content-preview --branch "draft-$DRAFT_ID" --commit-hash "$EXACT_CODE_SHA" --commit-dirty=false | tee preview-deploy.log
           preview_url="$(grep -Eo 'https://[^ ]+\.pages\.dev' preview-deploy.log | tail -1)"
           test -n "$preview_url"
           echo "PREVIEW_URL=$preview_url" >> "$GITHUB_ENV"
 
       - name: Verify Preview route parity
-        run: node scripts/verify-preview.mjs "$PREVIEW_URL" "$EXACT_CODE_SHA" astro/dist/release-manifests/site-route-manifest.json
+        run: node scripts/verify-preview.mjs "$PREVIEW_URL" "$EXACT_CODE_SHA" astro/dist/client/release-manifests/site-route-manifest.json
 
       - name: Register immutable Preview evidence
         run: |

--- a/.github/workflows/content-release.yml
+++ b/.github/workflows/content-release.yml
@@ -142,7 +142,7 @@ jobs:
       - name: Verify embedded release identity
         run: |
           node <<'NODE'
-          const build = require('./astro/dist/release-manifests/site-route-manifest.json').build;
+          const build = require('./astro/dist/client/release-manifests/site-route-manifest.json').build;
           const expected = {
             code_sha: process.env.EXACT_CODE_SHA,
             source_sha: process.env.EXACT_CODE_SHA,
@@ -179,7 +179,7 @@ jobs:
 
       - name: Create deterministic content-addressed artifact
         run: |
-          node scripts/create-content-addressed-artifact.mjs astro/dist content-release-artifact.json > artifact-summary.json
+          node scripts/create-content-addressed-artifact.mjs astro/dist/client content-release-artifact.json > artifact-summary.json
           echo "ARTIFACT_SHA256=$(jq -r .artifact_sha256 artifact-summary.json)" >> "$GITHUB_ENV"
           echo "ARTIFACT_BYTES=$(jq -r .artifact_byte_length artifact-summary.json)" >> "$GITHUB_ENV"
           echo "ARTIFACT_OBJECT_KEY=$(jq -r .artifact_object_key artifact-summary.json)" >> "$GITHUB_ENV"
@@ -209,12 +209,12 @@ jobs:
           R2_ENDPOINT: https://${{ secrets.CLOUDFLARE_ACCOUNT_ID }}.r2.cloudflarestorage.com
           R2_UPLOAD_CONCURRENCY: "8"
         run: |
-          node scripts/upload-content-addressed-artifact.mjs content-release-artifact.json astro/dist > r2-upload-summary.json
+          node scripts/upload-content-addressed-artifact.mjs content-release-artifact.json astro/dist/client > r2-upload-summary.json
           jq -e '.inventory_sha256 == env.ARTIFACT_SHA256 and (.inventory_byte_length | tostring) == env.ARTIFACT_BYTES' r2-upload-summary.json >/dev/null
 
       - name: Register immutable artifact
         run: |
-          artifact_fingerprint="$(jq -r '.build.artifact_sha256' astro/dist/release-manifests/site-route-manifest.json)"
+          artifact_fingerprint="$(jq -r '.build.artifact_sha256' astro/dist/client/release-manifests/site-route-manifest.json)"
           [[ "$artifact_fingerprint" =~ ^[0-9a-f]{64}$ ]]
           evidence="$(jq -nc --arg object_key "$ARTIFACT_OBJECT_KEY" --arg hash "$ARTIFACT_SHA256" --arg fingerprint "$artifact_fingerprint" --arg algorithm "$ARTIFACT_HASH_ALGORITHM" --arg code "$EXACT_CODE_SHA" --arg source_code "$SOURCE_CODE_SHA" --arg env "$BUILD_ENVIRONMENT_VERSION" --argjson bytes "$ARTIFACT_BYTES" '{object_key:$object_key,byte_length:$bytes,artifact_sha256:$hash,artifact_fingerprint_sha256:$fingerprint,hash_algorithm:$algorithm,code_sha:$code,source_code_sha:($source_code | if length > 0 then . else null end),build_environment_version:$env}')"
           node scripts/send-content-deployment-callback.mjs artifact_registered "$evidence"
@@ -224,13 +224,13 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_PREVIEW_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         run: |
-          npx wrangler pages deploy astro/dist --project-name bubble-content-preview --branch "release-$CONTENT_RELEASE_SEQUENCE" --commit-hash "$EXACT_CODE_SHA" --commit-dirty=false | tee preview-deploy.log
+          npx wrangler pages deploy astro/dist/client --project-name bubble-content-preview --branch "release-$CONTENT_RELEASE_SEQUENCE" --commit-hash "$EXACT_CODE_SHA" --commit-dirty=false | tee preview-deploy.log
           preview_url="$(grep -Eo 'https://[^ ]+\.pages\.dev' preview-deploy.log | tail -1)"
           test -n "$preview_url"
           echo "PREVIEW_URL=$preview_url" >> "$GITHUB_ENV"
 
       - name: Verify Preview route parity and exact bytes
-        run: node scripts/verify-preview.mjs "$PREVIEW_URL" "$EXACT_CODE_SHA" astro/dist/release-manifests/site-route-manifest.json
+        run: node scripts/verify-preview.mjs "$PREVIEW_URL" "$EXACT_CODE_SHA" astro/dist/client/release-manifests/site-route-manifest.json
 
       - name: Record Preview evidence
         run: |

--- a/astro/scripts/generate-site-contract.mjs
+++ b/astro/scripts/generate-site-contract.mjs
@@ -151,6 +151,13 @@ function htmlMetadata(html) {
 	return { canonical, hreflang, noindex };
 }
 
+// The Cloudflare adapter emits deployment metadata into the static asset
+// directory when every route is prerendered. It is not part of the public
+// Pages release and must not enter the immutable artifact inventory.
+await Promise.all(
+	['.assetsignore', 'wrangler.json'].map((name) => rm(resolve(distRoot, name), { force: true })),
+);
+
 for (const file of await walk(distRoot)) {
 	if (file.endsWith('/.DS_Store')) await rm(file, { force: true });
 }

--- a/astro/src/components/QuietIndexHome.astro
+++ b/astro/src/components/QuietIndexHome.astro
@@ -1,6 +1,13 @@
 ---
-import { fetchLatestReport } from '../lib/contentApi';
-import { dailyDateFromKey, formatDailyWeekday } from '../lib/daily';
+import { getCollection } from 'astro:content';
+
+import {
+	dailyDateFromKey,
+	dailyPermalink,
+	filterDailyEntries,
+	formatDailyWeekday,
+	parseDailyEntryId,
+} from '../lib/daily';
 import {
 	cleanTimelineSummary,
 	displayContentType,
@@ -12,6 +19,7 @@ import {
 	type DailyContentType,
 	type StructuredDailyReport,
 } from '../lib/structuredDaily';
+import { loadStructuredDailyReport } from '../lib/structuredDailyLocal';
 import '../styles/quiet-index.css';
 
 interface Props {
@@ -21,14 +29,15 @@ interface Props {
 const { locale } = Astro.props;
 const isEnglish = locale === 'en';
 
-const latest = await fetchLatestReport();
-const report = latest?.report as StructuredDailyReport | undefined ?? null;
-const dateKey = latest?.dateKey ?? null;
-const latestHref = dateKey
-	? `/daily/${dateKey.slice(0, 4)}/${dateKey.slice(5, 7)}/${dateKey}/`
-	: isEnglish
-		? '/en/daily/'
-		: '/daily/';
+const dailyEntries = await getCollection('daily');
+const entries = filterDailyEntries(dailyEntries, locale);
+const latest = entries[0];
+const latestIdentity = latest ? parseDailyEntryId(latest.id) : null;
+const dateKey = latestIdentity?.dateKey ?? null;
+const report: StructuredDailyReport | null = dateKey
+	? await loadStructuredDailyReport(dateKey)
+	: null;
+const latestHref = latest ? dailyPermalink(latest.id) : isEnglish ? '/en/daily/' : '/daily/';
 
 const typeLabels: Record<DailyContentType, string> = isEnglish
 	? { news: 'News', project: 'Project', paper: 'Paper', socialMedia: 'Social' }
@@ -61,7 +70,6 @@ const lead = items.find((item) => item.featured) ?? items[0] ?? null;
 const leadDisplayText = lead ? timelineDisplayText(lead) : null;
 const leadSource = lead ? timelineSourceDisplay(lead) : null;
 const feedItems = homepageFeedItems(items, report?.batches ?? []);
-
 ---
 
 <section class="quiet-home">
@@ -180,7 +188,6 @@ const feedItems = homepageFeedItems(items, report?.batches ?? []);
 							{isEnglish ? `View all ${items.length} items →` : `查看全部 ${items.length} 条 →`}
 						</a>
 					</div>
-
 				</div>
 			</>
 		) : (

--- a/astro/src/pages/daily/[year]/[month]/[slug].astro
+++ b/astro/src/pages/daily/[year]/[month]/[slug].astro
@@ -1,54 +1,67 @@
 ---
-export const prerender = false;
-
-import { getCollection } from 'astro:content';
+import { getCollection, type CollectionEntry } from 'astro:content';
 
 import DailyArticle from '../../../../components/DailyArticle.astro';
-import { fetchDailyReport } from '../../../../lib/contentApi';
-import { filterDailyEntries, parseDailyEntryId } from '../../../../lib/daily';
-import { isDatabaseOwnedDailyDate, type StructuredDailyReport } from '../../../../lib/structuredDaily';
+import { dailyPermalink, filterDailyEntries, parseDailyEntryId } from '../../../../lib/daily';
+import {
+	isDatabaseOwnedDailyDate,
+	type StructuredDailyReport,
+} from '../../../../lib/structuredDaily';
+import { loadStructuredDailyReport } from '../../../../lib/structuredDailyLocal';
 
-const { year, month, slug } = Astro.params;
-const dateKey = slug ?? `${year}-${month}`;
-const locale = 'zh-CN' as const;
-
-if (!/^\d{4}-\d{2}-\d{2}$/.test(dateKey) || dateKey !== `${year}-${month}${dateKey.slice(7)}`) {
-	return Astro.redirect('/daily/');
-}
-
-let report: StructuredDailyReport | null = null;
-let entry = null;
-
-if (isDatabaseOwnedDailyDate(dateKey)) {
-	const raw = await fetchDailyReport(dateKey);
-	report = raw as StructuredDailyReport | null;
-} else {
+export async function getStaticPaths() {
 	const allEntries = await getCollection('daily');
-	const entries = filterDailyEntries(allEntries, locale);
-	entry = entries.find((e) => parseDailyEntryId(e.id)?.dateKey === dateKey) ?? null;
+	const entries = filterDailyEntries(allEntries, 'zh-CN');
+	const englishDates = new Set(
+		filterDailyEntries(allEntries, 'en')
+			.map((entry) => parseDailyEntryId(entry.id)?.dateKey)
+			.filter((date): date is string => date !== undefined),
+	);
+
+	return entries.flatMap((entry, index) => {
+		const identity = parseDailyEntryId(entry.id);
+		if (!identity) return [];
+
+		return [
+			{
+				params: {
+					year: identity.year,
+					month: identity.month,
+					slug: identity.dateKey,
+				},
+				props: {
+					entry,
+					dateKey: identity.dateKey,
+					newerHref: index > 0 ? dailyPermalink(entries[index - 1].id) : null,
+					olderHref: index < entries.length - 1 ? dailyPermalink(entries[index + 1].id) : null,
+					alternateHref: englishDates.has(identity.dateKey)
+						? `/en/daily/${identity.year}/${identity.month}/${identity.dateKey}/`
+						: null,
+				},
+			},
+		];
+	});
 }
 
-if (!report && !entry) {
-	return Astro.redirect('/daily/');
+interface Props {
+	entry: CollectionEntry<'daily'>;
+	dateKey: string;
+	newerHref: string | null;
+	olderHref: string | null;
+	alternateHref: string | null;
 }
 
-const allEntries = await getCollection('daily');
-const entries = filterDailyEntries(allEntries, locale);
-const currentIndex = entries.findIndex((e) => parseDailyEntryId(e.id)?.dateKey === dateKey);
-const newerHref = currentIndex > 0
-	? `/daily/${entries[currentIndex - 1].id.replace(/(\d{4})-(\d{2})-(\d{2})/, '$1/$2/$1-$2-$3')}/`
+const { entry, dateKey, newerHref, olderHref, alternateHref } = Astro.props;
+const report: StructuredDailyReport | null = isDatabaseOwnedDailyDate(dateKey)
+	? await loadStructuredDailyReport(dateKey)
 	: null;
-const olderHref = currentIndex >= 0 && currentIndex < entries.length - 1
-	? `/daily/${entries[currentIndex + 1].id.replace(/(\d{4})-(\d{2})-(\d{2})/, '$1/$2/$1-$2-$3')}/`
-	: null;
-const alternateHref = `/en/daily/${year}/${month}/${dateKey}/`;
 ---
 
 <DailyArticle
 	entry={entry}
 	report={report}
 	dateKey={dateKey}
-	locale={locale}
+	locale="zh-CN"
 	newerHref={newerHref}
 	olderHref={olderHref}
 	alternateHref={alternateHref}

--- a/astro/src/pages/en/daily/[year]/[month]/[slug].astro
+++ b/astro/src/pages/en/daily/[year]/[month]/[slug].astro
@@ -1,54 +1,59 @@
 ---
-export const prerender = false;
-
-import { getCollection } from 'astro:content';
+import { getCollection, type CollectionEntry } from 'astro:content';
 
 import DailyArticle from '../../../../../components/DailyArticle.astro';
-import { fetchDailyReport } from '../../../../../lib/contentApi';
-import { filterDailyEntries, parseDailyEntryId } from '../../../../../lib/daily';
-import { isDatabaseOwnedDailyDate, type StructuredDailyReport } from '../../../../../lib/structuredDaily';
+import { dailyPermalink, filterDailyEntries, parseDailyEntryId } from '../../../../../lib/daily';
+import {
+	isDatabaseOwnedDailyDate,
+	type StructuredDailyReport,
+} from '../../../../../lib/structuredDaily';
+import { loadStructuredDailyReport } from '../../../../../lib/structuredDailyLocal';
 
-const { year, month, slug } = Astro.params;
-const dateKey = slug ?? `${year}-${month}`;
-const locale = 'en' as const;
+export async function getStaticPaths() {
+	const entries = filterDailyEntries(await getCollection('daily'), 'en');
 
-if (!/^\d{4}-\d{2}-\d{2}$/.test(dateKey) || dateKey !== `${year}-${month}${dateKey.slice(7)}`) {
-	return Astro.redirect('/en/daily/');
+	return entries.flatMap((entry, index) => {
+		const identity = parseDailyEntryId(entry.id);
+		if (!identity) return [];
+
+		return [
+			{
+				params: {
+					year: identity.year,
+					month: identity.month,
+					slug: identity.dateKey,
+				},
+				props: {
+					entry,
+					dateKey: identity.dateKey,
+					newerHref: index > 0 ? dailyPermalink(entries[index - 1].id) : null,
+					olderHref: index < entries.length - 1 ? dailyPermalink(entries[index + 1].id) : null,
+					alternateHref: `/daily/${identity.year}/${identity.month}/${identity.dateKey}/`,
+				},
+			},
+		];
+	});
 }
 
-let report: StructuredDailyReport | null = null;
-let entry = null;
-
-if (isDatabaseOwnedDailyDate(dateKey)) {
-	const raw = await fetchDailyReport(dateKey);
-	report = raw as StructuredDailyReport | null;
-} else {
-	const allEntries = await getCollection('daily');
-	const entries = filterDailyEntries(allEntries, locale);
-	entry = entries.find((e) => parseDailyEntryId(e.id)?.dateKey === dateKey) ?? null;
+interface Props {
+	entry: CollectionEntry<'daily'>;
+	dateKey: string;
+	newerHref: string | null;
+	olderHref: string | null;
+	alternateHref: string;
 }
 
-if (!report && !entry) {
-	return Astro.redirect('/en/daily/');
-}
-
-const allEntries = await getCollection('daily');
-const entries = filterDailyEntries(allEntries, locale);
-const currentIndex = entries.findIndex((e) => parseDailyEntryId(e.id)?.dateKey === dateKey);
-const newerHref = currentIndex > 0
-	? `/en/daily/${entries[currentIndex - 1].id.replace(/(\d{4})-(\d{2})-(\d{2})/, '$1/$2/$1-$2-$3')}/`
+const { entry, dateKey, newerHref, olderHref, alternateHref } = Astro.props;
+const report: StructuredDailyReport | null = isDatabaseOwnedDailyDate(dateKey)
+	? await loadStructuredDailyReport(dateKey)
 	: null;
-const olderHref = currentIndex >= 0 && currentIndex < entries.length - 1
-	? `/en/daily/${entries[currentIndex + 1].id.replace(/(\d{4})-(\d{2})-(\d{2})/, '$1/$2/$1-$2-$3')}/`
-	: null;
-const alternateHref = `/daily/${year}/${month}/${dateKey}/`;
 ---
 
 <DailyArticle
 	entry={entry}
 	report={report}
 	dateKey={dateKey}
-	locale={locale}
+	locale="en"
 	newerHref={newerHref}
 	olderHref={olderHref}
 	alternateHref={alternateHref}

--- a/astro/src/pages/en/index.astro
+++ b/astro/src/pages/en/index.astro
@@ -1,6 +1,4 @@
 ---
-export const prerender = false;
-
 import QuietIndexHome from '../../components/QuietIndexHome.astro';
 import BaseLayout from '../../layouts/BaseLayout.astro';
 ---

--- a/astro/src/pages/index.astro
+++ b/astro/src/pages/index.astro
@@ -1,6 +1,4 @@
 ---
-export const prerender = false;
-
 import QuietIndexHome from '../components/QuietIndexHome.astro';
 import BaseLayout from '../layouts/BaseLayout.astro';
 ---

--- a/cloudflare-pages.toml
+++ b/cloudflare-pages.toml
@@ -2,7 +2,7 @@
 
 [build]
   command = "npm ci && npm ci --prefix astro && npm run build --prefix astro && npm run verify:site"
-  publish = "astro/dist"
+  publish = "astro/dist/client"
 
 [build.environment]
   NODE_VERSION = "22.17.0"

--- a/scripts/create-content-addressed-artifact.mjs
+++ b/scripts/create-content-addressed-artifact.mjs
@@ -149,7 +149,7 @@ const isMain =
 if (isMain) {
   const distRoot =
     process.argv[2] ||
-    resolve(dirname(fileURLToPath(import.meta.url)), "../astro/dist");
+    resolve(dirname(fileURLToPath(import.meta.url)), "../astro/dist/client");
   const outputPath =
     process.argv[3] || resolve(process.cwd(), "content-release-artifact.json");
   const result = await createContentAddressedArtifact(distRoot, outputPath);

--- a/scripts/upload-content-addressed-artifact.mjs
+++ b/scripts/upload-content-addressed-artifact.mjs
@@ -341,7 +341,7 @@ const isMain =
   resolve(process.argv[1]) === fileURLToPath(import.meta.url);
 if (isMain) {
   const manifestPath = process.argv[2] || "content-release-artifact.json";
-  const distRoot = process.argv[3] || "astro/dist";
+  const distRoot = process.argv[3] || "astro/dist/client";
   const store = new AwsCliObjectStore({
     bucket: process.env.R2_ARTIFACT_BUCKET,
     endpoint: process.env.R2_ENDPOINT,

--- a/scripts/verify-preview.mjs
+++ b/scripts/verify-preview.mjs
@@ -35,7 +35,7 @@ if (!baseArgument) {
 
 const localManifestPath =
   manifestPathArgument ??
-  "astro/dist/release-manifests/site-route-manifest.json";
+  "astro/dist/client/release-manifests/site-route-manifest.json";
 const localManifestText = await readFile(localManifestPath, "utf8");
 const localDistRoot = resolve(dirname(resolve(localManifestPath)), "..");
 const localManifest = JSON.parse(localManifestText);

--- a/scripts/verify-site.mjs
+++ b/scripts/verify-site.mjs
@@ -192,7 +192,10 @@ invariant(
 let expectedPinnedBuild = null;
 if (pinnedContentBuild) {
   const input = JSON.parse(
-    await readFile(resolve(astroRoot, ".content-release", "build-input.json"), "utf8"),
+    await readFile(
+      resolve(astroRoot, ".content-release", "build-input.json"),
+      "utf8",
+    ),
   );
   expectedPinnedBuild = {
     code_sha: input.code_sha,
@@ -278,22 +281,18 @@ for (const file of await walk(distRoot)) {
   );
 }
 
-const serverRenderedRoute =
-  /^\/(?:en\/)?(?:$|daily\/\d{4}\/\d{2}\/\d{4}-\d{2}-\d{2}\/$)/;
-
 for (const record of contract.records.filter(
   (entry) => entry.status === 301 || entry.status === 308,
 )) {
   invariant(
-    byRoute.get(record.target)?.status === 200 ||
-      serverRenderedRoute.test(record.target),
+    byRoute.get(record.target)?.status === 200,
     `Redirect target is not a 200 route: ${record.route} -> ${record.target}`,
   );
 }
 
-// "/", "/en/", and structured daily pages are server-rendered and therefore
-// absent from the static route contract.
 const requiredRoutes = [
+  "/",
+  "/en/",
   "/daily/",
   "/en/daily/",
   "/search/",
@@ -341,9 +340,14 @@ invariant(
   "Static search release identity differs from the route manifest",
 );
 if (pinnedContentBuild) {
-  const searchHtml = await readFile(resolve(distRoot, "search", "index.html"), "utf8");
+  const searchHtml = await readFile(
+    resolve(distRoot, "search", "index.html"),
+    "utf8",
+  );
   invariant(
-    searchHtml.includes(`data-content-release-id="${contract.build.site_release_id}"`) &&
+    searchHtml.includes(
+      `data-content-release-id="${contract.build.site_release_id}"`,
+    ) &&
       searchHtml.includes(
         'data-content-api-origin="https://content-api.bubblenews.today"',
       ),
@@ -390,6 +394,36 @@ for (const name of dailyDataNames) {
   );
   const report = JSON.parse(source.toString("utf8"));
   const date = name.slice(0, -".json".length);
+  const year = date.slice(0, 4);
+  const month = date.slice(5, 7);
+  const chinesePageRoute = `/daily/${year}/${month}/${date}/`;
+  const englishPageRoute = `/en/daily/${year}/${month}/${date}/`;
+  const pageRoutes = [chinesePageRoute];
+  if (pinnedContentBuild || byRoute.has(englishPageRoute))
+    pageRoutes.push(englishPageRoute);
+  for (const pageRoute of pageRoutes) {
+    const pageRecord = byRoute.get(pageRoute);
+    invariant(
+      pageRecord?.status === 200 &&
+        pageRecord.content_type === "text/html" &&
+        pageRecord.owner === "astro",
+      `Missing structured daily HTML route: ${pageRoute}`,
+    );
+    const html = await readFile(
+      resolve(
+        distRoot,
+        pageRecord.output_path ??
+          pathFromRoute(pageRecord.route, pageRecord.content_type),
+      ),
+      "utf8",
+    );
+    for (const item of report.items) {
+      invariant(
+        html.includes(`id="news-${item.id}"`),
+        `Structured daily item is missing from HTML: ${pageRoute}#news-${item.id}`,
+      );
+    }
+  }
   if (expectedSearchWindow.has(date)) {
     expectedSearchItemCount += report.items.length;
     const searchItems = searchIndex.items.filter((item) => item.date === date);
@@ -608,8 +642,7 @@ for (const record of contract.records.filter(
     const path = decoded.replace(/^\//, "");
     const routeExists =
       contractRoutes.has(decoded) ||
-      contractRoutes.has(decoded.endsWith("/") ? decoded : `${decoded}/`) ||
-      serverRenderedRoute.test(decoded.endsWith("/") ? decoded : `${decoded}/`);
+      contractRoutes.has(decoded.endsWith("/") ? decoded : `${decoded}/`);
     const fileExists =
       allOutputPaths.has(path) ||
       allOutputPaths.has(`${path.replace(/\/$/, "")}/index.html`);

--- a/workers/content/deployer/index.test.ts
+++ b/workers/content/deployer/index.test.ts
@@ -200,6 +200,18 @@ describe("automatic code release boundary", () => {
             status: "modified",
           },
           {
+            filename: "scripts/create-content-addressed-artifact.mjs",
+            status: "modified",
+          },
+          {
+            filename: "scripts/upload-content-addressed-artifact.mjs",
+            status: "modified",
+          },
+          {
+            filename: "scripts/verify-preview.mjs",
+            status: "modified",
+          },
+          {
             filename: "supabase/migrations/20260719000100_release.sql",
             status: "added",
           },
@@ -232,7 +244,7 @@ describe("automatic code release boundary", () => {
           structuredCutoverDate: "2026-07-16",
         },
       ),
-    ).toHaveLength(30);
+    ).toHaveLength(33);
   });
 
   it.each([
@@ -499,6 +511,18 @@ describe("automatic code release boundary", () => {
               filename: "data/daily/2026-07-19.json",
               status: "modified",
             },
+            {
+              filename: "scripts/create-content-addressed-artifact.mjs",
+              status: "modified",
+            },
+            {
+              filename: "scripts/upload-content-addressed-artifact.mjs",
+              status: "modified",
+            },
+            {
+              filename: "scripts/verify-preview.mjs",
+              status: "modified",
+            },
           ],
           changeSetSha256: "e".repeat(64),
         })),
@@ -510,7 +534,7 @@ describe("automatic code release boundary", () => {
       ok: true,
       status: "no_changes",
       code_sha: targetCodeSha,
-      changed_file_count: 2,
+      changed_file_count: 5,
     });
     expect(getCurrentMainSha).toHaveBeenCalledTimes(1);
     expect(sql).toHaveBeenCalledTimes(1);

--- a/workers/content/deployer/index.ts
+++ b/workers/content/deployer/index.ts
@@ -211,11 +211,14 @@ type CodeReleasePathClass = "publishable" | "inert" | "db_owned";
 const INERT_ROOT_SCRIPTS = new Set([
   "scripts/check-content-observability.mjs",
   "scripts/check-content-observation-window.mjs",
+  "scripts/create-content-addressed-artifact.mjs",
   "scripts/pull-daily-content.sh",
   "scripts/request-code-release.mjs",
   "scripts/request-production-promotion.mjs",
   "scripts/test-content-failure-matrix-local.mjs",
+  "scripts/upload-content-addressed-artifact.mjs",
   "scripts/validate-content-production-config.mjs",
+  "scripts/verify-preview.mjs",
   "scripts/verify-site.mjs",
 ]);
 


### PR DESCRIPTION
## Summary

- restore static homepage and daily-report generation from the pinned local content release
- publish and verify the Cloudflare adapter's static `astro/dist/client` output
- strengthen route, redirect, structured-item anchor, and release-classification checks
- exclude adapter deployment metadata from immutable public artifacts

## Root cause

The Astro Cloudflare adapter now emits static assets under `astro/dist/client`, while the exact content-release workflow still read and deployed `astro/dist`. In parallel, the homepage and daily pages had been switched to SSR even though Cloudflare Pages remains the production renderer. The release therefore failed before the repository's 2026-07-24 content could reach the site.

## Validation

- `npm test` — 39 files / 595 tests
- `npm run verify --prefix astro` — 12 files / 83 tests, 645 routes, 27 XML endpoints, 99 sandboxed demos
- `npm run content:deployer:check`
- deterministic artifact — 531 files; contains `/`, `/en/`, 2026-07-24 daily HTML, and the site route manifest
- full old-production-to-head classifier check — 397 changed files accepted
- `git diff --check`