### PR TITLE
fix: roll terminal publication slots forward

### DIFF
--- a/supabase/migrations/20260724000100_terminal_publication_slot_rollover.sql
+++ b/supabase/migrations/20260724000100_terminal_publication_slot_rollover.sql
@@ -1,0 +1,126 @@
+set local role content_rpc_owner;
+
+create or replace function private.prepare_ingestion_publication_slot_v1(
+  p_report_snapshot_id uuid,
+  p_batch_id text,
+  p_input_sha256 text
+)
+returns jsonb
+language plpgsql
+volatile
+security definer
+set search_path = ''
+as $$
+declare
+  v_snapshot private.report_snapshots%rowtype;
+  v_slot private.publication_slots%rowtype;
+  v_reservation private.site_release_reservations%rowtype;
+  v_previous_release_id uuid;
+begin
+  if p_batch_id not in (
+    'morning', 'afternoon', 'night', 'lateNight', 'lateNightSupplement'
+  )
+    or p_input_sha256 !~ '^[a-f0-9]{64}$' then
+    raise exception using
+      errcode = '22023',
+      message = 'Invalid ingestion publication slot identity';
+  end if;
+
+  select * into v_snapshot
+  from private.report_snapshots
+  where id = p_report_snapshot_id;
+  if not found
+    or v_snapshot.byte_sha256 <> p_input_sha256 then
+    raise exception using
+      errcode = '22023',
+      message = 'Publication slot snapshot identity mismatch';
+  end if;
+
+  perform pg_advisory_xact_lock(
+    42002,
+    hashtext(v_snapshot.report_date::text || ':' || p_batch_id)
+  );
+
+  select * into v_slot
+  from private.publication_slots
+  where report_date = v_snapshot.report_date
+    and batch_id = p_batch_id
+  for update;
+  if not found then
+    return jsonb_build_object('reset', false, 'reason', 'slot_absent');
+  end if;
+
+  if v_slot.input_sha256 = p_input_sha256
+    and v_slot.content_sha256 = p_input_sha256
+    and v_slot.report_snapshot_id is not distinct from p_report_snapshot_id then
+    return jsonb_build_object('reset', false, 'reason', 'slot_matches');
+  end if;
+
+  if v_slot.site_release_id is not null then
+    if not exists (
+      select 1
+      from private.content_outbox outbox
+      where outbox.site_release_id = v_slot.site_release_id
+    )
+      or exists (
+        select 1
+        from private.content_outbox outbox
+        where outbox.site_release_id = v_slot.site_release_id
+          and outbox.status not in ('deployed', 'dead_letter')
+          and not (
+            outbox.status = 'preview_verified'
+            and outbox.payload ->> 'mode' = 'shadow'
+          )
+      )
+      or exists (
+        select 1
+        from private.release_head_claims claim
+        where claim.reservation_id = v_slot.site_release_id
+      ) then
+      raise exception using
+        errcode = '55P03',
+        message = 'Publication slot release is still active';
+    end if;
+    v_previous_release_id := v_slot.site_release_id;
+  elsif v_slot.reservation_id is not null then
+    select * into v_reservation
+    from private.site_release_reservations
+    where id = v_slot.reservation_id
+    for update;
+    if not found then
+      raise exception 'Publication slot references a missing reservation';
+    end if;
+    if v_reservation.status = 'reserved'
+      and v_reservation.expires_at > clock_timestamp() then
+      raise exception using
+        errcode = '55P03',
+        message = 'Publication slot reservation is still active';
+    end if;
+    if v_reservation.status = 'reserved' then
+      update private.site_release_reservations
+      set status = 'abandoned'
+      where id = v_reservation.id;
+    elsif v_reservation.status <> 'abandoned' then
+      raise exception 'Publication slot has an unusable reservation state';
+    end if;
+  end if;
+
+  delete from private.publication_slots
+  where report_date = v_snapshot.report_date
+    and batch_id = p_batch_id;
+
+  return jsonb_build_object(
+    'reset', true,
+    'reason', 'terminal_slot_rollover',
+    'previous_site_release_id', v_previous_release_id
+  );
+end;
+$$;
+
+reset role;
+
+revoke all on function private.prepare_ingestion_publication_slot_v1(uuid, text, text)
+  from public, anon, authenticated, service_role,
+       content_editor, content_controller, content_reader, content_deployer;
+grant execute on function private.prepare_ingestion_publication_slot_v1(uuid, text, text)
+  to content_ingestor;

--- a/supabase/migrations/20260724000100_terminal_publication_slot_rollover.sql
+++ b/supabase/migrations/20260724000100_terminal_publication_slot_rollover.sql
@@ -1,5 +1,3 @@
-set local role content_rpc_owner;
-
 create or replace function private.prepare_ingestion_publication_slot_v1(
   p_report_snapshot_id uuid,
   p_batch_id text,
@@ -117,7 +115,8 @@ begin
 end;
 $$;
 
-reset role;
+alter function private.prepare_ingestion_publication_slot_v1(uuid, text, text)
+  owner to content_rpc_owner;
 
 revoke all on function private.prepare_ingestion_publication_slot_v1(uuid, text, text)
   from public, anon, authenticated, service_role,

--- a/supabase/migrations/20260724000100_terminal_publication_slot_rollover.sql
+++ b/supabase/migrations/20260724000100_terminal_publication_slot_rollover.sql
@@ -1,3 +1,7 @@
+begin;
+
+set local role content_rpc_owner;
+
 create or replace function private.prepare_ingestion_publication_slot_v1(
   p_report_snapshot_id uuid,
   p_batch_id text,
@@ -115,11 +119,11 @@ begin
 end;
 $$;
 
-alter function private.prepare_ingestion_publication_slot_v1(uuid, text, text)
-  owner to content_rpc_owner;
-
 revoke all on function private.prepare_ingestion_publication_slot_v1(uuid, text, text)
   from public, anon, authenticated, service_role,
-       content_editor, content_controller, content_reader, content_deployer;
+       content_backup, content_editor, content_controller,
+       content_reader, content_deployer;
 grant execute on function private.prepare_ingestion_publication_slot_v1(uuid, text, text)
   to content_ingestor;
+
+commit;

--- a/supabase/tests/database/content_database_security.test.sql
+++ b/supabase/tests/database/content_database_security.test.sql
@@ -1,7 +1,7 @@
 begin;
 
 create extension if not exists pgtap with schema extensions;
-select plan(114);
+select plan(116);
 
 select cmp_ok(
   (select count(*) from information_schema.tables where table_schema = 'private' and table_name like '%content%' or table_schema = 'private' and table_name like '%release%'),

--- a/supabase/tests/database/content_database_security.test.sql
+++ b/supabase/tests/database/content_database_security.test.sql
@@ -176,6 +176,8 @@ select ok(
 select ok(has_function_privilege('content_ingestor', 'private.ingest_report_snapshot_v1(jsonb,text,bigint,text,text,text,text)', 'execute'), 'ingestor can ingest snapshots');
 select ok(has_function_privilege('content_ingestor', 'private.reserve_site_release_v1(uuid)', 'execute'), 'ingestor can reserve releases');
 select ok(has_function_privilege('content_ingestor', 'private.reserve_ingestion_site_release_v1(uuid,text,text,text,text,text)', 'execute'), 'ingestor can reserve deterministic publication slots');
+select ok(has_function_privilege('content_ingestor', 'private.prepare_ingestion_publication_slot_v1(uuid,text,text)', 'execute'), 'ingestor can roll a terminal publication slot forward');
+select ok(not has_function_privilege('content_editor', 'private.prepare_ingestion_publication_slot_v1(uuid,text,text)', 'execute'), 'routine editor cannot roll ingestion publication slots');
 select ok(
   position('lateNightSupplement' in (
     select p.prosrc

--- a/tests/worker/contentMirror.test.js
+++ b/tests/worker/contentMirror.test.js
@@ -74,6 +74,9 @@ function database({
                 },
             ];
         }
+        if (query.includes('prepare_ingestion_publication_slot_v1')) {
+            return [{ result: { reset: false, reason: 'slot_absent' } }];
+        }
         if (query.includes('reserve_ingestion_site_release_v1')) {
             if (reserveError && reserveFailures < reserveFailureCount) {
                 reserveFailures += 1;
@@ -255,6 +258,14 @@ describe('structured content database mirror', () => {
             });
             expect(siteManifest).not.toHaveProperty('daily_source_contract_version');
             const reserve = db.calls.find((call) => call.query.includes('reserve_ingestion_site_release_v1'));
+            const prepare = db.calls.find((call) =>
+                call.query.includes('prepare_ingestion_publication_slot_v1'),
+            );
+            expect(prepare.values).toEqual([
+                '11111111-1111-4111-8111-111111111111',
+                'morning',
+                result.contentSha256,
+            ]);
             expect(reserve.values.slice(1)).toEqual([
                 'morning',
                 result.contentSha256,

--- a/workers/content/ingestion/mirror.ts
+++ b/workers/content/ingestion/mirror.ts
@@ -7,6 +7,7 @@ import {
   ingestReportSnapshot,
   isRetryableReleaseContention,
   openContentDatabase,
+  prepareIngestionPublicationSlot,
   reserveIngestionSiteRelease,
   type ContentSql,
 } from "../shared/db";
@@ -192,6 +193,16 @@ export async function mirrorStructuredReport(
       serializerVersion: env.DAILY_SERIALIZER_VERSION || "daily-json-c14n-v1",
       provenanceKind: "live_ingestion",
     });
+    await withContentionRetry(
+      () =>
+        prepareIngestionPublicationSlot(sql, {
+          reportSnapshotId: String(snapshot.report_snapshot_id),
+          batchId: publicationBatch,
+          inputSha256: reportObject.sha256,
+        }),
+      "prepare_slot",
+      sleep,
+    );
     const reservation = await withContentionRetry(
       () =>
         reserveIngestionSiteRelease(sql, {

--- a/workers/content/shared/db.ts
+++ b/workers/content/shared/db.ts
@@ -100,6 +100,22 @@ export async function reserveIngestionSiteRelease(
   return oneJson(rows, "result");
 }
 
+export async function prepareIngestionPublicationSlot(
+  sql: ContentSql,
+  input: {
+    reportSnapshotId: string;
+    batchId: string;
+    inputSha256: string;
+  },
+): Promise<Record<string, unknown>> {
+  const rows = await sql<Record<string, unknown>[]>`
+    select private.prepare_ingestion_publication_slot_v1(
+      ${input.reportSnapshotId}::uuid, ${input.batchId}, ${input.inputSha256}
+    ) as result
+  `;
+  return oneJson(rows, "result");
+}
+
 export async function failIngestionPublicationAttempt(
   sql: ContentSql,
   input: {


### PR DESCRIPTION
## Summary
- add a guarded database RPC that clears a semantic publication slot only after its previous outbox is terminal and its release head is free
- call the guard before reserving a new ingestion release
- restrict the capability to the content ingestor and add regression coverage

## Why
Repeated updates in the same daily batch were blocked by the first finalized slot even after its outbox reached deployed or dead-letter state. That prevented new content snapshots from producing an outbox and left the website behind main.

## Validation
- npm test: 39 files / 595 tests passed
- npm run worker:check passed
- targeted content mirror tests: 15 passed