### PR TITLE
fix: correct homepage stream order and batch labels

### DIFF
--- a/astro/src/components/QuietIndexHome.astro
+++ b/astro/src/components/QuietIndexHome.astro
@@ -9,10 +9,10 @@ import {
 	parseDailyEntryId,
 } from '../lib/daily';
 import {
-	cleanTimelineSummary,
 	displayContentType,
 	formatDailyTime,
 	formatTimelineTime,
+	homepageBatchLabel,
 	homepageFeedItems,
 	timelineDisplayText,
 	timelineSourceDisplay,
@@ -98,7 +98,7 @@ const feedItems = homepageFeedItems(items, report?.batches ?? []);
 					<div class="schedule">
 						{report.batches.map((batch) => (
 							<div class={`slot ${batch.status === 'completed' ? 'done' : 'waiting'}`}>
-								<span class="t">{cleanTimelineSummary(batch.label)}</span>
+								<span class="t">{homepageBatchLabel(batch, locale)}</span>
 								<span class="s">
 									{batch.status === 'completed'
 										? isEnglish

--- a/astro/src/lib/structuredDaily.test.ts
+++ b/astro/src/lib/structuredDaily.test.ts
@@ -6,6 +6,7 @@ import { afterEach, describe, expect, it } from 'vitest';
 
 import {
 	formatTimelineTime,
+	homepageBatchLabel,
 	homepageFeedItems,
 	isDatabaseOwnedDailyDate,
 	orderTimelineBatches,
@@ -156,7 +157,7 @@ describe('timeline batch order', () => {
 		expect(batches.map(({ id }) => id)).toEqual(['morning', 'afternoon', 'night', 'lateNight']);
 	});
 
-	it('orders the homepage by latest completed batch, then source publication time', () => {
+	it('orders the homepage globally by source publication time across completed batches', () => {
 		const batches = [
 			batch('morning', 'completed'),
 			batch('afternoon', 'pending'),
@@ -183,10 +184,17 @@ describe('timeline batch order', () => {
 		];
 
 		expect(homepageFeedItems(items, batches, 3).map(({ id }) => id)).toEqual([
+			'night-newer-source',
 			'late-night-newer-source',
 			'late-night-older-source',
-			'night-newer-source',
 		]);
+	});
+
+	it('uses phase names instead of presenting batch labels as cron execution times', () => {
+		expect(homepageBatchLabel(batch('morning', 'completed'), 'zh-CN')).toBe('早间累计');
+		expect(homepageBatchLabel(batch('afternoon', 'completed'), 'zh-CN')).toBe('午后累计');
+		expect(homepageBatchLabel(batch('night', 'completed'), 'en')).toBe('Evening total');
+		expect(homepageBatchLabel(batch('lateNight', 'pending'), 'en')).toBe('Overnight supplement');
 	});
 });
 

--- a/astro/src/lib/structuredDaily.ts
+++ b/astro/src/lib/structuredDaily.ts
@@ -83,19 +83,30 @@ export function homepageFeedItems(
 	batches: readonly StructuredDailyBatch[],
 	limit = 8,
 ): StructuredDailyItem[] {
-	const completedBatchRank = new Map(
-		orderTimelineBatches(batches)
-			.filter((batch) => batch.status === 'completed')
-			.map((batch, index) => [batch.id, index]),
+	const completedBatchIds = new Set(
+		batches.filter((batch) => batch.status === 'completed').map((batch) => batch.id),
 	);
 
 	return items
-		.filter((item) => completedBatchRank.has(item.batch))
-		.sort((a, b) => {
-			const batchOrder = completedBatchRank.get(a.batch)! - completedBatchRank.get(b.batch)!;
-			return batchOrder || itemPublishedTimestamp(b) - itemPublishedTimestamp(a);
-		})
+		.filter((item) => completedBatchIds.has(item.batch))
+		.sort(
+			(a, b) => itemPublishedTimestamp(b) - itemPublishedTimestamp(a) || a.id.localeCompare(b.id),
+		)
 		.slice(0, Math.max(0, Math.trunc(limit)));
+}
+
+const homepageBatchLabels: Record<StructuredDailyBatch['id'], Record<'zh-CN' | 'en', string>> = {
+	morning: { 'zh-CN': '早间累计', en: 'Morning total' },
+	afternoon: { 'zh-CN': '午后累计', en: 'Afternoon total' },
+	night: { 'zh-CN': '晚间累计', en: 'Evening total' },
+	lateNight: { 'zh-CN': '深夜补充', en: 'Overnight supplement' },
+};
+
+export function homepageBatchLabel(
+	batch: Pick<StructuredDailyBatch, 'id'>,
+	locale: 'zh-CN' | 'en',
+): string {
+	return homepageBatchLabels[batch.id][locale];
 }
 
 const dateKeyPattern = /^\d{4}-\d{2}-\d{2}$/;


### PR DESCRIPTION
## Summary
- sort the homepage daily stream globally by publication time across completed batches
- replace misleading fixed schedule times with phase labels
- add regression coverage for stream ordering and localized labels

## Validation
- 84 Astro tests passed
- Astro check: 0 errors, 0 warnings
- deterministic renderer build: 314 pages