### PR TITLE
feat: harden content release pipeline

### DIFF
--- a/.github/workflows/content-release.yml
+++ b/.github/workflows/content-release.yml
@@ -31,6 +31,12 @@ on:
         required: true
         type: choice
         options: [shadow, production]
+      attempt_token:
+        required: false
+        type: string
+      execution_generation:
+        required: false
+        type: string
 
 permissions:
   contents: read
@@ -56,6 +62,8 @@ jobs:
       SOURCE_CODE_SHA: ${{ github.event.inputs.source_code_sha }}
       BUILD_ENVIRONMENT_VERSION: ${{ github.event.inputs.build_environment_version }}
       DEPLOYMENT_MODE: ${{ github.event.inputs.mode }}
+      DEPLOYMENT_ATTEMPT_TOKEN: ${{ github.event.inputs.attempt_token }}
+      DEPLOYMENT_EXECUTION_GENERATION: ${{ github.event.inputs.execution_generation }}
       CONTENT_BUILD_API_ORIGIN: ${{ vars.CONTENT_DEPLOYER_ORIGIN }}
       PUBLIC_CONTENT_API_ORIGIN: https://content-api.bubblenews.today
       PUBLIC_COMMENTS_WRITE_UI_ENABLED: ${{ vars.PUBLIC_COMMENTS_WRITE_UI_ENABLED || 'false' }}
@@ -63,6 +71,7 @@ jobs:
       CONTENT_DEPLOY_CALLBACK_URL: ${{ vars.CONTENT_DEPLOY_CALLBACK_URL }}
       CONTENT_DEPLOY_CALLBACK_SECRET: ${{ secrets.CONTENT_DEPLOY_CALLBACK_SECRET }}
       R2_ARTIFACT_BUCKET: bubble-content-artifacts
+      R2_INCREMENTAL_REUSE_ENABLED: ${{ vars.R2_INCREMENTAL_REUSE_ENABLED || 'false' }}
       TZ: UTC
       LANG: C.UTF-8
       LC_ALL: C.UTF-8
@@ -82,7 +91,88 @@ jobs:
           if [[ -n "$SOURCE_CODE_SHA" ]]; then
             [[ "$SOURCE_CODE_SHA" =~ ^[0-9a-f]{40}$ ]]
           fi
+          if [[ "$DEPLOYMENT_MODE" == "production" || -n "$DEPLOYMENT_ATTEMPT_TOKEN" || -n "$DEPLOYMENT_EXECUTION_GENERATION" ]]; then
+            [[ "$DEPLOYMENT_ATTEMPT_TOKEN" =~ ^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89aAbB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$ ]]
+            [[ "$DEPLOYMENT_EXECUTION_GENERATION" =~ ^[1-9][0-9]*$ ]]
+          fi
           [[ "$BUILD_ENVIRONMENT_VERSION" == "node22.17-astro7-hugo0.147.9-v1" ]]
+
+      - name: Create immutable fenced release helper
+        shell: bash
+        run: |
+          umask 077
+          cat > "$RUNNER_TEMP/content-release-helper.mjs" <<'NODE'
+          import { createHmac } from "node:crypto";
+
+          const [action, eventType, evidenceText = "{}"] = process.argv.slice(2);
+          const callbackUrl = process.env.CONTENT_DEPLOY_CALLBACK_URL;
+          const secret = process.env.CONTENT_DEPLOY_CALLBACK_SECRET;
+          const siteReleaseId = process.env.SITE_RELEASE_ID;
+          const dispatchId = process.env.DISPATCH_ID;
+          const attemptToken = process.env.DEPLOYMENT_ATTEMPT_TOKEN;
+          const executionGeneration = Number(
+            process.env.DEPLOYMENT_EXECUTION_GENERATION || 0,
+          );
+          if (!callbackUrl || !secret || !siteReleaseId || !dispatchId) {
+            throw new Error("Content release helper environment is incomplete");
+          }
+
+          let url = callbackUrl;
+          let payload;
+          if (action === "plan") {
+            if (!attemptToken || !Number.isSafeInteger(executionGeneration) || executionGeneration < 1) {
+              throw new Error("Fenced deployment plan identity is incomplete");
+            }
+            url = new URL("/internal/deployment-plan", callbackUrl).toString();
+            payload = {
+              site_release_id: siteReleaseId,
+              dispatch_id: dispatchId,
+              attempt_token: attemptToken,
+              execution_generation: executionGeneration,
+            };
+          } else if (action === "callback" && eventType) {
+            payload = {
+              site_release_id: siteReleaseId,
+              dispatch_id: dispatchId,
+              ...(attemptToken
+                ? {
+                    attempt_token: attemptToken,
+                    execution_generation: executionGeneration,
+                  }
+                : {}),
+              event_type: eventType,
+              evidence: JSON.parse(evidenceText),
+            };
+          } else {
+            throw new Error("Unknown content release helper action");
+          }
+
+          const body = JSON.stringify(payload);
+          const signature = createHmac("sha256", secret).update(body).digest("hex");
+          const response = await fetch(url, {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+              "X-Content-Signature": signature,
+            },
+            body,
+          });
+          const responseBody = await response.text();
+          if (!response.ok) {
+            throw new Error(
+              `Content release ${action} failed with ${response.status}: ${responseBody
+                .trim()
+                .slice(0, 1024)}`,
+            );
+          }
+          if (action === "plan") {
+            const plan = JSON.parse(responseBody);
+            if (!plan || typeof plan !== "object") {
+              throw new Error("Content release plan response is invalid");
+            }
+            process.stdout.write(`${JSON.stringify(plan)}\n`);
+          }
+          NODE
 
       - name: Checkout exact code SHA
         uses: actions/checkout@v4
@@ -96,6 +186,53 @@ jobs:
           if [[ -n "$SOURCE_CODE_SHA" ]]; then
             git merge-base --is-ancestor "$SOURCE_CODE_SHA" "$EXACT_CODE_SHA"
           fi
+          if [[ -f scripts/materialize-content-addressed-artifact.mjs ]]; then
+            echo "RESUME_CONTRACT_VERSION=r2-materialize-v1" >> "$GITHUB_ENV"
+          else
+            echo "RESUME_CONTRACT_VERSION=" >> "$GITHUB_ENV"
+          fi
+
+      - name: Resolve fenced server resume plan
+        id: resume
+        run: |
+          if [[ -z "$DEPLOYMENT_ATTEMPT_TOKEN" ]]; then
+            printf '%s\n' '{"resume_stage":"build","trusted_baseline":null}' > server-resume-plan.json
+          else
+            node "$RUNNER_TEMP/content-release-helper.mjs" plan > server-resume-plan.json
+          fi
+          resume_stage="$(jq -r '.resume_stage' server-resume-plan.json)"
+          [[ "$resume_stage" =~ ^(build|preview|promote)$ ]]
+          if [[ "$resume_stage" != "build" ]]; then
+            jq -e \
+              --arg release "$SITE_RELEASE_ID" \
+              --arg code "$EXACT_CODE_SHA" \
+              --arg content "$CONTENT_ROOT_SHA256" \
+              '.artifact.site_release_id == $release
+                and .artifact.code_sha == $code
+                and .artifact.content_sha256 == $content
+                and (.artifact.artifact_sha256 | test("^[a-f0-9]{64}$"))
+                and (.artifact.artifact_fingerprint_sha256 | test("^[a-f0-9]{64}$"))
+                and .artifact.hash_algorithm == "sha256-content-addressed-pages-v1"' \
+              server-resume-plan.json >/dev/null
+            echo "ARTIFACT_SHA256=$(jq -r '.artifact.artifact_sha256' server-resume-plan.json)" >> "$GITHUB_ENV"
+            echo "ARTIFACT_BYTES=$(jq -r '.artifact.byte_length' server-resume-plan.json)" >> "$GITHUB_ENV"
+            echo "ARTIFACT_OBJECT_KEY=$(jq -r '.artifact.object_key' server-resume-plan.json)" >> "$GITHUB_ENV"
+            echo "ARTIFACT_HASH_ALGORITHM=$(jq -r '.artifact.hash_algorithm' server-resume-plan.json)" >> "$GITHUB_ENV"
+          fi
+          if [[ "$resume_stage" == "promote" ]]; then
+            jq -e \
+              --arg artifact "$(jq -r '.artifact.artifact_sha256' server-resume-plan.json)" \
+              --arg code "$EXACT_CODE_SHA" \
+              --arg content "$CONTENT_ROOT_SHA256" \
+              '.preview_checkpoint.artifact_sha256 == $artifact
+                and .preview_checkpoint.code_sha == $code
+                and .preview_checkpoint.content_sha256 == $content
+                and (.preview_checkpoint.preview_url | test("^https://"))' \
+              server-resume-plan.json >/dev/null
+            echo "PREVIEW_URL=$(jq -r '.preview_checkpoint.preview_url' server-resume-plan.json)" >> "$GITHUB_ENV"
+          fi
+          echo "SERVER_RESUME_STAGE=$resume_stage" >> "$GITHUB_ENV"
+          echo "stage=$resume_stage" >> "$GITHUB_OUTPUT"
 
       - name: Setup Node.js 22.17.0
         uses: actions/setup-node@v4
@@ -122,15 +259,19 @@ jobs:
           PRODUCTION_BROKER_HMAC_SECRET: ${{ secrets.PRODUCTION_BROKER_HMAC_SECRET }}
         run: node scripts/validate-content-production-config.mjs workflow-release
 
-      - name: Install locked dependencies
-        run: |
-          npm ci
-          npm ci --prefix astro
+      - name: Install root locked dependencies
+        run: npm ci
+
+      - name: Install Astro locked dependencies
+        if: ${{ steps.resume.outputs.stage == 'build' }}
+        run: npm ci --prefix astro
 
       - name: Verify Worker contracts
+        if: ${{ steps.resume.outputs.stage == 'build' }}
         run: npm test
 
       - name: Build pinned content release
+        if: ${{ steps.resume.outputs.stage == 'build' }}
         run: |
           npm run check --prefix astro
           npm run lint --prefix astro
@@ -140,6 +281,7 @@ jobs:
           npm run verify:site --prefix astro
 
       - name: Verify embedded release identity
+        if: ${{ steps.resume.outputs.stage == 'build' }}
         run: |
           node <<'NODE'
           const build = require('./astro/dist/client/release-manifests/site-route-manifest.json').build;
@@ -178,6 +320,7 @@ jobs:
           NODE
 
       - name: Create deterministic content-addressed artifact
+        if: ${{ steps.resume.outputs.stage == 'build' }}
         run: |
           node scripts/create-content-addressed-artifact.mjs astro/dist/client content-release-artifact.json > artifact-summary.json
           echo "ARTIFACT_SHA256=$(jq -r .artifact_sha256 artifact-summary.json)" >> "$GITHUB_ENV"
@@ -186,6 +329,7 @@ jobs:
           echo "ARTIFACT_HASH_ALGORITHM=$(jq -r .hash_algorithm artifact-summary.json)" >> "$GITHUB_ENV"
 
       - name: Require indefinite locks for every artifact prefix
+        if: ${{ steps.resume.outputs.stage == 'build' }}
         env:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           CLOUDFLARE_R2_LOCK_READ_TOKEN: ${{ secrets.R2_LOCK_READ_API_TOKEN }}
@@ -202,6 +346,7 @@ jobs:
             > artifact-lock-evidence.json
 
       - name: Upload immutable content-addressed R2 artifact
+        if: ${{ steps.resume.outputs.stage == 'build' }}
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.R2_ARTIFACT_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_ARTIFACT_SECRET_ACCESS_KEY }}
@@ -209,17 +354,47 @@ jobs:
           R2_ENDPOINT: https://${{ secrets.CLOUDFLARE_ACCOUNT_ID }}.r2.cloudflarestorage.com
           R2_UPLOAD_CONCURRENCY: "8"
         run: |
+          if [[ "$R2_INCREMENTAL_REUSE_ENABLED" == "true" ]]; then
+            if jq -e '.trusted_baseline != null' server-resume-plan.json > /dev/null 2>&1; then
+              jq '.trusted_baseline' server-resume-plan.json > trusted-base-descriptor.json
+              trusted_key="$(jq -r '.object_key' trusted-base-descriptor.json)"
+              if aws s3 cp "s3://$R2_ARTIFACT_BUCKET/$trusted_key" trusted-base-manifest.json \
+                --endpoint-url "$R2_ENDPOINT" --no-progress; then
+                export R2_TRUSTED_BASE_DESCRIPTOR_PATH=trusted-base-descriptor.json
+                export R2_TRUSTED_BASE_MANIFEST_PATH=trusted-base-manifest.json
+              else
+                echo "Trusted baseline unavailable; falling back to full R2 verification" >&2
+                rm -f trusted-base-manifest.json trusted-base-descriptor.json
+              fi
+            fi
+          fi
           node scripts/upload-content-addressed-artifact.mjs content-release-artifact.json astro/dist/client > r2-upload-summary.json
           jq -e '.inventory_sha256 == env.ARTIFACT_SHA256 and (.inventory_byte_length | tostring) == env.ARTIFACT_BYTES' r2-upload-summary.json >/dev/null
 
       - name: Register immutable artifact
+        if: ${{ steps.resume.outputs.stage == 'build' }}
         run: |
           artifact_fingerprint="$(jq -r '.build.artifact_sha256' astro/dist/client/release-manifests/site-route-manifest.json)"
           [[ "$artifact_fingerprint" =~ ^[0-9a-f]{64}$ ]]
-          evidence="$(jq -nc --arg object_key "$ARTIFACT_OBJECT_KEY" --arg hash "$ARTIFACT_SHA256" --arg fingerprint "$artifact_fingerprint" --arg algorithm "$ARTIFACT_HASH_ALGORITHM" --arg code "$EXACT_CODE_SHA" --arg source_code "$SOURCE_CODE_SHA" --arg env "$BUILD_ENVIRONMENT_VERSION" --argjson bytes "$ARTIFACT_BYTES" '{object_key:$object_key,byte_length:$bytes,artifact_sha256:$hash,artifact_fingerprint_sha256:$fingerprint,hash_algorithm:$algorithm,code_sha:$code,source_code_sha:($source_code | if length > 0 then . else null end),build_environment_version:$env}')"
-          node scripts/send-content-deployment-callback.mjs artifact_registered "$evidence"
+          lock_evidence_sha256="$(sha256sum artifact-lock-evidence.json | awk '{print $1}')"
+          r2_verified_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          evidence="$(jq -nc --arg object_key "$ARTIFACT_OBJECT_KEY" --arg hash "$ARTIFACT_SHA256" --arg fingerprint "$artifact_fingerprint" --arg algorithm "$ARTIFACT_HASH_ALGORITHM" --arg code "$EXACT_CODE_SHA" --arg source_code "$SOURCE_CODE_SHA" --arg content "$CONTENT_ROOT_SHA256" --arg env "$BUILD_ENVIRONMENT_VERSION" --arg profile "r2-full-get-sha256-indefinite-lock-v1" --arg verified_at "$r2_verified_at" --arg lock "$lock_evidence_sha256" --arg contract "$RESUME_CONTRACT_VERSION" --argjson bytes "$ARTIFACT_BYTES" '{object_key:$object_key,byte_length:$bytes,artifact_sha256:$hash,artifact_fingerprint_sha256:$fingerprint,hash_algorithm:$algorithm,code_sha:$code,source_code_sha:($source_code | if length > 0 then . else null end),content_sha256:$content,build_environment_version:$env,verification_profile:$profile,r2_verified_at:$verified_at,lock_evidence_sha256:$lock,resume_contract_version:($contract | if length > 0 then . else null end)}')"
+          node "$RUNNER_TEMP/content-release-helper.mjs" callback artifact_registered "$evidence"
+
+      - name: Materialize exact registered R2 artifact
+        if: ${{ steps.resume.outputs.stage != 'build' }}
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.R2_ARTIFACT_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_ARTIFACT_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: auto
+          R2_ENDPOINT: https://${{ secrets.CLOUDFLARE_ACCOUNT_ID }}.r2.cloudflarestorage.com
+          R2_MATERIALIZE_CONCURRENCY: "8"
+        run: |
+          node scripts/materialize-content-addressed-artifact.mjs server-resume-plan.json astro/dist/client > materialize-summary.json
+          jq -e '.site_release_id == env.SITE_RELEASE_ID and .artifact_sha256 == env.ARTIFACT_SHA256' materialize-summary.json >/dev/null
 
       - name: Deploy exact files to Pages Preview
+        if: ${{ steps.resume.outputs.stage != 'promote' }}
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_PREVIEW_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
@@ -234,8 +409,8 @@ jobs:
 
       - name: Record Preview evidence
         run: |
-          evidence="$(jq -nc --arg url "$PREVIEW_URL" --arg artifact "$ARTIFACT_SHA256" --arg content "$CONTENT_ROOT_SHA256" '{preview_url:$url,artifact_sha256:$artifact,content_sha256:$content,route_parity:true}')"
-          node scripts/send-content-deployment-callback.mjs preview_verified "$evidence"
+          evidence="$(jq -nc --arg url "$PREVIEW_URL" --arg artifact "$ARTIFACT_SHA256" --arg content "$CONTENT_ROOT_SHA256" --arg code "$EXACT_CODE_SHA" --arg contract "$RESUME_CONTRACT_VERSION" '{preview_url:$url,artifact_sha256:$artifact,content_sha256:$content,code_sha:$code,route_parity:true,resume_contract_version:($contract | if length > 0 then . else null end)}')"
+          node "$RUNNER_TEMP/content-release-helper.mjs" callback preview_verified "$evidence"
 
       - name: Request fenced production promotion
         if: ${{ github.event.inputs.mode == 'production' }}
@@ -244,21 +419,11 @@ jobs:
           PRODUCTION_BROKER_HMAC_SECRET: ${{ secrets.PRODUCTION_BROKER_HMAC_SECRET }}
         run: |
           test -n "$PRODUCTION_BROKER_URL"
-          body="$(jq -nc --arg dispatch "$DISPATCH_ID" --arg release "$SITE_RELEASE_ID" --argjson sequence "$CONTENT_RELEASE_SEQUENCE" --arg predecessor "$EXPECTED_PREDECESSOR_ID" --arg artifact "$ARTIFACT_SHA256" --arg object "$ARTIFACT_OBJECT_KEY" --arg code "$EXACT_CODE_SHA" --arg content "$CONTENT_ROOT_SHA256" --arg environment "$BUILD_ENVIRONMENT_VERSION" '{dispatch_id:$dispatch,site_release_id:$release,site_release_sequence:$sequence,expected_predecessor_id:($predecessor | if length > 0 then . else null end),artifact_sha256:$artifact,artifact_object_key:$object,code_sha:$code,content_sha256:$content,build_environment_version:$environment}')"
+          body="$(jq -nc --arg dispatch "$DISPATCH_ID" --arg release "$SITE_RELEASE_ID" --arg attempt "$DEPLOYMENT_ATTEMPT_TOKEN" --argjson execution_generation "$DEPLOYMENT_EXECUTION_GENERATION" --argjson sequence "$CONTENT_RELEASE_SEQUENCE" --arg predecessor "$EXPECTED_PREDECESSOR_ID" --arg artifact "$ARTIFACT_SHA256" --arg object "$ARTIFACT_OBJECT_KEY" --arg code "$EXACT_CODE_SHA" --arg content "$CONTENT_ROOT_SHA256" --arg environment "$BUILD_ENVIRONMENT_VERSION" '{dispatch_id:$dispatch,site_release_id:$release,attempt_token:$attempt,execution_generation:$execution_generation,site_release_sequence:$sequence,expected_predecessor_id:($predecessor | if length > 0 then . else null end),artifact_sha256:$artifact,artifact_object_key:$object,code_sha:$code,content_sha256:$content,build_environment_version:$environment}')"
           printf '%s' "$body" | node scripts/request-production-promotion.mjs > broker-result.json
           jq -e '.ok == true and (.site_release_id == env.SITE_RELEASE_ID)' broker-result.json >/dev/null
-
-      - name: Upload short-lived workflow artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: content-release-${{ github.event.inputs.site_release_sequence }}
-          path: |
-            content-release-artifact.json
-            artifact-lock-evidence.json
-          retention-days: 14
-          if-no-files-found: error
 
       - name: Record failed workflow
         if: ${{ failure() }}
         continue-on-error: true
-        run: node scripts/send-content-deployment-callback.mjs failed '{"error":"workflow_failed"}'
+        run: node "$RUNNER_TEMP/content-release-helper.mjs" callback failed '{"error":"workflow_failed"}'

--- a/.github/workflows/worker-ci.yml
+++ b/.github/workflows/worker-ci.yml
@@ -42,10 +42,12 @@ jobs:
       - name: Bundle isolated staging Worker
         run: npm run worker:check:staging
 
-      - name: Bundle Community API and Access admin Workers
+      - name: Bundle Community, admin and production release Workers
         run: |
           npm run community:check
           npm run admin:check
+          npm run content:deployer:check
+          npm run content:broker:check
 
   astro-verify:
     runs-on: ubuntu-latest
@@ -76,11 +78,20 @@ jobs:
 
   database-security:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 20
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+
+      - name: Setup Node.js 22.17
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.17.0
+          cache: npm
+
+      - name: Install locked dependencies
+        run: npm ci
 
       - name: Setup Supabase CLI
         uses: supabase/setup-cli@v1

--- a/scripts/check-content-observability.mjs
+++ b/scripts/check-content-observability.mjs
@@ -4,19 +4,16 @@ import { fileURLToPath } from "node:url";
 import postgres from "postgres";
 
 import { validateContentDatabaseTopology } from "./content-database-topology.mjs";
+import {
+  chunkScheduledRuns,
+  dueScheduledRuns,
+} from "../src/daily/scheduleContract.js";
 
 const PROJECT_REF = /^[a-z0-9]{20}$/;
 const ACCOUNT_ID = /^[a-f0-9]{32}$/i;
 const UUID =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 const SHA256 = /^[a-f0-9]{64}$/;
-const BATCHES = [
-  [2, "morning"],
-  [7, "afternoon"],
-  [15, "night"],
-  [18, "lateNight"],
-  [19, "lateNightSupplement"],
-];
 
 function required(label, value) {
   const normalized = String(value || "").trim();
@@ -184,28 +181,8 @@ export function validateContentObservabilityEnvironment(env) {
   };
 }
 
-function dateString(date) {
-  return date.toISOString().slice(0, 10);
-}
-
 export function dueContentBatches(now = Date.now(), lookbackHours = 30) {
-  const due = [];
-  const start = now - lookbackHours * 60 * 60 * 1000;
-  const firstDay = new Date(start);
-  firstDay.setUTCHours(0, 0, 0, 0);
-  for (let day = firstDay.getTime(); day <= now; day += 24 * 60 * 60 * 1000) {
-    for (const [hour, batch_id] of BATCHES) {
-      const scheduled_at = day + hour * 60 * 60 * 1000;
-      if (scheduled_at < start || scheduled_at + 10 * 60 * 1000 > now) continue;
-      due.push({
-        batch_id,
-        deadline: new Date(scheduled_at + 10 * 60 * 1000).toISOString(),
-        report_date: dateString(new Date(day)),
-        scheduled_at: new Date(scheduled_at).toISOString(),
-      });
-    }
-  }
-  return due;
+  return dueScheduledRuns(now, lookbackHours);
 }
 
 function currentIdentity(value) {
@@ -265,6 +242,59 @@ function sameStaticIdentity(current, staticManifest) {
   );
 }
 
+function sameInstant(left, right) {
+  const leftEpoch = Date.parse(String(left || ""));
+  const rightEpoch = Date.parse(String(right || ""));
+  return (
+    Number.isFinite(leftEpoch) &&
+    Number.isFinite(rightEpoch) &&
+    leftEpoch === rightEpoch
+  );
+}
+
+function scheduledRunEvidenceComplete(outcome, due) {
+  const startedAt = Date.parse(String(outcome?.started_at || ""));
+  const finishedAt = Date.parse(String(outcome?.finished_at || ""));
+  const releaseRequired = outcome?.no_op !== true;
+  return (
+    outcome?.run_id === due.run_id &&
+    sameInstant(outcome?.scheduled_at, due.scheduled_at) &&
+    outcome?.status === "succeeded" &&
+    Number.isFinite(startedAt) &&
+    Number.isFinite(finishedAt) &&
+    finishedAt >= startedAt &&
+    outcome?.source_result?.status === "succeeded" &&
+    SHA256.test(String(outcome?.content_sha256 || "")) &&
+    outcome?.database_mirror?.status === "mirrored" &&
+    (!releaseRequired ||
+      (UUID.test(String(outcome?.site_release_id || "")) &&
+        UUID.test(String(outcome?.dispatch_id || "")) &&
+        Number.isSafeInteger(Number(outcome?.site_release_sequence)) &&
+        Number(outcome.site_release_sequence) > 0))
+  );
+}
+
+function scheduledRunEvidenceAligned(kvOutcome, databaseOutcome) {
+  return (
+    kvOutcome?.run_id === databaseOutcome?.run_id &&
+    sameInstant(kvOutcome?.scheduled_at, databaseOutcome?.scheduled_at) &&
+    kvOutcome?.status === databaseOutcome?.status &&
+    sameInstant(kvOutcome?.started_at, databaseOutcome?.started_at) &&
+    sameInstant(kvOutcome?.finished_at, databaseOutcome?.finished_at) &&
+    kvOutcome?.source_result?.status === databaseOutcome?.source_result?.status &&
+    kvOutcome?.content_sha256 === databaseOutcome?.content_sha256 &&
+    (kvOutcome?.no_op === true) === (databaseOutcome?.no_op === true) &&
+    kvOutcome?.database_mirror?.status ===
+      databaseOutcome?.database_mirror?.status &&
+    String(kvOutcome?.site_release_id || "") ===
+      String(databaseOutcome?.site_release_id || "") &&
+    Number(kvOutcome?.site_release_sequence) ===
+      Number(databaseOutcome?.site_release_sequence) &&
+    String(kvOutcome?.dispatch_id || "") ===
+      String(databaseOutcome?.dispatch_id || "")
+  );
+}
+
 export function evaluateContentObservability(input, now = Date.now()) {
   const reasons = [];
   const database = input.database || {};
@@ -291,13 +321,13 @@ export function evaluateContentObservability(input, now = Date.now()) {
       reasons.push(`static_manifest_drift:${endpoint.url}`);
   }
 
-  const attempts = new Map(
-    (database.publication_attempts || []).map((attempt) => [
-      `${attempt.report_date}:${attempt.batch_id}`,
-      attempt,
-    ]),
+  const publicationAttempts = database.publication_attempts || [];
+  const attemptsByRunId = new Map(
+    publicationAttempts
+      .filter((attempt) => /^scheduled:\d{13}$/.test(String(attempt.trigger_kind || "")))
+      .map((attempt) => [String(attempt.trigger_kind), attempt]),
   );
-  const dueBatches = dueContentBatches(now).filter(
+  const dueRuns = dueContentBatches(now).filter(
     (batch) => Date.parse(batch.scheduled_at) >= (input.startedAt ?? -Infinity),
   );
   const scheduledOutcomes = new Map(
@@ -306,23 +336,48 @@ export function evaluateContentObservability(input, now = Date.now()) {
       outcome,
     ]),
   );
-  for (const due of dueBatches) {
+  const databaseScheduledRuns = new Map(
+    (Array.isArray(database.scheduled_runs) ? database.scheduled_runs : [])
+      .map((outcome) => [String(outcome?.run_id || ""), outcome]),
+  );
+  for (const due of dueRuns) {
     const scheduledOutcome = scheduledOutcomes.get(due.scheduled_at);
-    const scheduledKey = `${due.report_date}:${due.batch_id}:${due.scheduled_at}`;
+    const databaseScheduledRun = databaseScheduledRuns.get(due.run_id);
+    const scheduledKey = `${due.run_id}:${due.report_date}:${due.batch_id}`;
     if (!scheduledOutcome || scheduledOutcome.status === "missing") {
       reasons.push(`scheduled_run_missing:${scheduledKey}`);
+    } else if (scheduledOutcome.status === "started") {
+      reasons.push(`scheduled_run_terminal_missing:${scheduledKey}`);
     } else if (scheduledOutcome.status !== "succeeded") {
       reasons.push(`scheduled_run_failed:${scheduledKey}`);
+    } else if (!scheduledRunEvidenceComplete(scheduledOutcome, due)) {
+      reasons.push(`scheduled_run_evidence_incomplete:${scheduledKey}`);
     }
-    const attempt = attempts.get(`${due.report_date}:${due.batch_id}`);
-    if (!attempt || !["succeeded", "failed"].includes(attempt.status)) {
-      reasons.push(`batch_terminal_missing:${due.report_date}:${due.batch_id}`);
-    } else if (attempt.status === "failed") {
-      reasons.push(`batch_failed:${due.report_date}:${due.batch_id}`);
+
+    if (!databaseScheduledRun) {
+      reasons.push(`scheduled_run_database_trace_missing:${scheduledKey}`);
+    } else if (!scheduledRunEvidenceComplete(databaseScheduledRun, due)) {
+      reasons.push(`scheduled_run_database_trace_invalid:${scheduledKey}`);
+    } else if (
+      scheduledOutcome &&
+      !scheduledRunEvidenceAligned(scheduledOutcome, databaseScheduledRun)
+    ) {
+      reasons.push(`scheduled_run_database_trace_mismatch:${scheduledKey}`);
+    }
+
+    const attempt = attemptsByRunId.get(due.run_id);
+    const noOp =
+      databaseScheduledRun?.no_op === true || scheduledOutcome?.no_op === true;
+    if (!attempt && !noOp) {
+      reasons.push(`scheduled_run_database_attempt_missing:${scheduledKey}`);
+    } else if (attempt && attempt.status === "failed") {
+      reasons.push(`scheduled_run_database_failed:${scheduledKey}`);
+    } else if (attempt && !["succeeded", "failed"].includes(attempt.status)) {
+      reasons.push(`scheduled_run_database_terminal_missing:${scheduledKey}`);
     }
   }
 
-  const latestSucceededDate = [...attempts.values()]
+  const latestSucceededDate = publicationAttempts
     .filter((attempt) => attempt.status === "succeeded")
     .map((attempt) => String(attempt.report_date))
     .sort()
@@ -399,7 +454,8 @@ export function evaluateContentObservability(input, now = Date.now()) {
     },
     checked_at: new Date(now).toISOString(),
     current,
-    due_batches: dueBatches,
+    due_batches: dueRuns,
+    due_runs: dueRuns,
     healthy: reasons.length === 0,
     outbox: {
       dead_letter_count: deadLetterCount,
@@ -468,20 +524,31 @@ async function cloudflareAnalytics(input, now) {
   );
 }
 
-async function scheduledRunHealth(input, now) {
+export async function scheduledRunHealth(input, now, fetcher = fetchJson) {
   const due = dueContentBatches(now).filter(
     (batch) => Date.parse(batch.scheduled_at) >= input.startedAt,
   );
   if (!due.length) return [];
-  const url = new URL(input.scheduleHealthUrl);
-  for (const batch of due) url.searchParams.append("scheduled_at", batch.scheduled_at);
-  const body = await fetchJson(url, {
-    headers: { Authorization: `Bearer ${input.scheduleHealthToken}` },
-  });
-  if (body?.success !== true || !Array.isArray(body.slots)) {
-    throw new Error("scheduled run health response is malformed");
-  }
-  return body.slots;
+  const pages = await Promise.all(
+    chunkScheduledRuns(due).map(async (page) => {
+      const url = new URL(input.scheduleHealthUrl);
+      for (const run of page) {
+        url.searchParams.append("scheduled_at", run.scheduled_at);
+      }
+      const body = await fetcher(url, {
+        headers: { Authorization: `Bearer ${input.scheduleHealthToken}` },
+      });
+      if (
+        body?.success !== true ||
+        !Array.isArray(body.slots) ||
+        body.slots.length !== page.length
+      ) {
+        throw new Error("scheduled run health response is malformed");
+      }
+      return body.slots;
+    }),
+  );
+  return pages.flat();
 }
 
 async function run(env = process.env, now = Date.now()) {

--- a/scripts/check-content-observation-window.mjs
+++ b/scripts/check-content-observation-window.mjs
@@ -5,19 +5,13 @@ import { fileURLToPath } from "node:url";
 import postgres from "postgres";
 
 import { validateContentObservabilityDatabaseEnvironment } from "./check-content-observability.mjs";
+import { scheduledRunsForReportDate } from "../src/daily/scheduleContract.js";
 
 const DATE = /^\d{4}-\d{2}-\d{2}$/;
 const UUID =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 const SHA256 = /^[a-f0-9]{64}$/;
 const SHA1 = /^[a-f0-9]{40}$/;
-const BATCHES = [
-  [2, "morning"],
-  [7, "afternoon"],
-  [15, "night"],
-  [19, "lateNight"],
-];
-
 function validDate(value) {
   if (!DATE.test(String(value || ""))) return false;
   const parsed = new Date(`${value}T00:00:00.000Z`);
@@ -39,20 +33,21 @@ export function expectedObservationSlots(startDate) {
   const slots = [];
   for (let day = 0; day < 2; day += 1) {
     const reportDate = addDays(startDate, day);
-    for (const [hour, batchId] of BATCHES) {
-      const scheduledAt = Date.parse(
-        `${reportDate}T${String(hour).padStart(2, "0")}:00:00.000Z`,
-      );
+    for (const run of scheduledRunsForReportDate(reportDate)) {
       slots.push({
-        batch_id: batchId,
-        deadline: new Date(scheduledAt + 10 * 60 * 1000).toISOString(),
-        expected_trigger_kind: `scheduled:${scheduledAt}`,
+        batch_id: run.batch_id,
+        deadline: run.deadline,
+        expected_trigger_kind: run.run_id,
+        publication_batch_id: run.publication_batch_id,
         report_date: reportDate,
-        scheduled_at: new Date(scheduledAt).toISOString(),
+        run_id: run.run_id,
+        scheduled_at: run.scheduled_at,
       });
     }
   }
-  return slots;
+  return slots.sort(
+    (left, right) => Date.parse(left.scheduled_at) - Date.parse(right.scheduled_at),
+  );
 }
 
 function identityMatches(current, slot) {
@@ -116,12 +111,45 @@ function checkCoversSlot(check, slot, expected, upperBound) {
         Number(check.current?.site_release_sequence) >
           Number(slot.site_release_sequence) &&
         check.current?.content_sha256 === slot.site_content_sha256)) &&
-    Array.isArray(check.due_batches) &&
-    check.due_batches.some(
-      (batch) =>
-        batch?.report_date === expected.report_date &&
-        batch?.batch_id === expected.batch_id,
-    )
+    checkReferencesRun(check, expected)
+  );
+}
+
+function checkReferencesRun(check, expected) {
+  const dueRuns = Array.isArray(check?.due_runs)
+    ? check.due_runs
+    : Array.isArray(check?.due_batches)
+      ? check.due_batches
+      : [];
+  return dueRuns.some((run) => run?.run_id === expected.run_id);
+}
+
+function checkCoversNoOp(check, expected, upperBound) {
+  const checkedAt = Date.parse(String(check?.checked_at || ""));
+  return (
+    check?.healthy === true &&
+    Array.isArray(check.reasons) &&
+    check.reasons.length === 0 &&
+    Number.isFinite(checkedAt) &&
+    checkedAt >= Date.parse(expected.deadline) &&
+    checkedAt < upperBound &&
+    checkReferencesRun(check, expected)
+  );
+}
+
+function scheduledRunComplete(run, expected) {
+  const startedAt = Date.parse(String(run?.started_at || ""));
+  const finishedAt = Date.parse(String(run?.finished_at || ""));
+  return (
+    run?.run_id === expected.run_id &&
+    run?.scheduled_at === expected.scheduled_at &&
+    run?.status === "succeeded" &&
+    Number.isFinite(startedAt) &&
+    Number.isFinite(finishedAt) &&
+    finishedAt >= startedAt &&
+    run?.source_result?.status === "succeeded" &&
+    SHA256.test(String(run?.content_sha256 || "")) &&
+    run?.database_mirror?.status === "mirrored"
   );
 }
 
@@ -140,10 +168,13 @@ export function evaluateContentObservationWindow(input, now = Date.now()) {
     };
   }
   const readyAt = Date.parse(String(input?.ready_at || ""));
+  const latestDeadline = Date.parse(expectedSlots.at(-1)?.deadline || "");
   if (
     input?.window_complete !== true ||
     !Number.isFinite(readyAt) ||
-    now < readyAt
+    !Number.isFinite(latestDeadline) ||
+    readyAt < latestDeadline ||
+    now < Math.max(readyAt, latestDeadline)
   ) {
     reasons.push("observation_window_not_complete");
   }
@@ -152,6 +183,12 @@ export function evaluateContentObservationWindow(input, now = Date.now()) {
     ? input.publication_attempts
     : [];
   const slots = Array.isArray(input?.slots) ? input.slots : [];
+  const scheduledRuns = Array.isArray(input?.scheduled_runs)
+    ? input.scheduled_runs
+    : [];
+  const scheduledRunsById = new Map(
+    scheduledRuns.map((run) => [String(run?.run_id || ""), run]),
+  );
   const checks = Array.isArray(input?.checks) ? input.checks : [];
   if (checks.some((check) => check?.healthy !== true))
     reasons.push("observation_contains_unhealthy_check");
@@ -164,37 +201,50 @@ export function evaluateContentObservationWindow(input, now = Date.now()) {
 
   for (let index = 0; index < expectedSlots.length; index += 1) {
     const expected = expectedSlots[index];
-    const key = `${expected.report_date}:${expected.batch_id}`;
+    const key = expected.run_id;
+    const scheduledRun = scheduledRunsById.get(expected.run_id);
+    if (!scheduledRun) {
+      reasons.push(`scheduled_run_evidence_missing:${key}`);
+      continue;
+    }
+    if (!scheduledRunComplete(scheduledRun, expected)) {
+      reasons.push(`scheduled_run_evidence_invalid:${key}`);
+    }
+    const nextScheduledAt = expectedSlots[index + 1]?.scheduled_at;
+    const upperBound = nextScheduledAt
+      ? Date.parse(nextScheduledAt)
+      : Math.max(readyAt, latestDeadline) + 6 * 60 * 60 * 1000;
+    if (scheduledRun.no_op === true) {
+      if (!checks.some((check) => checkCoversNoOp(check, expected, upperBound))) {
+        reasons.push(`scheduled_run_healthy_observation_missing:${key}`);
+      }
+      continue;
+    }
     const matchingAttempts = attempts
-      .filter(
-        (attempt) =>
-          attempt?.report_date === expected.report_date &&
-          attempt?.batch_id === expected.batch_id,
-      )
+      .filter((attempt) => attempt?.trigger_kind === expected.run_id)
       .sort(
         (left, right) =>
           Number(left.attempt_number) - Number(right.attempt_number),
       );
     if (!matchingAttempts.length) {
-      reasons.push(`slot_attempt_missing:${key}`);
+      reasons.push(`scheduled_run_attempt_missing:${key}`);
     } else {
-      if (
-        matchingAttempts.some(
-          (attempt) => attempt.trigger_kind !== expected.expected_trigger_kind,
-        )
-      ) {
-        reasons.push(`slot_noncanonical_trigger:${key}`);
-      }
       if (matchingAttempts.at(-1)?.status !== "succeeded")
-        reasons.push(`slot_final_attempt_not_succeeded:${key}`);
+        reasons.push(`scheduled_run_final_attempt_not_succeeded:${key}`);
       if (matchingAttempts.some((attempt) => attempt.status === "started"))
-        reasons.push(`slot_attempt_unfinished:${key}`);
+        reasons.push(`scheduled_run_attempt_unfinished:${key}`);
+    }
+    if (
+      !UUID.test(String(scheduledRun.site_release_id || "")) ||
+      !UUID.test(String(scheduledRun.dispatch_id || "")) ||
+      !scheduledRun.stable_verified_at
+    ) {
+      reasons.push(`scheduled_run_release_identity_invalid:${key}`);
+      continue;
     }
 
     const matchingSlots = slots.filter(
-      (slot) =>
-        slot?.report_date === expected.report_date &&
-        slot?.batch_id === expected.batch_id,
+      (slot) => slot?.site_release_id === scheduledRun.site_release_id,
     );
     if (matchingSlots.length !== 1) {
       reasons.push(`slot_semantic_result_count:${key}:${matchingSlots.length}`);
@@ -227,10 +277,6 @@ export function evaluateContentObservationWindow(input, now = Date.now()) {
     if (!slot.edge_verified_at || !verifierIdentityComplete(slot))
       reasons.push(`slot_edge_evidence_invalid:${key}`);
 
-    const nextScheduledAt = expectedSlots[index + 1]?.scheduled_at;
-    const upperBound = nextScheduledAt
-      ? Date.parse(nextScheduledAt)
-      : readyAt + 6 * 60 * 60 * 1000;
     if (
       !checks.some((check) =>
         checkCoversSlot(check, slot, expected, upperBound),

--- a/scripts/materialize-content-addressed-artifact.mjs
+++ b/scripts/materialize-content-addressed-artifact.mjs
@@ -1,0 +1,252 @@
+import { createHash, randomUUID } from "node:crypto";
+import { mkdir, readFile, rename, rm, stat, writeFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { AwsCliObjectStore } from "./upload-content-addressed-artifact.mjs";
+
+const SHA256 = /^[a-f0-9]{64}$/;
+const SHA1 = /^[a-f0-9]{40}$/;
+const UUID =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const ALGORITHM = "sha256-content-addressed-pages-v1";
+const ROUTE_MANIFEST = "release-manifests/site-route-manifest.json";
+const MAX_FILES = 20_000;
+const MAX_FILE_BYTES = 25 * 1024 * 1024;
+const MAX_MANIFEST_BYTES = 2 * 1024 * 1024;
+const MAX_TOTAL_BYTES = 1280 * 1024 * 1024;
+const DEFAULT_CONCURRENCY = 8;
+
+function sha256(bytes) {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+function safePath(path) {
+  return Boolean(
+    path &&
+    !/[\u0000-\u001f\u007f]/.test(path) &&
+    !path.startsWith("/") &&
+    !path.includes("\\") &&
+    !path
+      .split("/")
+      .some((part) => part === "." || part === ".." || part === ""),
+  );
+}
+
+function positiveInteger(value) {
+  const parsed = Number(value ?? DEFAULT_CONCURRENCY);
+  if (!Number.isSafeInteger(parsed) || parsed < 1 || parsed > 32) {
+    throw new Error(
+      "Artifact materialization concurrency must be between 1 and 32",
+    );
+  }
+  return parsed;
+}
+
+async function runPool(entries, concurrency, worker) {
+  let cursor = 0;
+  await Promise.all(
+    Array.from({ length: Math.min(concurrency, entries.length) }, async () => {
+      while (cursor < entries.length) {
+        const index = cursor;
+        cursor += 1;
+        await worker(entries[index], index);
+      }
+    }),
+  );
+}
+
+function validateDescriptor(descriptor, expected) {
+  const artifactSha256 = String(descriptor?.artifact_sha256 || "");
+  if (
+    descriptor?.hash_algorithm !== ALGORITHM ||
+    !UUID.test(String(descriptor?.site_release_id || "")) ||
+    !SHA1.test(String(descriptor?.code_sha || "")) ||
+    !SHA256.test(String(descriptor?.content_sha256 || "")) ||
+    !SHA256.test(String(descriptor?.artifact_fingerprint_sha256 || "")) ||
+    !Number.isSafeInteger(Number(descriptor?.byte_length)) ||
+    Number(descriptor.byte_length) < 1 ||
+    !SHA256.test(artifactSha256) ||
+    descriptor.object_key !== `artifacts/sha256/${artifactSha256}.json`
+  ) {
+    throw new Error("Resume artifact descriptor is invalid");
+  }
+  if (
+    descriptor.site_release_id !== expected.siteReleaseId ||
+    descriptor.code_sha !== expected.codeSha ||
+    descriptor.content_sha256 !== expected.contentSha256
+  ) {
+    throw new Error(
+      "Resume artifact descriptor does not match workflow identity",
+    );
+  }
+}
+
+function parseInventory(bytes, descriptor) {
+  if (
+    bytes.byteLength !== Number(descriptor.byte_length) ||
+    bytes.byteLength > MAX_MANIFEST_BYTES ||
+    sha256(bytes) !== descriptor.artifact_sha256
+  ) {
+    throw new Error("Resume artifact inventory byte identity mismatch");
+  }
+  let manifest;
+  try {
+    manifest = JSON.parse(bytes.toString("utf8"));
+  } catch {
+    throw new Error("Resume artifact inventory is malformed");
+  }
+  if (
+    manifest?.schema_version !== 1 ||
+    manifest?.hash_algorithm !== ALGORITHM ||
+    !Array.isArray(manifest.files) ||
+    manifest.files.length === 0 ||
+    manifest.files.length > MAX_FILES ||
+    manifest.file_count !== manifest.files.length ||
+    manifest.artifact_fingerprint_sha256 !==
+      descriptor.artifact_fingerprint_sha256 ||
+    manifest.build?.site_release_id !== descriptor.site_release_id ||
+    manifest.build?.code_sha !== descriptor.code_sha ||
+    manifest.build?.content_sha256 !== descriptor.content_sha256 ||
+    manifest.build?.artifact_sha256 !== descriptor.artifact_fingerprint_sha256
+  ) {
+    throw new Error("Resume artifact inventory contract is invalid");
+  }
+
+  const paths = new Set();
+  let totalBytes = 0;
+  for (const file of manifest.files) {
+    if (
+      !safePath(file?.path) ||
+      paths.has(file.path) ||
+      !Number.isSafeInteger(file.byte_length) ||
+      file.byte_length < 0 ||
+      file.byte_length > MAX_FILE_BYTES ||
+      !SHA256.test(file.sha256) ||
+      file.object_key !== `assets/sha256/${file.sha256}`
+    ) {
+      throw new Error("Resume artifact inventory contains an invalid asset");
+    }
+    paths.add(file.path);
+    totalBytes += file.byte_length;
+  }
+  if (
+    !paths.has(ROUTE_MANIFEST) ||
+    totalBytes !== manifest.total_asset_bytes ||
+    totalBytes > MAX_TOTAL_BYTES
+  ) {
+    throw new Error("Resume artifact inventory totals are invalid");
+  }
+  const fingerprint = createHash("sha256");
+  for (const file of [...manifest.files]
+    .filter((entry) => entry.path !== ROUTE_MANIFEST)
+    .sort((left, right) => left.path.localeCompare(right.path))) {
+    fingerprint.update(file.path);
+    fingerprint.update("\0");
+    fingerprint.update(file.sha256);
+    fingerprint.update("\n");
+  }
+  if (fingerprint.digest("hex") !== descriptor.artifact_fingerprint_sha256) {
+    throw new Error("Resume artifact path fingerprint mismatch");
+  }
+  return manifest;
+}
+
+export async function materializeContentAddressedArtifact({
+  descriptor,
+  expectedSiteReleaseId,
+  expectedCodeSha,
+  expectedContentSha256,
+  targetRoot,
+  store,
+  concurrency = DEFAULT_CONCURRENCY,
+}) {
+  validateDescriptor(descriptor, {
+    siteReleaseId: expectedSiteReleaseId,
+    codeSha: expectedCodeSha,
+    contentSha256: expectedContentSha256,
+  });
+  const inventoryBytes = await store.get(descriptor.object_key);
+  const manifest = parseInventory(inventoryBytes, descriptor);
+  const target = resolve(targetRoot);
+  const temporary = `${target}.materializing-${randomUUID()}`;
+  const backup = `${target}.previous-${randomUUID()}`;
+  const objectReads = new Map();
+  let targetMoved = false;
+  try {
+    await mkdir(temporary, { recursive: true });
+    await runPool(
+      manifest.files,
+      positiveInteger(concurrency),
+      async (file) => {
+        let pending = objectReads.get(file.object_key);
+        if (!pending) {
+          pending = store.get(file.object_key);
+          objectReads.set(file.object_key, pending);
+        }
+        const bytes = await pending;
+        if (
+          bytes.byteLength !== file.byte_length ||
+          sha256(bytes) !== file.sha256
+        ) {
+          throw new Error(
+            `Resume artifact asset identity mismatch: ${file.path}`,
+          );
+        }
+        const destination = resolve(temporary, file.path);
+        await mkdir(dirname(destination), { recursive: true });
+        await writeFile(destination, bytes, { flag: "wx" });
+      },
+    );
+    const existing = await stat(target).catch(() => null);
+    if (existing) {
+      await rename(target, backup);
+      targetMoved = true;
+    }
+    await rename(temporary, target);
+    if (targetMoved) await rm(backup, { recursive: true, force: true });
+    return {
+      site_release_id: descriptor.site_release_id,
+      artifact_sha256: descriptor.artifact_sha256,
+      artifact_fingerprint_sha256: descriptor.artifact_fingerprint_sha256,
+      file_count: manifest.file_count,
+      total_asset_bytes: manifest.total_asset_bytes,
+      unique_object_reads: objectReads.size,
+      target_root: target,
+    };
+  } catch (error) {
+    await rm(temporary, { recursive: true, force: true });
+    if (targetMoved) {
+      await rm(target, { recursive: true, force: true });
+      await rename(backup, target);
+    }
+    throw error;
+  }
+}
+
+const isMain =
+  process.argv[1] &&
+  resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+if (isMain) {
+  const plan = JSON.parse(
+    await readFile(
+      process.argv[2] || resolve(process.cwd(), "server-resume-plan.json"),
+      "utf8",
+    ),
+  );
+  const descriptor = plan.artifact;
+  const store = new AwsCliObjectStore({
+    bucket: process.env.R2_ARTIFACT_BUCKET,
+    endpoint: process.env.R2_ENDPOINT,
+    aws: process.env.AWS_CLI || "aws",
+  });
+  const result = await materializeContentAddressedArtifact({
+    descriptor,
+    expectedSiteReleaseId: process.env.SITE_RELEASE_ID,
+    expectedCodeSha: process.env.EXACT_CODE_SHA,
+    expectedContentSha256: process.env.CONTENT_ROOT_SHA256,
+    targetRoot: process.argv[3] || "astro/dist/client",
+    store,
+    concurrency: process.env.R2_MATERIALIZE_CONCURRENCY || DEFAULT_CONCURRENCY,
+  });
+  process.stdout.write(`${JSON.stringify(result)}\n`);
+}

--- a/scripts/request-content-release-plan.mjs
+++ b/scripts/request-content-release-plan.mjs
@@ -1,0 +1,38 @@
+import { createHmac } from "node:crypto";
+
+const callbackUrl = process.env.CONTENT_DEPLOY_CALLBACK_URL;
+const secret = process.env.CONTENT_DEPLOY_CALLBACK_SECRET;
+const body = JSON.stringify({
+  site_release_id: process.env.SITE_RELEASE_ID,
+  dispatch_id: process.env.DISPATCH_ID,
+  attempt_token: process.env.DEPLOYMENT_ATTEMPT_TOKEN,
+  execution_generation: Number(
+    process.env.DEPLOYMENT_EXECUTION_GENERATION || 0,
+  ),
+});
+if (!callbackUrl || !secret) {
+  throw new Error("Content release plan environment is incomplete");
+}
+const signature = createHmac("sha256", secret).update(body).digest("hex");
+const url = new URL("/internal/deployment-plan", callbackUrl);
+const response = await fetch(url, {
+  method: "POST",
+  headers: {
+    "Content-Type": "application/json",
+    "X-Content-Signature": signature,
+  },
+  body,
+});
+const responseBody = await response.text();
+if (!response.ok) {
+  throw new Error(
+    `Content release plan request failed with ${response.status}: ${responseBody
+      .trim()
+      .slice(0, 1024)}`,
+  );
+}
+const plan = JSON.parse(responseBody);
+if (!plan || typeof plan !== "object") {
+  throw new Error("Content release plan response is invalid");
+}
+process.stdout.write(`${JSON.stringify(plan)}\n`);

--- a/scripts/send-content-deployment-callback.mjs
+++ b/scripts/send-content-deployment-callback.mjs
@@ -5,6 +5,10 @@ const callbackUrl = process.env.CONTENT_DEPLOY_CALLBACK_URL;
 const secret = process.env.CONTENT_DEPLOY_CALLBACK_SECRET;
 const siteReleaseId = process.env.SITE_RELEASE_ID;
 const dispatchId = process.env.DISPATCH_ID;
+const attemptToken = process.env.DEPLOYMENT_ATTEMPT_TOKEN;
+const executionGeneration = Number(
+  process.env.DEPLOYMENT_EXECUTION_GENERATION || 0,
+);
 if (!callbackUrl || !secret || !siteReleaseId || !dispatchId || !eventType) {
   throw new Error("Deployment callback environment is incomplete");
 }
@@ -12,6 +16,12 @@ const evidence = JSON.parse(evidenceText);
 const body = JSON.stringify({
   site_release_id: siteReleaseId,
   dispatch_id: dispatchId,
+  ...(attemptToken
+    ? {
+        attempt_token: attemptToken,
+        execution_generation: executionGeneration,
+      }
+    : {}),
   event_type: eventType,
   evidence,
 });

--- a/scripts/test-content-failure-matrix-local.mjs
+++ b/scripts/test-content-failure-matrix-local.mjs
@@ -980,17 +980,18 @@ try {
     callbackState[0].last_error === null,
     "Late failure callback mutated terminal error state",
   );
+  const unknownDispatchId = randomUUID();
   const wrongTupleMessage = await expectRejected(
     "wrong deployment callback tuple",
     () =>
       asRole(
         "content_deployer",
         (sql) => sql`
-				select private.record_deployment_event_v1(
-					${releaseA.site_release_id}::uuid, ${claimFixtures[0].dispatchId}::uuid,
-					'building', '{}'::jsonb
-				)
-			`,
+					select private.record_deployment_event_v1(
+						${releaseA.site_release_id}::uuid, ${unknownDispatchId}::uuid,
+						'building', '{}'::jsonb
+					)
+				`,
       ),
     /Deployment event identity mismatch/,
   );
@@ -1253,12 +1254,29 @@ try {
       releaseB.site_release_id,
     "Rollback authorization moved pointer",
   );
-  const reconcile = rpc(
+  const activeLeaseReconcile = rpc(
     await asRole(
       "content_deployer",
       (sql) => sql`
 			select private.begin_production_reconcile_v1() as result
 		`,
+    ),
+  );
+  assert(
+    activeLeaseReconcile === null,
+    "Active rollback lease was incorrectly claimable by reconciler",
+  );
+  await admin`
+    update private.production_promotion_slot
+    set lease_expires_at = clock_timestamp() - interval '1 second'
+    where project_key = 'bubble-brain-pages'
+  `;
+  const reconcile = rpc(
+    await asRole(
+      "content_deployer",
+      (sql) => sql`
+        select private.begin_production_reconcile_v1() as result
+      `,
     ),
   );
   assert(
@@ -1270,10 +1288,10 @@ try {
     "Reconcile did not identify B as current",
   );
   await asRole(
-    "content_deployer",
-    (sql) => sql`
+      "content_deployer",
+      (sql) => sql`
 		select private.finish_production_recovery_v1(
-			${releaseA.site_release_id}::uuid, ${rollbackAuth.fencing_token}, 2, true,
+			${releaseA.site_release_id}::uuid, ${reconcile.slot.fencing_token}, 2, true,
 			'{"restored_site_release":"B","multi_edge_verified":true}'::jsonb
 		)
 	`,
@@ -2069,6 +2087,15 @@ try {
     staged_global_overrides: 0,
     finalize_audit_rows: 1,
   };
+  await asRole(
+    "content_deployer",
+    (sql) => sql`
+      select private.record_deployment_event_v1(
+        ${hideRelease.site_release_id}::uuid, ${hideDispatchId}::uuid,
+        'edge_verified', '{"synthetic_cleanup":true}'::jsonb
+      )
+    `,
+  );
 
   const controlBody = sha256("routine-control-denial");
   await expectRejected(
@@ -2439,6 +2466,17 @@ try {
         `,
       ),
     /permission denied for function retry_content_outbox_v1/,
+  );
+  await asRole(
+    "content_deployer",
+    (sql) => sql`
+      select private.record_deployment_event_v1(
+        ${suppressionRelease.site_release_id}::uuid,
+        ${suppressionDispatchId}::uuid,
+        'failed',
+        ${sql.json({ error: "failure_matrix_retry_exhausted_fixture" })}
+      )
+    `,
   );
 
   const rebuildBodyHash = sha256("operations-same-release-rebuild");

--- a/scripts/test-supabase-local.sh
+++ b/scripts/test-supabase-local.sh
@@ -39,4 +39,6 @@ for migration in supabase/migrations/*.sql; do
 done
 
 run_supabase test db
-echo "Supabase migrations, second-run idempotency, and pgTAP passed."
+CONTENT_TEST_DATABASE_URL="postgresql://supabase_admin:postgres@127.0.0.1:54322/postgres" \
+  node scripts/test-content-failure-matrix-local.mjs
+echo "Supabase migrations, second-run idempotency, pgTAP, and failure matrix passed."

--- a/scripts/upload-content-addressed-artifact.mjs
+++ b/scripts/upload-content-addressed-artifact.mjs
@@ -10,6 +10,10 @@ const MAX_FILE_BYTES = 25 * 1024 * 1024;
 const MAX_MANIFEST_BYTES = 2 * 1024 * 1024;
 const MAX_TOTAL_BYTES = 1280 * 1024 * 1024;
 const DEFAULT_CONCURRENCY = 8;
+const CONTENT_ADDRESSED_ALGORITHM = "sha256-content-addressed-pages-v1";
+const TRUSTED_VERIFICATION_PROFILE = "r2-full-get-sha256-indefinite-lock-v1";
+const UUID =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
 function sha256(bytes) {
   return createHash("sha256").update(bytes).digest("hex");
@@ -33,6 +37,89 @@ function positiveInteger(value, fallback) {
     throw new Error("Artifact upload concurrency must be between 1 and 32");
   }
   return parsed;
+}
+
+function parseInventoryBytes(bytes, label) {
+  if (bytes.byteLength === 0 || bytes.byteLength > MAX_MANIFEST_BYTES) {
+    throw new Error(`${label} inventory byte length is invalid`);
+  }
+  let manifest;
+  try {
+    manifest = JSON.parse(bytes.toString("utf8"));
+  } catch {
+    throw new Error(`${label} inventory is malformed`);
+  }
+  if (
+    manifest?.schema_version !== 1 ||
+    manifest?.hash_algorithm !== CONTENT_ADDRESSED_ALGORITHM ||
+    !Array.isArray(manifest.files) ||
+    manifest.files.length === 0 ||
+    manifest.files.length > MAX_FILES ||
+    manifest.file_count !== manifest.files.length
+  ) {
+    throw new Error(`${label} inventory contract is invalid`);
+  }
+  const seenPaths = new Set();
+  let totalBytes = 0;
+  for (const file of manifest.files) {
+    if (
+      !safePath(file?.path) ||
+      seenPaths.has(file.path) ||
+      !Number.isSafeInteger(file.byte_length) ||
+      file.byte_length < 0 ||
+      file.byte_length > MAX_FILE_BYTES ||
+      !SHA256.test(file.sha256) ||
+      file.object_key !== `assets/sha256/${file.sha256}`
+    ) {
+      throw new Error(`${label} inventory contains an invalid asset`);
+    }
+    seenPaths.add(file.path);
+    totalBytes += file.byte_length;
+  }
+  if (
+    totalBytes !== manifest.total_asset_bytes ||
+    totalBytes > MAX_TOTAL_BYTES
+  ) {
+    throw new Error(`${label} inventory total byte length is invalid`);
+  }
+  return manifest;
+}
+
+export function trustedObjectKeys(trustedBaseline) {
+  const descriptor = trustedBaseline?.descriptor;
+  const bytes = trustedBaseline?.manifestBytes;
+  if (!descriptor || !Buffer.isBuffer(bytes)) {
+    throw new Error("Trusted baseline is incomplete");
+  }
+  const artifactSha256 = String(descriptor.artifact_sha256 || "");
+  const artifactFingerprint = String(
+    descriptor.artifact_fingerprint_sha256 || "",
+  );
+  const siteReleaseId = String(descriptor.site_release_id || "");
+  if (
+    descriptor.production_verified !== true ||
+    descriptor.hash_algorithm !== CONTENT_ADDRESSED_ALGORITHM ||
+    descriptor.verification_profile !== TRUSTED_VERIFICATION_PROFILE ||
+    !SHA256.test(artifactSha256) ||
+    descriptor.object_key !== `artifacts/sha256/${artifactSha256}.json` ||
+    Number(descriptor.byte_length) !== bytes.byteLength ||
+    !SHA256.test(artifactFingerprint) ||
+    !UUID.test(siteReleaseId) ||
+    !SHA256.test(String(descriptor.lock_evidence_sha256 || "")) ||
+    !Number.isFinite(Date.parse(String(descriptor.r2_verified_at || ""))) ||
+    sha256(bytes) !== artifactSha256
+  ) {
+    throw new Error("Trusted baseline provenance is invalid");
+  }
+  const manifest = parseInventoryBytes(bytes, "Trusted baseline");
+  if (
+    manifest.artifact_fingerprint_sha256 !== artifactFingerprint ||
+    manifest.build?.artifact_sha256 !== artifactFingerprint ||
+    manifest.build?.site_release_id !== siteReleaseId
+  ) {
+    throw new Error("Trusted baseline release identity is invalid");
+  }
+  return new Set(manifest.files.map((file) => file.object_key));
 }
 
 async function runPool(entries, concurrency, worker) {
@@ -160,41 +247,11 @@ async function loadPlan(manifestPath, distRoot, expectedManifestSha256) {
   if (expectedManifestSha256 && manifestSha256 !== expectedManifestSha256) {
     throw new Error("Artifact inventory SHA-256 does not match workflow state");
   }
-  let manifest;
-  try {
-    manifest = JSON.parse(manifestBytes.toString("utf8"));
-  } catch {
-    throw new Error("Artifact inventory is malformed");
-  }
-  if (
-    manifest?.schema_version !== 1 ||
-    manifest?.hash_algorithm !== "sha256-content-addressed-pages-v1" ||
-    !Array.isArray(manifest.files) ||
-    manifest.files.length === 0 ||
-    manifest.files.length > MAX_FILES ||
-    manifest.file_count !== manifest.files.length
-  ) {
-    throw new Error("Artifact inventory contract is invalid");
-  }
+  const manifest = parseInventoryBytes(manifestBytes, "Artifact");
 
   const root = await realpath(resolve(distRoot));
-  const seenPaths = new Set();
   const objects = new Map();
-  let totalBytes = 0;
   for (const file of manifest.files) {
-    if (
-      !safePath(file?.path) ||
-      seenPaths.has(file.path) ||
-      !Number.isSafeInteger(file.byte_length) ||
-      file.byte_length < 0 ||
-      file.byte_length > MAX_FILE_BYTES ||
-      !SHA256.test(file.sha256) ||
-      file.object_key !== `assets/sha256/${file.sha256}`
-    ) {
-      throw new Error("Artifact inventory contains an invalid asset");
-    }
-    seenPaths.add(file.path);
-    totalBytes += file.byte_length;
     const absolute = await realpath(resolve(root, file.path));
     const escaped = relative(root, absolute);
     if (escaped.startsWith(`..${sep}`) || escaped === "..") {
@@ -220,12 +277,6 @@ async function loadPlan(manifestPath, distRoot, expectedManifestSha256) {
         sha256: file.sha256,
       });
     }
-  }
-  if (
-    totalBytes !== manifest.total_asset_bytes ||
-    totalBytes > MAX_TOTAL_BYTES
-  ) {
-    throw new Error("Artifact inventory total byte length is invalid");
   }
   return {
     manifest,
@@ -278,6 +329,8 @@ export async function uploadContentAddressedArtifact({
   artifactObjectKey,
   expectedManifestSha256,
   store,
+  incrementalReuseEnabled = false,
+  trustedBaseline = null,
   concurrency = DEFAULT_CONCURRENCY,
   onProgress = () => {},
 }) {
@@ -298,11 +351,26 @@ export async function uploadContentAddressedArtifact({
     distRoot,
     expectedManifestSha256 || parsedKeySha256,
   );
+  let trustedKeys = new Set();
+  let trustedBaselineReason = incrementalReuseEnabled
+    ? "baseline_unavailable"
+    : "feature_disabled";
+  if (incrementalReuseEnabled && trustedBaseline) {
+    try {
+      trustedKeys = trustedObjectKeys(trustedBaseline);
+      trustedBaselineReason = "verified";
+    } catch (error) {
+      trustedBaselineReason =
+        error instanceof Error ? error.message : "baseline_invalid";
+    }
+  }
   const limit = positiveInteger(concurrency, DEFAULT_CONCURRENCY);
-  const results = { uploaded: 0, reused: 0 };
+  const results = { uploaded: 0, reused: 0, trusted_reused: 0 };
   let completed = 0;
   await runPool(plan.objects, limit, async (object) => {
-    const disposition = await putAndVerify(store, object);
+    const disposition = trustedKeys.has(object.key)
+      ? "trusted_reused"
+      : await putAndVerify(store, object);
     results[disposition] += 1;
     completed += 1;
     onProgress({
@@ -328,6 +396,8 @@ export async function uploadContentAddressedArtifact({
   });
   return {
     ...results,
+    incremental_reuse_enabled: incrementalReuseEnabled,
+    trusted_baseline_status: trustedBaselineReason,
     unique_asset_objects: plan.objects.length,
     inventory_object_key: artifactObjectKey,
     inventory_sha256: plan.manifestSha256,
@@ -347,11 +417,28 @@ if (isMain) {
     endpoint: process.env.R2_ENDPOINT,
     aws: process.env.AWS_CLI || "aws",
   });
+  const incrementalReuseEnabled =
+    process.env.R2_INCREMENTAL_REUSE_ENABLED === "true";
+  let trustedBaseline = null;
+  if (
+    incrementalReuseEnabled &&
+    process.env.R2_TRUSTED_BASE_DESCRIPTOR_PATH &&
+    process.env.R2_TRUSTED_BASE_MANIFEST_PATH
+  ) {
+    trustedBaseline = {
+      descriptor: JSON.parse(
+        await readFile(process.env.R2_TRUSTED_BASE_DESCRIPTOR_PATH, "utf8"),
+      ),
+      manifestBytes: await readFile(process.env.R2_TRUSTED_BASE_MANIFEST_PATH),
+    };
+  }
   const result = await uploadContentAddressedArtifact({
     manifestPath,
     distRoot,
     artifactObjectKey: process.env.ARTIFACT_OBJECT_KEY,
     expectedManifestSha256: process.env.ARTIFACT_SHA256,
+    incrementalReuseEnabled,
+    trustedBaseline,
     concurrency: process.env.R2_UPLOAD_CONCURRENCY || DEFAULT_CONCURRENCY,
     store,
     onProgress: ({ completed, total, disposition }) => {

--- a/src/daily/scheduleContract.js
+++ b/src/daily/scheduleContract.js
@@ -1,0 +1,159 @@
+const HOUR_MS = 60 * 60 * 1000;
+const DAY_MS = 24 * HOUR_MS;
+const TERMINAL_GRACE_MS = 10 * 60 * 1000;
+
+export const SCHEDULE_UTC_HOURS = Object.freeze([
+    0, 2, 4, 6, 8, 10, 12, 14, 16, 17, 18, 19, 20, 21, 22, 23,
+]);
+export const SCHEDULE_HEALTH_PAGE_SIZE = 16;
+
+const SCHEDULE_UTC_HOUR_SET = new Set(SCHEDULE_UTC_HOURS);
+const DATE = /^\d{4}-\d{2}-\d{2}$/;
+
+function beijingParts(date) {
+    return Object.fromEntries(new Intl.DateTimeFormat('en-CA', {
+        timeZone: 'Asia/Shanghai',
+        year: 'numeric',
+        month: '2-digit',
+        day: '2-digit',
+        hour: '2-digit',
+        minute: '2-digit',
+        hour12: false,
+    }).formatToParts(date).map(part => [part.type, part.value]));
+}
+
+function beijingDate(date) {
+    const parts = beijingParts(date);
+    return `${parts.year}-${parts.month}-${parts.day}`;
+}
+
+function addReportDays(reportDate, days) {
+    const date = new Date(`${reportDate}T00:00:00+08:00`);
+    if (Number.isNaN(date.getTime())) throw new Error('Invalid report date');
+    date.setUTCDate(date.getUTCDate() + days);
+    return beijingDate(date);
+}
+
+function normalizeScheduledInstant(value) {
+    const parsed = new Date(value);
+    if (Number.isNaN(parsed.getTime())) throw new Error('Invalid scheduled instant');
+    parsed.setUTCSeconds(0, 0);
+    if (
+        parsed.getUTCMinutes() !== 0 ||
+        !SCHEDULE_UTC_HOUR_SET.has(parsed.getUTCHours())
+    ) {
+        throw new Error('Instant is not in the production schedule');
+    }
+    return parsed;
+}
+
+function batchForBeijingHour(hour) {
+    if (hour >= 2 && hour < 5) return 'lateNight';
+    if (hour >= 22 || hour < 2) return 'night';
+    if (hour >= 14 && hour < 22) return 'afternoon';
+    return 'morning';
+}
+
+export function scheduledRunId(value) {
+    const scheduled = normalizeScheduledInstant(value);
+    return `scheduled:${scheduled.getTime()}`;
+}
+
+export function resolveScheduledRun(value) {
+    const scheduled = normalizeScheduledInstant(value);
+    const local = beijingParts(scheduled);
+    const localHour = Number(local.hour);
+    const batchId = batchForBeijingHour(localHour);
+    const localDate = `${local.year}-${local.month}-${local.day}`;
+    const reportDate =
+        batchId === 'lateNight' ? addReportDays(localDate, -1) : localDate;
+    const scheduledAt = scheduled.toISOString();
+    return {
+        batch_id: batchId,
+        deadline: new Date(scheduled.getTime() + TERMINAL_GRACE_MS).toISOString(),
+        publication_batch_id:
+            batchId === 'lateNight' && localHour === 3
+                ? 'lateNightSupplement'
+                : batchId,
+        report_date: reportDate,
+        run_id: `scheduled:${scheduled.getTime()}`,
+        scheduled_at: scheduledAt,
+    };
+}
+
+export function scheduledRunsBetween(start, end) {
+    const startMs = new Date(start).getTime();
+    const endMs = new Date(end).getTime();
+    if (!Number.isFinite(startMs) || !Number.isFinite(endMs) || endMs < startMs) {
+        throw new Error('Invalid schedule range');
+    }
+    const firstDay = new Date(startMs);
+    firstDay.setUTCHours(0, 0, 0, 0);
+    const runs = [];
+    for (
+        let day = firstDay.getTime();
+        day <= endMs;
+        day += DAY_MS
+    ) {
+        for (const hour of SCHEDULE_UTC_HOURS) {
+            const scheduledAt = day + hour * HOUR_MS;
+            if (scheduledAt < startMs || scheduledAt > endMs) continue;
+            runs.push(resolveScheduledRun(scheduledAt));
+        }
+    }
+    return runs;
+}
+
+export function dueScheduledRuns(
+    now = Date.now(),
+    lookbackHours = 30,
+    terminalGraceMs = TERMINAL_GRACE_MS,
+) {
+    if (
+        !Number.isFinite(now) ||
+        !Number.isFinite(lookbackHours) ||
+        lookbackHours <= 0 ||
+        !Number.isFinite(terminalGraceMs) ||
+        terminalGraceMs < 0
+    ) {
+        throw new Error('Invalid due schedule range');
+    }
+    const start = now - lookbackHours * HOUR_MS;
+    return scheduledRunsBetween(start, now).filter(
+        run => Date.parse(run.scheduled_at) + terminalGraceMs <= now,
+    );
+}
+
+export function scheduledRunsForReportDate(reportDate) {
+    if (!DATE.test(String(reportDate || ''))) {
+        throw new Error('Invalid report date');
+    }
+    const start = Date.parse(`${reportDate}T00:00:00+08:00`) - 4 * HOUR_MS;
+    const end = start + 36 * HOUR_MS;
+    const runs = scheduledRunsBetween(start, end).filter(
+        run => run.report_date === reportDate,
+    );
+    if (runs.length !== SCHEDULE_UTC_HOURS.length) {
+        throw new Error('Report date does not resolve to sixteen scheduled runs');
+    }
+    return runs;
+}
+
+export function chunkScheduledRuns(
+    runs,
+    pageSize = SCHEDULE_HEALTH_PAGE_SIZE,
+) {
+    if (
+        !Array.isArray(runs) ||
+        !Number.isSafeInteger(pageSize) ||
+        pageSize < 1 ||
+        pageSize > SCHEDULE_HEALTH_PAGE_SIZE
+    ) {
+        throw new Error('Invalid schedule health page');
+    }
+    const pages = [];
+    for (let index = 0; index < runs.length; index += pageSize) {
+        pages.push(runs.slice(index, index + pageSize));
+    }
+    return pages;
+}

--- a/src/daily/structuredWorkflow.js
+++ b/src/daily/structuredWorkflow.js
@@ -45,9 +45,10 @@ export class StructuredRunLockedError extends Error {
 }
 
 export class StructuredSourceFetchError extends Error {
-    constructor(sourceErrors) {
+    constructor(sourceErrors, sourceCounts = {}) {
         super(`Structured source fetch failed for ${sourceErrors.length} provider(s)`);
         this.name = 'StructuredSourceFetchError';
+        this.sourceCounts = sourceCounts;
         this.sourceErrors = sourceErrors.map((error) => ({
             provider: error.provider,
             content_type: error.content_type,
@@ -56,6 +57,60 @@ export class StructuredSourceFetchError extends Error {
             attempts: Number.isInteger(error.attempts) ? error.attempts : 1,
         }));
     }
+}
+
+async function sha256Text(value) {
+    if (typeof value !== 'string') return null;
+    const bytes = new TextEncoder().encode(value);
+    const digest = new Uint8Array(await crypto.subtle.digest('SHA-256', bytes));
+    return Array.from(digest, byte => byte.toString(16).padStart(2, '0')).join('');
+}
+
+function safeSourceCounts(value) {
+    const counts = {};
+    for (const key of ['news', 'project', 'paper', 'socialMedia']) {
+        const count = Number(value?.[key] || 0);
+        counts[key] = Number.isSafeInteger(count) && count >= 0 ? count : 0;
+    }
+    return counts;
+}
+
+async function attachScheduledRunEvidence(response, {
+    databaseMirror,
+    fetched,
+    result,
+    runAt,
+    sourceCompletedAt,
+    triggerId,
+}) {
+    const contentSha256 =
+        databaseMirror?.contentSha256 || await sha256Text(result?.json);
+    const mirrorStatus = String(databaseMirror?.status || 'disabled');
+    return {
+        ...response,
+        run_id: /^scheduled:\d{13}$/.test(String(triggerId || ''))
+            ? triggerId
+            : null,
+        scheduled_at: runAt,
+        source_result: {
+            status: 'succeeded',
+            completed_at: sourceCompletedAt,
+            counts: safeSourceCounts(fetched?.sourceCounts),
+        },
+        content_sha256: contentSha256,
+        no_op: result?.noOp === true,
+        site_release_id: databaseMirror?.siteReleaseId || null,
+        site_release_sequence: Number.isSafeInteger(databaseMirror?.siteReleaseSequence)
+            ? databaseMirror.siteReleaseSequence
+            : null,
+        dispatch_id: databaseMirror?.dispatchId || null,
+        stage: mirrorStatus === 'failed'
+            ? 'database_mirror_failed'
+            : mirrorStatus === 'mirrored'
+                ? 'release_registered'
+                : 'content_published',
+        stable_verified_at: null,
+    };
 }
 
 function parseReport(text, path) {
@@ -344,8 +399,12 @@ export async function runStructuredDailyWorkflow(
         const foloCookie = await deps.getFoloCookie(env);
         const fetchPageCap = scheduledFetchPageCap(env, batch, runAt);
         const fetched = await deps.fetchData(env, foloCookie, { fetchPageCap });
+        const sourceCompletedAt = new Date().toISOString();
         if (fetched.errors.length > 0) {
-            throw new StructuredSourceFetchError(fetched.errors);
+            throw new StructuredSourceFetchError(
+                fetched.errors,
+                safeSourceCounts(fetched.sourceCounts),
+            );
         }
 
         const editorialCache = new Map();
@@ -450,7 +509,7 @@ export async function runStructuredDailyWorkflow(
                         triggerId,
                         deps.mirror,
                     );
-                    const response = {
+                    const response = await attachScheduledRunEvidence({
                         success: true,
                         mode: 'structured',
                         reportDate,
@@ -468,7 +527,14 @@ export async function runStructuredDailyWorkflow(
                             : {}),
                         metrics: result.metrics,
                         database_mirror: databaseMirror,
-                    };
+                    }, {
+                        databaseMirror,
+                        fetched,
+                        result,
+                        runAt,
+                        sourceCompletedAt,
+                        triggerId,
+                    });
                     await storeConfirmedMarker(
                         env,
                         triggerId,
@@ -497,7 +563,15 @@ export async function runStructuredDailyWorkflow(
                     },
                     { api: deps.api },
                 );
-                const response = {
+                const databaseMirror = await mirrorWithoutBlocking(
+                    env,
+                    result,
+                    published.commitSha,
+                    batch,
+                    triggerId,
+                    deps.mirror,
+                );
+                const response = await attachScheduledRunEvidence({
                     success: true,
                     mode: 'structured',
                     reportDate,
@@ -512,15 +586,15 @@ export async function runStructuredDailyWorkflow(
                     ...(published.pullRequest ? { pull_request: published.pullRequest } : {}),
                     ...(published.lockRelease ? { lock_release: published.lockRelease } : {}),
                     metrics: result.metrics,
-                    database_mirror: await mirrorWithoutBlocking(
-                        env,
-                        result,
-                        published.commitSha,
-                        batch,
-                        triggerId,
-                        deps.mirror,
-                    ),
-                };
+                    database_mirror: databaseMirror,
+                }, {
+                    databaseMirror,
+                    fetched,
+                    result,
+                    runAt,
+                    sourceCompletedAt,
+                    triggerId,
+                });
                 await storeConfirmedMarker(
                     env,
                     triggerId,

--- a/src/handlers/incrementalDailyWorkflow.js
+++ b/src/handlers/incrementalDailyWorkflow.js
@@ -20,6 +20,7 @@ import {
 } from '../daily/structuredWorkflow.js';
 import { runStructuredShadow } from '../daily/shadowWorkflow.js';
 import { fetchProviderPreservingData } from '../daily/structuredFetch.js';
+import { resolveScheduledRun } from '../daily/scheduleContract.js';
 import {
     getSystemPromptArticleEvaluation,
     getSystemPromptBatchSection,
@@ -56,6 +57,19 @@ function getBeijingDateString(date = new Date()) {
 
 function resolveBatch(date = new Date(), forcedBatch = null, forcedDate = null) {
     if (forcedBatch && forcedDate) return { reportDate: forcedDate, batch: forcedBatch };
+
+    if (!forcedBatch) {
+        try {
+            const scheduled = resolveScheduledRun(date);
+            return {
+                reportDate: scheduled.report_date,
+                batch: scheduled.batch_id,
+            };
+        } catch {
+            // Manual runs outside the production schedule keep the legacy
+            // clock-based mapping below.
+        }
+    }
 
     const p = getBeijingParts(date);
     const hour = Number(p.hour);

--- a/src/index.js
+++ b/src/index.js
@@ -13,8 +13,10 @@ import { debugFoloCookie, storeFoloCookieToKV } from './folo.js';
 import { handleAdminRoute, isAdminRoute } from './routes/adminRoutes.js';
 import { logMissingConfig } from './logging.js';
 import { storeFailureMarker, storeScheduledOutcome } from './daily/runState.js';
+import { resolveScheduledRun } from './daily/scheduleContract.js';
 import { SOURCE_REGISTRY } from './daily/sourceRegistry.js';
 import { handleScheduledHealth } from './routes/scheduledHealth.js';
+import { recordScheduledRunTrace } from '../workers/content/ingestion/mirror.ts';
 
 const SAFE_PROVIDER_NAMES = new Set(Object.keys(SOURCE_REGISTRY));
 const SAFE_CONTENT_TYPES = new Set(['news', 'project', 'paper', 'socialMedia']);
@@ -113,7 +115,56 @@ function appendSessionCookie(response, cookie) {
     });
 }
 
-function scheduledFailureMarker(error, runAt) {
+function safeSourceCounts(value) {
+    const counts = {};
+    for (const contentType of SAFE_CONTENT_TYPES) {
+        const count = Number(value?.[contentType] || 0);
+        counts[contentType] = Number.isSafeInteger(count) && count >= 0 ? count : 0;
+    }
+    return counts;
+}
+
+function scheduledSuccessMarker(result, scheduled, startedAt, finishedAt) {
+    const sourceResult = result?.source_result;
+    const mirror = result?.database_mirror;
+    return {
+        success: true,
+        status: 'succeeded',
+        stage: String(result?.stage || 'workflow_completed'),
+        trigger_type: 'scheduled',
+        run_id: scheduled.run_id,
+        run_at: scheduled.scheduled_at,
+        started_at: startedAt,
+        finished_at: finishedAt,
+        source_result: {
+            status: sourceResult?.status === 'succeeded' ? 'succeeded' : 'unknown',
+            completed_at: sourceResult?.completed_at || null,
+            counts: safeSourceCounts(sourceResult?.counts),
+        },
+        content_sha256: /^[a-f0-9]{64}$/.test(String(result?.content_sha256 || ''))
+            ? result.content_sha256
+            : null,
+        no_op: result?.no_op === true || result?.noOp === true,
+        database_mirror: {
+            status: ['mirrored', 'disabled', 'failed'].includes(mirror?.status)
+                ? mirror.status
+                : 'unknown',
+        },
+        site_release_id: /^[0-9a-f-]{36}$/i.test(String(result?.site_release_id || ''))
+            ? result.site_release_id
+            : null,
+        site_release_sequence: Number.isSafeInteger(result?.site_release_sequence)
+            ? result.site_release_sequence
+            : null,
+        dispatch_id: /^[0-9a-f-]{36}$/i.test(String(result?.dispatch_id || ''))
+            ? result.dispatch_id
+            : null,
+        stable_verified_at: result?.stable_verified_at || null,
+    };
+}
+
+function scheduledFailureMarker(error, scheduled, startedAt) {
+    const runAt = scheduled.scheduled_at;
     const subrequestBudgetExceeded = /too many subrequests|subrequest(?:s)? limit/i.test(
         String(error?.message || ''),
     );
@@ -138,15 +189,27 @@ function scheduledFailureMarker(error, runAt) {
                 : 1,
         }))
         : [];
+    const evidence = error?.runEvidence || {};
+    const sourceCounts = safeSourceCounts(
+        error?.sourceCounts || evidence?.source_result?.counts,
+    );
     return {
         success: false,
         status: 'failed',
+        stage: error?.name === 'ScheduledDatabaseMirrorError'
+            ? 'database_mirror_failed'
+            : 'failed',
         trigger_type: 'scheduled',
+        run_id: scheduled.run_id,
         run_at: runAt,
+        started_at: startedAt,
+        finished_at: new Date().toISOString(),
         error_type: subrequestBudgetExceeded
             ? 'subrequest_budget_exceeded'
             : error?.name === 'StructuredSourceFetchError'
                 ? 'structured_source_fetch_failed'
+                : error?.name === 'ScheduledDatabaseMirrorError'
+                    ? 'database_mirror_failed'
                 : 'scheduled_workflow_failed',
         failure_stage: SAFE_WORKFLOW_FAILURE_STAGES.has(error?.failureStage)
             ? error.failureStage
@@ -155,6 +218,20 @@ function scheduledFailureMarker(error, runAt) {
                 : error?.name === 'AtomicGitConflictError' || error?.name === 'AtomicGitUncertainError'
                     ? 'git_publish'
                     : 'unknown',
+        source_result: {
+            status: 'failed',
+            completed_at: evidence?.source_result?.completed_at || null,
+            counts: sourceCounts,
+            error_count: sourceErrors.length,
+        },
+        content_sha256: /^[a-f0-9]{64}$/.test(String(evidence?.content_sha256 || ''))
+            ? evidence.content_sha256
+            : null,
+        no_op: evidence?.no_op === true,
+        site_release_id: evidence?.site_release_id || null,
+        site_release_sequence: evidence?.site_release_sequence || null,
+        dispatch_id: evidence?.dispatch_id || null,
+        stable_verified_at: null,
         ...(sourceErrors.length > 0 ? { source_errors: sourceErrors } : {}),
     };
 }
@@ -181,9 +258,32 @@ async function recordScheduledOutcome(env, scheduledAt, marker) {
     }
 }
 
+async function recordScheduledDatabaseTrace(
+    env,
+    scheduledAt,
+    eventType,
+    marker,
+    recorder,
+) {
+    try {
+        await recorder(env, {
+            runId: marker.run_id,
+            scheduledAt,
+            eventType,
+            evidence: marker,
+        });
+    } catch (traceError) {
+        console.warn('[Scheduled] database trace write failed', {
+            errorType: traceError?.name || 'Error',
+            eventType,
+        });
+    }
+}
+
 export function createWorker({
     adminHandlers = defaultAdminHandlers,
     scheduledWorkflow = runIncrementalDailyWorkflow,
+    scheduledTrace = recordScheduledRunTrace,
 } = {}) {
     return {
         async fetch(request, env) {
@@ -269,19 +369,64 @@ export function createWorker({
                 console.warn('[Scheduled] external writes are disabled; workflow skipped');
                 return;
             }
-            const triggerId = `scheduled:${event.scheduledTime}`;
-            const runAt = new Date(event.scheduledTime).toISOString();
+            const scheduled = resolveScheduledRun(event.scheduledTime);
+            const triggerId = scheduled.run_id;
+            const runAt = scheduled.scheduled_at;
+            const startedAt = new Date().toISOString();
             const workflow = Promise.resolve()
+                .then(async () => {
+                    const started = {
+                        success: null,
+                        status: 'started',
+                        stage: 'started',
+                        trigger_type: 'scheduled',
+                        run_id: triggerId,
+                        run_at: runAt,
+                        started_at: startedAt,
+                        finished_at: null,
+                        stable_verified_at: null,
+                    };
+                    await Promise.all([
+                        recordScheduledOutcome(env, runAt, started),
+                        recordScheduledDatabaseTrace(
+                            env,
+                            runAt,
+                            'started',
+                            started,
+                            scheduledTrace,
+                        ),
+                    ]);
+                })
                 .then(() => scheduledWorkflow(env, { triggerId, runAt }))
                 .then(async result => {
-                    await recordScheduledOutcome(env, runAt, {
-                        status: 'succeeded',
-                        run_at: runAt,
-                    });
+                    const terminal = scheduledSuccessMarker(
+                        result,
+                        scheduled,
+                        startedAt,
+                        new Date().toISOString(),
+                    );
+                    if (
+                        String(env.CONTENT_DATABASE_MIRROR_ENABLED).toLowerCase() === 'true' &&
+                        terminal.database_mirror.status !== 'mirrored'
+                    ) {
+                        const error = new Error('Scheduled database mirror did not complete');
+                        error.name = 'ScheduledDatabaseMirrorError';
+                        error.failureStage = 'database_mirror';
+                        error.runEvidence = terminal;
+                        throw error;
+                    }
+                    await recordScheduledDatabaseTrace(
+                        env,
+                        runAt,
+                        'succeeded',
+                        terminal,
+                        scheduledTrace,
+                    );
+                    await recordScheduledOutcome(env, runAt, terminal);
                     return result;
                 })
                 .catch(async error => {
-                    const marker = scheduledFailureMarker(error, runAt);
+                    const marker = scheduledFailureMarker(error, scheduled, startedAt);
                     console.error('[Scheduled] workflow failed', {
                         errorType: marker.error_type,
                         failureStage: marker.failure_stage,
@@ -295,6 +440,13 @@ export function createWorker({
                             }))
                             : [],
                     });
+                    await recordScheduledDatabaseTrace(
+                        env,
+                        runAt,
+                        'failed',
+                        marker,
+                        scheduledTrace,
+                    );
                     await recordScheduledFailure(env, triggerId, marker);
                     await recordScheduledOutcome(env, runAt, marker);
                     throw error;

--- a/src/routes/scheduledHealth.js
+++ b/src/routes/scheduledHealth.js
@@ -1,6 +1,5 @@
 import { readScheduledOutcome } from '../daily/runState.js';
-
-const MAX_SLOTS = 16;
+import { SCHEDULE_HEALTH_PAGE_SIZE } from '../daily/scheduleContract.js';
 
 async function tokenDigest(value) {
     return new Uint8Array(await crypto.subtle.digest(
@@ -38,6 +37,61 @@ function validScheduledInstant(value) {
     return !Number.isNaN(parsed.getTime()) && parsed.toISOString() === value;
 }
 
+function publicSourceResult(value) {
+    const counts = {};
+    for (const contentType of ['news', 'project', 'paper', 'socialMedia']) {
+        const count = Number(value?.counts?.[contentType] || 0);
+        counts[contentType] = Number.isSafeInteger(count) && count >= 0 ? count : 0;
+    }
+    return {
+        status: ['succeeded', 'failed', 'unknown'].includes(value?.status)
+            ? value.status
+            : 'unknown',
+        completed_at: value?.completed_at || null,
+        counts,
+        ...(Number.isSafeInteger(value?.error_count)
+            ? { error_count: value.error_count }
+            : {}),
+    };
+}
+
+function publicScheduledOutcome(marker, scheduledAt) {
+    const status = ['started', 'succeeded', 'failed'].includes(marker?.status)
+        ? marker.status
+        : 'failed';
+    return {
+        scheduled_at: scheduledAt,
+        run_id: /^scheduled:\d{13}$/.test(String(marker?.run_id || ''))
+            ? marker.run_id
+            : `scheduled:${Date.parse(scheduledAt)}`,
+        status,
+        stage: String(marker?.stage || (status === 'succeeded' ? 'workflow_completed' : status)),
+        run_at: marker?.run_at || null,
+        started_at: marker?.started_at || null,
+        finished_at: marker?.finished_at || null,
+        source_result: publicSourceResult(marker?.source_result),
+        content_sha256: /^[a-f0-9]{64}$/.test(String(marker?.content_sha256 || ''))
+            ? marker.content_sha256
+            : null,
+        no_op: marker?.no_op === true,
+        database_mirror: {
+            status: ['mirrored', 'disabled', 'failed', 'unknown'].includes(
+                marker?.database_mirror?.status,
+            )
+                ? marker.database_mirror.status
+                : 'unknown',
+        },
+        site_release_id: marker?.site_release_id || null,
+        site_release_sequence: Number.isSafeInteger(marker?.site_release_sequence)
+            ? marker.site_release_sequence
+            : null,
+        dispatch_id: marker?.dispatch_id || null,
+        stable_verified_at: marker?.stable_verified_at || null,
+        error_type: marker?.error_type || null,
+        failure_stage: marker?.failure_stage || null,
+    };
+}
+
 export async function handleScheduledHealth(request, env) {
     if (request.method !== 'GET') {
         return json({ success: false, error: 'Method not allowed' }, 405, { Allow: 'GET' });
@@ -55,7 +109,7 @@ export async function handleScheduledHealth(request, env) {
     const scheduledAt = new URL(request.url).searchParams.getAll('scheduled_at');
     if (
         scheduledAt.length < 1 ||
-        scheduledAt.length > MAX_SLOTS ||
+        scheduledAt.length > SCHEDULE_HEALTH_PAGE_SIZE ||
         new Set(scheduledAt).size !== scheduledAt.length ||
         scheduledAt.some(value => !validScheduledInstant(value))
     ) {
@@ -65,14 +119,26 @@ export async function handleScheduledHealth(request, env) {
     const slots = await Promise.all(scheduledAt.map(async scheduled_at => {
         const marker = await readScheduledOutcome(env.DATA_KV, scheduled_at);
         return marker
-            ? {
+            ? publicScheduledOutcome(marker, scheduled_at)
+            : {
                   scheduled_at,
-                  status: marker.status === 'succeeded' ? 'succeeded' : 'failed',
-                  run_at: marker.run_at || null,
-                  error_type: marker.error_type || null,
-                  failure_stage: marker.failure_stage || null,
-              }
-            : { scheduled_at, status: 'missing', run_at: null, error_type: null, failure_stage: null };
+                  run_id: `scheduled:${Date.parse(scheduled_at)}`,
+                  status: 'missing',
+                  stage: 'missing',
+                  run_at: null,
+                  started_at: null,
+                  finished_at: null,
+                  source_result: publicSourceResult(null),
+                  content_sha256: null,
+                  no_op: false,
+                  database_mirror: { status: 'unknown' },
+                  site_release_id: null,
+                  site_release_sequence: null,
+                  dispatch_id: null,
+                  stable_verified_at: null,
+                  error_type: null,
+                  failure_stage: null,
+              };
     }));
     return json({ success: true, slots });
 }

--- a/supabase/migrations/20260724000200_production_reconcile_fencing.sql
+++ b/supabase/migrations/20260724000200_production_reconcile_fencing.sql
@@ -1,0 +1,275 @@
+begin;
+
+set local role content_rpc_owner;
+
+-- A scheduled reconciler is recovery work, not a peer production writer. It
+-- may only take over an expired operation and must rotate the fencing token
+-- before returning any deployment context. Active publishers and rollbacks
+-- therefore remain invisible to the reconciler.
+create or replace function private.begin_production_reconcile_v1()
+returns jsonb
+language plpgsql
+volatile
+security definer
+set search_path = ''
+as $$
+declare
+  slot private.production_promotion_slot%rowtype;
+  pointer_generation bigint;
+begin
+  perform pg_advisory_xact_lock(42003);
+
+  select * into slot
+  from private.production_promotion_slot
+  where project_key = 'bubble-brain-pages'
+  for update;
+
+  if slot.project_key is null
+    or slot.status = 'committed'
+    or slot.lease_expires_at > clock_timestamp() then
+    return null;
+  end if;
+
+  pointer_generation := coalesce(
+    (select generation
+     from private.release_current_pointer
+     where singleton),
+    0
+  );
+  if pointer_generation <> slot.expected_pointer_generation then
+    raise exception 'Pointer generation conflict during reconcile';
+  end if;
+
+  update private.production_promotion_slot
+  set
+    fencing_token = fencing_token + 1,
+    locked_by = 'reconciler:' || (fencing_token + 1)::text,
+    status = case
+      when operation = 'forward' then 'verifying'
+      else 'rolling_back'
+    end,
+    lease_expires_at = clock_timestamp() + interval '10 minutes',
+    updated_at = clock_timestamp()
+  where project_key = 'bubble-brain-pages';
+
+  return private.get_promotion_reconcile_context_v1();
+end;
+$$;
+
+-- Finishing recovery is a state mutation and must be held to the same lease,
+-- pointer and evidence checks as the production commit RPCs. A stale recovery
+-- may have observed an old pointer, but it cannot mark itself successful.
+create or replace function private.finish_production_recovery_v1(
+  site_release_id uuid,
+  fencing_token bigint,
+  expected_pointer_generation bigint,
+  recovery_succeeded boolean,
+  evidence jsonb
+)
+returns void
+language plpgsql
+volatile
+security definer
+set search_path = ''
+as $$
+begin
+  perform pg_advisory_xact_lock(42003);
+
+  if coalesce(
+    (select generation
+     from private.release_current_pointer
+     where singleton),
+    0
+  ) <> expected_pointer_generation then
+    raise exception 'Pointer generation conflict during recovery';
+  end if;
+
+  if recovery_succeeded
+    and coalesce((evidence ->> 'production_unchanged')::boolean, false) is not true
+    and coalesce((evidence ->> 'multi_edge_verified')::boolean, false) is not true then
+    raise exception 'Recovery verifier evidence is required';
+  end if;
+
+  update private.production_promotion_slot
+  set
+    status = case
+      when recovery_succeeded then 'committed'
+      else 'rolling_back_failed'
+    end,
+    updated_at = clock_timestamp()
+  where project_key = 'bubble-brain-pages'
+    and private.production_promotion_slot.site_release_id =
+      finish_production_recovery_v1.site_release_id
+    and private.production_promotion_slot.fencing_token =
+      finish_production_recovery_v1.fencing_token
+    and private.production_promotion_slot.expected_pointer_generation =
+      finish_production_recovery_v1.expected_pointer_generation
+    and lease_expires_at > clock_timestamp()
+    and status in (
+      'deploying', 'verifying', 'reconciling',
+      'rolling_back', 'rolling_back_failed'
+    );
+
+  if not found then
+    raise exception 'Stale recovery fencing token';
+  end if;
+
+  insert into private.release_deployment_attempts(
+    site_release_id,
+    event_type,
+    evidence
+  )
+  values (
+    site_release_id,
+    case
+      when recovery_succeeded then 'rollback_deployed'
+      else 'failed'
+    end,
+    evidence
+  );
+end;
+$$;
+
+create or replace function private.get_current_pages_deployment_v1(
+  target_site_release_id uuid
+)
+returns jsonb
+language plpgsql
+stable
+security definer
+set search_path = ''
+as $$
+declare
+  pointer private.release_current_pointer%rowtype;
+begin
+  select * into pointer
+  from private.release_current_pointer
+  where singleton;
+
+  if pointer.target_site_release_id is distinct from target_site_release_id
+    or nullif(btrim(pointer.pages_deployment_id), '') is null then
+    raise exception 'Requested release is not the current production pointer';
+  end if;
+
+  return jsonb_build_object(
+    'site_release_id', pointer.target_site_release_id,
+    'site_release_sequence', pointer.target_release_sequence,
+    'pointer_generation', pointer.generation,
+    'pages_deployment_id', pointer.pages_deployment_id,
+    'manifest_sha256', pointer.manifest_sha256,
+    'artifact_sha256', pointer.artifact_sha256
+  );
+end;
+$$;
+
+create or replace function private.record_current_pages_repair_v1(
+  target_site_release_id uuid,
+  expected_pointer_generation bigint,
+  pages_deployment_id text,
+  verifier_evidence jsonb
+)
+returns jsonb
+language plpgsql
+volatile
+security definer
+set search_path = ''
+as $$
+begin
+  perform pg_advisory_xact_lock(42003);
+
+  if pages_deployment_id is null
+    or pages_deployment_id !~
+      '^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89aAbB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$' then
+    raise exception 'Invalid Pages repair deployment identity';
+  end if;
+
+  if coalesce((verifier_evidence ->> 'multi_edge_verified')::boolean, false)
+    is not true then
+    raise exception 'Multi-edge repair evidence is required';
+  end if;
+  if verifier_evidence ->> 'site_release_id'
+    is distinct from target_site_release_id::text then
+    raise exception 'Pages repair evidence release mismatch';
+  end if;
+
+  if exists (
+    select 1
+    from private.production_promotion_slot slot
+    where slot.project_key = 'bubble-brain-pages'
+      and slot.status <> 'committed'
+      and slot.lease_expires_at > clock_timestamp()
+  ) then
+    raise exception 'Production promotion slot is busy during Pages repair';
+  end if;
+
+  -- A same-release repair is a new physical production generation. Any
+  -- expired operation against the previous generation is superseded before
+  -- the pointer advances so future reconcilers cannot revive it.
+  update private.production_promotion_slot
+  set
+    status = 'committed',
+    updated_at = clock_timestamp()
+  where project_key = 'bubble-brain-pages'
+    and status <> 'committed'
+    and lease_expires_at <= clock_timestamp();
+
+  if not exists (
+    select 1
+    from private.release_current_pointer pointer
+    where pointer.singleton
+      and pointer.target_site_release_id =
+        record_current_pages_repair_v1.target_site_release_id
+      and pointer.generation =
+        record_current_pages_repair_v1.expected_pointer_generation
+  ) then
+    raise exception 'Current pointer changed during Pages repair';
+  end if;
+
+  update private.release_current_pointer
+  set
+    pages_deployment_id = record_current_pages_repair_v1.pages_deployment_id,
+    generation = expected_pointer_generation + 1,
+    updated_at = clock_timestamp()
+  where singleton;
+
+  insert into private.release_deployment_attempts(
+    site_release_id,
+    event_type,
+    evidence
+  )
+  values (
+    target_site_release_id,
+    'production_deployed',
+    verifier_evidence || jsonb_build_object(
+      'repair_current', true,
+      'pages_deployment_id', pages_deployment_id
+    )
+  );
+
+  return jsonb_build_object(
+    'site_release_id', target_site_release_id,
+    'generation', expected_pointer_generation + 1,
+    'pages_deployment_id', pages_deployment_id
+  );
+end;
+$$;
+
+revoke all on function private.get_current_pages_deployment_v1(uuid)
+  from public, anon, authenticated, service_role,
+       content_backup, content_editor, content_controller,
+       content_reader, content_ingestor;
+grant execute on function private.get_current_pages_deployment_v1(uuid)
+  to content_deployer;
+
+revoke all on function private.record_current_pages_repair_v1(
+  uuid, bigint, text, jsonb
+)
+  from public, anon, authenticated, service_role,
+       content_backup, content_editor, content_controller,
+       content_reader, content_ingestor;
+grant execute on function private.record_current_pages_repair_v1(
+  uuid, bigint, text, jsonb
+)
+  to content_deployer;
+
+commit;

--- a/supabase/migrations/20260724000300_release_attempt_checkpoints.sql
+++ b/supabase/migrations/20260724000300_release_attempt_checkpoints.sql
@@ -1,0 +1,693 @@
+begin;
+
+alter table private.content_outbox
+  add column if not exists attempt_token uuid;
+alter table private.content_outbox
+  add column if not exists execution_generation bigint not null default 0
+  check (execution_generation >= 0);
+create unique index if not exists content_outbox_attempt_token_idx
+  on private.content_outbox (attempt_token)
+  where attempt_token is not null;
+
+alter table private.release_artifacts
+  add column if not exists verification_profile text;
+alter table private.release_artifacts
+  add column if not exists r2_verified_at timestamptz;
+alter table private.release_artifacts
+  add column if not exists lock_evidence_sha256 text
+  check (lock_evidence_sha256 ~ '^[a-f0-9]{64}$');
+
+alter table private.release_deployment_attempts
+  drop constraint if exists release_deployment_attempts_event_type_check;
+alter table private.release_deployment_attempts
+  add constraint release_deployment_attempts_event_type_check
+  check (event_type in (
+    'queued', 'building', 'artifact_registered', 'preview_verified',
+    'preview_failed', 'production_deployed', 'edge_verified',
+    'rollback_authorized', 'rollback_deployed', 'rollback_committed',
+    'failed', 'heartbeat', 'stale_callback_ignored'
+  ));
+
+create table if not exists private.release_deployment_checkpoints (
+  site_release_id uuid not null references private.site_releases(id),
+  stage text not null check (stage in ('artifact_registered', 'preview_verified')),
+  dispatch_id uuid not null,
+  originating_attempt_token uuid not null,
+  originating_execution_generation bigint not null
+    check (originating_execution_generation > 0),
+  artifact_sha256 text not null check (artifact_sha256 ~ '^[a-f0-9]{64}$'),
+  content_sha256 text check (content_sha256 ~ '^[a-f0-9]{64}$'),
+  code_sha text check (code_sha ~ '^[a-f0-9]{40}$'),
+  evidence jsonb not null check (jsonb_typeof(evidence) = 'object'),
+  completed_at timestamptz not null default clock_timestamp(),
+  check (
+    stage <> 'preview_verified'
+    or nullif(evidence ->> 'preview_url', '') is not null
+  ),
+  primary key (site_release_id, stage)
+);
+
+alter table private.release_deployment_checkpoints enable row level security;
+alter table private.release_deployment_checkpoints force row level security;
+drop policy if exists content_rpc_owner_all
+  on private.release_deployment_checkpoints;
+create policy content_rpc_owner_all
+  on private.release_deployment_checkpoints
+  for all to content_rpc_owner
+  using (true) with check (true);
+revoke all on table private.release_deployment_checkpoints
+  from public, anon, authenticated, service_role, content_ingestor,
+       content_editor, content_controller, content_reader, content_deployer;
+grant select, insert, update on private.release_deployment_checkpoints
+  to content_rpc_owner;
+grant select on private.release_deployment_checkpoints to content_backup;
+
+set local role content_rpc_owner;
+
+create or replace function private.claim_content_outbox_v1(
+  worker_id text,
+  lease_seconds integer default 1800
+)
+returns jsonb
+language plpgsql
+volatile
+security definer
+set search_path = ''
+as $$
+declare
+  claimed private.content_outbox%rowtype;
+  next_token uuid := gen_random_uuid();
+begin
+  update private.content_outbox
+  set status = 'dead_letter',
+      lease_expires_at = null,
+      attempt_token = null,
+      dead_lettered_at = coalesce(dead_lettered_at, clock_timestamp()),
+      last_error = coalesce(last_error, 'lease expired after maximum attempts'),
+      updated_at = clock_timestamp()
+  where attempts >= max_attempts
+    and status in ('queued', 'failed', 'claimed', 'dispatched', 'building', 'promoting')
+    and (lease_expires_at is null or lease_expires_at <= clock_timestamp());
+
+  update private.content_outbox value
+  set status = 'claimed',
+      locked_by = worker_id,
+      locked_at = clock_timestamp(),
+      lease_expires_at = clock_timestamp()
+        + make_interval(secs => least(greatest(lease_seconds, 300), 3600)),
+      attempts = attempts + 1,
+      attempt_token = next_token,
+      execution_generation = execution_generation + 1,
+      updated_at = clock_timestamp()
+  where value.id = (
+    select id
+    from private.content_outbox
+    where (
+        status in ('queued', 'failed', 'claimed', 'dispatched', 'building', 'promoting')
+        or (status = 'preview_verified' and payload ->> 'mode' = 'production')
+      )
+      and next_attempt_at <= clock_timestamp()
+      and (lease_expires_at is null or lease_expires_at <= clock_timestamp())
+      and attempts < max_attempts
+    order by inserted_at
+    for update skip locked
+    limit 1
+  )
+  returning * into claimed;
+
+  if not found then return null; end if;
+  return jsonb_build_object(
+    'outbox_id', claimed.id,
+    'site_release_id', claimed.site_release_id,
+    'dispatch_id', claimed.dispatch_id,
+    'payload', claimed.payload,
+    'lease_expires_at', claimed.lease_expires_at,
+    'attempt', claimed.attempts,
+    'attempt_token', claimed.attempt_token,
+    'execution_generation', claimed.execution_generation
+  );
+end;
+$$;
+
+create or replace function private.get_content_release_resume_plan_v1(
+  p_site_release_id uuid,
+  p_dispatch_id uuid,
+  p_attempt_token uuid
+)
+returns jsonb
+language plpgsql
+stable
+security definer
+set search_path = ''
+as $$
+declare
+  outbox private.content_outbox%rowtype;
+  release private.site_releases%rowtype;
+  artifact private.release_artifacts%rowtype;
+  predecessor private.release_artifacts%rowtype;
+  resume_stage text;
+begin
+  select * into outbox
+  from private.content_outbox value
+  where value.site_release_id = p_site_release_id
+    and value.dispatch_id = p_dispatch_id
+    and value.attempt_token = p_attempt_token
+    and value.lease_expires_at > clock_timestamp();
+  if not found then raise exception 'Stale deployment attempt token'; end if;
+
+  select * into release from private.site_releases where id = p_site_release_id;
+  select * into artifact from private.release_artifacts
+  where site_release_id = p_site_release_id;
+
+  if exists (
+    select 1
+    from private.release_deployment_checkpoints checkpoint
+    where checkpoint.site_release_id = p_site_release_id
+      and checkpoint.stage = 'preview_verified'
+      and checkpoint.dispatch_id = p_dispatch_id
+      and checkpoint.artifact_sha256 = artifact.artifact_sha256
+      and checkpoint.content_sha256 = release.content_root_sha256
+      and checkpoint.code_sha = artifact.code_sha
+      and checkpoint.evidence ->> 'resume_contract_version'
+        = 'r2-materialize-v1'
+      and exists (
+        select 1
+        from private.release_deployment_checkpoints artifact_checkpoint
+        where artifact_checkpoint.site_release_id = p_site_release_id
+          and artifact_checkpoint.stage = 'artifact_registered'
+          and artifact_checkpoint.dispatch_id = p_dispatch_id
+          and artifact_checkpoint.artifact_sha256 = artifact.artifact_sha256
+          and artifact_checkpoint.content_sha256 = release.content_root_sha256
+          and artifact_checkpoint.code_sha = artifact.code_sha
+          and artifact_checkpoint.evidence ->> 'resume_contract_version'
+            = 'r2-materialize-v1'
+      )
+  ) then
+    resume_stage := 'promote';
+  elsif artifact.site_release_id is not null and exists (
+    select 1
+    from private.release_deployment_checkpoints checkpoint
+    where checkpoint.site_release_id = p_site_release_id
+      and checkpoint.stage = 'artifact_registered'
+      and checkpoint.dispatch_id = p_dispatch_id
+      and checkpoint.artifact_sha256 = artifact.artifact_sha256
+      and checkpoint.content_sha256 = release.content_root_sha256
+      and checkpoint.code_sha = artifact.code_sha
+      and checkpoint.evidence ->> 'resume_contract_version'
+        = 'r2-materialize-v1'
+  ) then
+    resume_stage := 'preview';
+  else
+    resume_stage := 'build';
+  end if;
+
+  if release.expected_predecessor_id is not null then
+    select * into predecessor
+    from private.release_artifacts value
+    where value.site_release_id = release.expected_predecessor_id
+      and value.production_verified_at is not null
+      and value.hash_algorithm = 'sha256-content-addressed-pages-v1'
+      and value.verification_profile = 'r2-full-get-sha256-indefinite-lock-v1'
+      and value.r2_verified_at is not null
+      and value.lock_evidence_sha256 is not null;
+  end if;
+
+  return jsonb_build_object(
+    'resume_stage', resume_stage,
+    'preview_checkpoint', (
+      select jsonb_build_object(
+        'dispatch_id', checkpoint.dispatch_id,
+        'preview_url', checkpoint.evidence ->> 'preview_url',
+        'artifact_sha256', checkpoint.artifact_sha256,
+        'content_sha256', checkpoint.content_sha256,
+        'code_sha', checkpoint.code_sha,
+        'evidence', checkpoint.evidence,
+        'completed_at', checkpoint.completed_at
+      )
+      from private.release_deployment_checkpoints checkpoint
+      where checkpoint.site_release_id = p_site_release_id
+        and checkpoint.stage = 'preview_verified'
+        and checkpoint.dispatch_id = p_dispatch_id
+        and checkpoint.artifact_sha256 = artifact.artifact_sha256
+        and checkpoint.content_sha256 = release.content_root_sha256
+        and checkpoint.code_sha = artifact.code_sha
+        and checkpoint.evidence ->> 'resume_contract_version'
+          = 'r2-materialize-v1'
+    ),
+    'artifact', case when artifact.site_release_id is null then null else
+      jsonb_build_object(
+        'object_key', artifact.object_key,
+        'byte_length', artifact.byte_length,
+        'artifact_sha256', artifact.artifact_sha256,
+        'artifact_fingerprint_sha256', artifact.artifact_fingerprint_sha256,
+        'hash_algorithm', artifact.hash_algorithm,
+        'code_sha', artifact.code_sha,
+        'content_sha256', release.content_root_sha256,
+        'site_release_id', release.id,
+        'site_release_sequence', release.sequence,
+        'expected_predecessor_id', release.expected_predecessor_id,
+        'build_environment_version', artifact.build_environment_version
+      ) end,
+    'trusted_baseline', case when predecessor.site_release_id is null then null else
+      jsonb_build_object(
+        'site_release_id', predecessor.site_release_id,
+        'production_verified', true,
+        'object_key', predecessor.object_key,
+        'byte_length', predecessor.byte_length,
+        'artifact_sha256', predecessor.artifact_sha256,
+        'artifact_fingerprint_sha256', predecessor.artifact_fingerprint_sha256,
+        'hash_algorithm', predecessor.hash_algorithm,
+        'verification_profile', predecessor.verification_profile,
+        'r2_verified_at', predecessor.r2_verified_at,
+        'lock_evidence_sha256', predecessor.lock_evidence_sha256
+      ) end
+  );
+end;
+$$;
+
+create or replace function private.accept_deployment_callback_v2(
+  p_site_release_id uuid,
+  p_dispatch_id uuid,
+  p_attempt_token uuid,
+  p_execution_generation bigint,
+  p_event_type text,
+  p_evidence jsonb
+)
+returns boolean
+language plpgsql
+volatile
+security definer
+set search_path = ''
+as $$
+begin
+  update private.content_outbox value
+  set lease_expires_at = clock_timestamp() + interval '30 minutes',
+      github_run_id = coalesce((p_evidence ->> 'github_run_id')::bigint, github_run_id),
+      updated_at = clock_timestamp()
+  where value.site_release_id = p_site_release_id
+    and value.dispatch_id = p_dispatch_id
+    and value.attempt_token = p_attempt_token
+    and value.execution_generation = p_execution_generation
+    and value.status not in ('deployed', 'dead_letter')
+    and value.lease_expires_at > clock_timestamp();
+
+  if not found then
+    insert into private.release_deployment_attempts(
+      site_release_id, dispatch_id, event_type, evidence
+    ) values (
+      p_site_release_id, p_dispatch_id, 'stale_callback_ignored',
+      coalesce(p_evidence, '{}'::jsonb) || jsonb_build_object(
+        'stale_event_type', p_event_type,
+        'execution_generation', p_execution_generation
+      )
+    );
+    return false;
+  end if;
+
+  if p_event_type = 'heartbeat' then
+    insert into private.release_deployment_attempts(
+      site_release_id, dispatch_id, event_type, evidence
+    ) values (
+      p_site_release_id, p_dispatch_id, 'heartbeat', coalesce(p_evidence, '{}'::jsonb)
+    );
+  end if;
+  return true;
+end;
+$$;
+
+create or replace function private.attest_release_artifact_v1(
+  p_site_release_id uuid,
+  p_artifact_sha256 text,
+  p_verification_profile text,
+  p_r2_verified_at timestamptz,
+  p_lock_evidence_sha256 text
+)
+returns void
+language plpgsql
+volatile
+security definer
+set search_path = ''
+as $$
+begin
+  if p_verification_profile <> 'r2-full-get-sha256-indefinite-lock-v1'
+    or p_artifact_sha256 !~ '^[a-f0-9]{64}$'
+    or p_lock_evidence_sha256 !~ '^[a-f0-9]{64}$'
+    or p_r2_verified_at is null then
+    raise exception 'Invalid R2 verification attestation';
+  end if;
+
+  update private.release_artifacts value
+  set verification_profile = p_verification_profile,
+      r2_verified_at = greatest(value.r2_verified_at, p_r2_verified_at),
+      lock_evidence_sha256 = p_lock_evidence_sha256
+  where value.site_release_id = p_site_release_id
+    and value.artifact_sha256 = p_artifact_sha256
+    and (value.verification_profile is null
+      or (value.verification_profile = p_verification_profile
+        and value.lock_evidence_sha256 = p_lock_evidence_sha256));
+  if not found then raise exception 'Artifact verification attestation collision'; end if;
+end;
+$$;
+
+create or replace function private.record_deployment_checkpoint_v2(
+  p_site_release_id uuid,
+  p_dispatch_id uuid,
+  p_attempt_token uuid,
+  p_execution_generation bigint,
+  p_event_type text,
+  p_evidence jsonb
+)
+returns void
+language plpgsql
+volatile
+security definer
+set search_path = ''
+as $$
+declare
+  checkpoint_stage text;
+begin
+  if not exists (
+    select 1 from private.content_outbox value
+    where value.site_release_id = p_site_release_id
+      and value.dispatch_id = p_dispatch_id
+      and value.attempt_token = p_attempt_token
+      and value.execution_generation = p_execution_generation
+      and value.lease_expires_at > clock_timestamp()
+  ) then
+    raise exception 'Stale deployment attempt token';
+  end if;
+
+  checkpoint_stage := case
+    when p_event_type in ('artifact_registered', 'preview_verified') then p_event_type
+    else null
+  end;
+  if checkpoint_stage is not null then
+    insert into private.release_deployment_checkpoints(
+      site_release_id, stage, dispatch_id, originating_attempt_token,
+      originating_execution_generation, artifact_sha256, content_sha256,
+      code_sha, evidence
+    ) values (
+      p_site_release_id, checkpoint_stage, p_dispatch_id, p_attempt_token,
+      p_execution_generation,
+      p_evidence ->> 'artifact_sha256',
+      nullif(p_evidence ->> 'content_sha256', ''),
+      nullif(p_evidence ->> 'code_sha', ''),
+      p_evidence
+    )
+    on conflict (site_release_id, stage) do nothing;
+
+    if not exists (
+      select 1 from private.release_deployment_checkpoints value
+      where value.site_release_id = p_site_release_id
+        and value.stage = checkpoint_stage
+        and value.dispatch_id = p_dispatch_id
+        and value.artifact_sha256 = p_evidence ->> 'artifact_sha256'
+        and value.content_sha256 is not distinct from nullif(p_evidence ->> 'content_sha256', '')
+        and value.code_sha is not distinct from nullif(p_evidence ->> 'code_sha', '')
+        and (
+          checkpoint_stage <> 'preview_verified'
+          or value.evidence ->> 'preview_url'
+            is not distinct from nullif(p_evidence ->> 'preview_url', '')
+        )
+    ) then
+      raise exception 'Deployment checkpoint identity collision';
+    end if;
+  end if;
+
+  perform private.record_deployment_event_v1(
+    p_site_release_id, p_dispatch_id, p_event_type, p_evidence
+  );
+end;
+$$;
+
+create or replace function private.authorize_attempt_production_promotion_v1(
+  p_site_release_id uuid,
+  p_dispatch_id uuid,
+  p_attempt_token uuid,
+  p_execution_generation bigint,
+  p_expected_pointer_generation bigint,
+  p_locked_by text,
+  p_attempt_lease_seconds integer default 900,
+  p_slot_lease_seconds integer default 600
+)
+returns jsonb
+language plpgsql
+volatile
+security definer
+set search_path = ''
+as $$
+declare
+  attempt private.content_outbox%rowtype;
+  pointer private.release_current_pointer%rowtype;
+  promotion_authorization jsonb;
+  attempt_lease_expires_at timestamptz;
+begin
+  perform private.require_setting_v1('publication');
+  perform pg_advisory_xact_lock(42003);
+
+  select * into attempt
+  from private.content_outbox value
+  where value.site_release_id = p_site_release_id
+    and value.dispatch_id = p_dispatch_id
+    and value.attempt_token = p_attempt_token
+    and value.execution_generation = p_execution_generation
+  for update;
+  if not found then
+    raise exception 'Stale production deployment attempt';
+  end if;
+  if p_locked_by is distinct from (
+    'broker:' || p_dispatch_id::text || ':' || p_attempt_token::text
+  ) then
+    raise exception 'Invalid production broker lock identity';
+  end if;
+
+  select * into pointer
+  from private.release_current_pointer
+  where singleton
+  for update;
+  if coalesce(pointer.generation, 0) <> p_expected_pointer_generation then
+    raise exception 'Pointer generation conflict';
+  end if;
+
+  -- A Durable Object retry may arrive after the database commit response was
+  -- lost. It may acknowledge that exact attempt, but it must not run the
+  -- same-release repair path or perform another Pages mutation.
+  if pointer.target_site_release_id = p_site_release_id then
+    if attempt.status = 'dead_letter'
+      or (
+        attempt.status <> 'deployed'
+        and (
+          attempt.lease_expires_at is null
+          or attempt.lease_expires_at <= clock_timestamp()
+        )
+      ) then
+      raise exception 'Stale production deployment attempt';
+    end if;
+    update private.content_outbox value
+    set status = 'deployed',
+        lease_expires_at = null,
+        updated_at = clock_timestamp()
+    where value.id = attempt.id;
+    return jsonb_build_object(
+      'site_release_id', p_site_release_id,
+      'already_committed', true,
+      'expected_pointer_generation', pointer.generation
+    );
+  end if;
+
+  if attempt.status <> 'preview_verified'
+    or attempt.lease_expires_at is null
+    or attempt.lease_expires_at <= clock_timestamp() then
+    raise exception 'Stale production deployment attempt';
+  end if;
+
+  attempt_lease_expires_at := clock_timestamp()
+    + make_interval(
+        secs => least(greatest(p_attempt_lease_seconds, 900), 1800)
+      );
+  update private.content_outbox value
+  set status = 'promoting',
+      locked_by = p_locked_by,
+      lease_expires_at = attempt_lease_expires_at,
+      updated_at = clock_timestamp()
+  where value.id = attempt.id;
+
+  promotion_authorization := private.authorize_production_promotion_v1(
+    p_site_release_id,
+    p_expected_pointer_generation,
+    p_locked_by,
+    least(greatest(p_slot_lease_seconds, 60), 600)
+  );
+  return promotion_authorization || jsonb_build_object(
+    'already_committed', false,
+    'dispatch_id', p_dispatch_id,
+    'attempt_token', p_attempt_token,
+    'execution_generation', p_execution_generation,
+    'attempt_lease_expires_at', attempt_lease_expires_at
+  );
+end;
+$$;
+
+create or replace function private.commit_attempt_production_promotion_v1(
+  p_site_release_id uuid,
+  p_dispatch_id uuid,
+  p_attempt_token uuid,
+  p_execution_generation bigint,
+  p_fencing_token bigint,
+  p_expected_pointer_generation bigint,
+  p_pages_deployment_id text,
+  p_manifest_sha256 text,
+  p_artifact_sha256 text,
+  p_build_environment_version text,
+  p_verifier_evidence jsonb
+)
+returns jsonb
+language plpgsql
+volatile
+security definer
+set search_path = ''
+as $$
+declare
+  attempt private.content_outbox%rowtype;
+  committed jsonb;
+begin
+  perform pg_advisory_xact_lock(42003);
+
+  select * into attempt
+  from private.content_outbox value
+  where value.site_release_id = p_site_release_id
+    and value.dispatch_id = p_dispatch_id
+    and value.attempt_token = p_attempt_token
+    and value.execution_generation = p_execution_generation
+    and value.status = 'promoting'
+    and value.lease_expires_at > clock_timestamp()
+  for update;
+  if not found then
+    raise exception 'Stale production deployment attempt';
+  end if;
+
+  committed := private.commit_production_promotion_v1(
+    p_site_release_id,
+    p_fencing_token,
+    p_expected_pointer_generation,
+    p_pages_deployment_id,
+    p_manifest_sha256,
+    p_artifact_sha256,
+    p_build_environment_version,
+    p_verifier_evidence
+  );
+  return committed || jsonb_build_object(
+    'dispatch_id', p_dispatch_id,
+    'execution_generation', p_execution_generation
+  );
+end;
+$$;
+
+create or replace function private.commit_reconciled_production_promotion_v1(
+  p_site_release_id uuid,
+  p_fencing_token bigint,
+  p_expected_pointer_generation bigint,
+  p_pages_deployment_id text,
+  p_manifest_sha256 text,
+  p_artifact_sha256 text,
+  p_build_environment_version text,
+  p_verifier_evidence jsonb
+)
+returns jsonb
+language plpgsql
+volatile
+security definer
+set search_path = ''
+as $$
+declare
+  committed jsonb;
+begin
+  perform pg_advisory_xact_lock(42003);
+  if not exists (
+    select 1
+    from private.production_promotion_slot slot
+    where slot.project_key = 'bubble-brain-pages'
+      and slot.site_release_id = p_site_release_id
+      and slot.fencing_token = p_fencing_token
+      and slot.expected_pointer_generation = p_expected_pointer_generation
+      and slot.operation = 'forward'
+      and slot.status = 'verifying'
+      and slot.locked_by like 'reconciler:%'
+      and slot.lease_expires_at > clock_timestamp()
+  ) then
+    raise exception 'Stale production reconcile fencing token';
+  end if;
+
+  committed := private.commit_production_promotion_v1(
+    p_site_release_id,
+    p_fencing_token,
+    p_expected_pointer_generation,
+    p_pages_deployment_id,
+    p_manifest_sha256,
+    p_artifact_sha256,
+    p_build_environment_version,
+    p_verifier_evidence
+  );
+  return committed;
+end;
+$$;
+
+revoke all on function private.get_content_release_resume_plan_v1(uuid, uuid, uuid)
+  from public, anon, authenticated, service_role, content_backup,
+       content_ingestor, content_editor, content_controller, content_reader;
+grant execute on function private.get_content_release_resume_plan_v1(uuid, uuid, uuid)
+  to content_deployer;
+
+revoke all on function private.accept_deployment_callback_v2(
+  uuid, uuid, uuid, bigint, text, jsonb
+) from public, anon, authenticated, service_role, content_backup,
+       content_ingestor, content_editor, content_controller, content_reader;
+grant execute on function private.accept_deployment_callback_v2(
+  uuid, uuid, uuid, bigint, text, jsonb
+) to content_deployer;
+
+revoke all on function private.attest_release_artifact_v1(
+  uuid, text, text, timestamptz, text
+) from public, anon, authenticated, service_role, content_backup,
+       content_ingestor, content_editor, content_controller, content_reader;
+grant execute on function private.attest_release_artifact_v1(
+  uuid, text, text, timestamptz, text
+) to content_deployer;
+
+revoke all on function private.record_deployment_checkpoint_v2(
+  uuid, uuid, uuid, bigint, text, jsonb
+) from public, anon, authenticated, service_role, content_backup,
+       content_ingestor, content_editor, content_controller, content_reader;
+grant execute on function private.record_deployment_checkpoint_v2(
+  uuid, uuid, uuid, bigint, text, jsonb
+) to content_deployer;
+
+revoke all on function private.authorize_attempt_production_promotion_v1(
+  uuid, uuid, uuid, bigint, bigint, text, integer, integer
+) from public, anon, authenticated, service_role, content_backup,
+       content_ingestor, content_editor, content_controller, content_reader;
+grant execute on function private.authorize_attempt_production_promotion_v1(
+  uuid, uuid, uuid, bigint, bigint, text, integer, integer
+) to content_deployer;
+
+revoke all on function private.commit_attempt_production_promotion_v1(
+  uuid, uuid, uuid, bigint, bigint, bigint, text, text, text, text, jsonb
+) from public, anon, authenticated, service_role, content_backup,
+       content_ingestor, content_editor, content_controller, content_reader;
+grant execute on function private.commit_attempt_production_promotion_v1(
+  uuid, uuid, uuid, bigint, bigint, bigint, text, text, text, text, jsonb
+) to content_deployer;
+
+revoke all on function private.commit_reconciled_production_promotion_v1(
+  uuid, bigint, bigint, text, text, text, text, jsonb
+) from public, anon, authenticated, service_role, content_backup,
+       content_ingestor, content_editor, content_controller, content_reader;
+grant execute on function private.commit_reconciled_production_promotion_v1(
+  uuid, bigint, bigint, text, text, text, text, jsonb
+) to content_deployer;
+
+-- Expand phase only: the legacy authorize RPC remains executable until every
+-- production Broker instance is running the attempt-fenced call above. Revoke
+-- it in a separately deployed contract phase to avoid a DB/Broker rollout gap.
+
+commit;

--- a/supabase/migrations/20260724000400_scheduled_run_observability.sql
+++ b/supabase/migrations/20260724000400_scheduled_run_observability.sql
@@ -1,0 +1,778 @@
+begin;
+
+create table if not exists private.scheduled_run_observability_events (
+  id bigint generated always as identity primary key,
+  run_id text not null check (run_id ~ '^scheduled:[0-9]{13}$'),
+  scheduled_at timestamptz not null,
+  report_date date not null,
+  batch_id text not null check (
+    batch_id in ('morning', 'afternoon', 'night', 'lateNight')
+  ),
+  publication_batch_id text not null check (
+    publication_batch_id in (
+      'morning', 'afternoon', 'night', 'lateNight', 'lateNightSupplement'
+    )
+  ),
+  event_type text not null check (
+    event_type in ('started', 'release_registered', 'succeeded', 'failed')
+  ),
+  content_sha256 text check (
+    content_sha256 is null or content_sha256 ~ '^[a-f0-9]{64}$'
+  ),
+  no_op boolean not null default false,
+  site_release_id uuid references private.site_releases(id),
+  dispatch_id uuid,
+  evidence jsonb not null check (jsonb_typeof(evidence) = 'object'),
+  evidence_sha256 text not null check (evidence_sha256 ~ '^[a-f0-9]{64}$'),
+  recorded_at timestamptz not null default clock_timestamp(),
+  unique (run_id, event_type, evidence_sha256)
+);
+
+create index if not exists scheduled_run_observability_events_window_idx
+  on private.scheduled_run_observability_events (
+    report_date, scheduled_at, id
+  );
+create index if not exists scheduled_run_observability_events_release_idx
+  on private.scheduled_run_observability_events (site_release_id, id)
+  where site_release_id is not null;
+
+create table if not exists private.scheduled_run_observability_current (
+  run_id text primary key check (run_id ~ '^scheduled:[0-9]{13}$'),
+  scheduled_at timestamptz not null unique,
+  report_date date not null,
+  batch_id text not null check (
+    batch_id in ('morning', 'afternoon', 'night', 'lateNight')
+  ),
+  publication_batch_id text not null check (
+    publication_batch_id in (
+      'morning', 'afternoon', 'night', 'lateNight', 'lateNightSupplement'
+    )
+  ),
+  status text not null check (status in ('started', 'succeeded', 'failed')),
+  stage text not null,
+  started_at timestamptz,
+  finished_at timestamptz,
+  source_result jsonb check (
+    source_result is null or jsonb_typeof(source_result) = 'object'
+  ),
+  content_sha256 text check (
+    content_sha256 is null or content_sha256 ~ '^[a-f0-9]{64}$'
+  ),
+  no_op boolean not null default false,
+  site_release_id uuid references private.site_releases(id),
+  dispatch_id uuid,
+  last_event_id bigint not null
+    references private.scheduled_run_observability_events(id),
+  updated_at timestamptz not null default clock_timestamp(),
+  check (
+    (status = 'started' and finished_at is null)
+    or (status in ('succeeded', 'failed') and finished_at is not null)
+  )
+);
+
+create index if not exists scheduled_run_observability_current_window_idx
+  on private.scheduled_run_observability_current (
+    report_date, scheduled_at, run_id
+  );
+
+alter table private.scheduled_run_observability_events enable row level security;
+alter table private.scheduled_run_observability_events force row level security;
+drop policy if exists content_rpc_owner_all
+  on private.scheduled_run_observability_events;
+create policy content_rpc_owner_all
+  on private.scheduled_run_observability_events
+  for all to content_rpc_owner using (true) with check (true);
+drop policy if exists content_backup_select
+  on private.scheduled_run_observability_events;
+create policy content_backup_select
+  on private.scheduled_run_observability_events
+  for select to content_backup using (true);
+
+alter table private.scheduled_run_observability_current enable row level security;
+alter table private.scheduled_run_observability_current force row level security;
+drop policy if exists content_rpc_owner_all
+  on private.scheduled_run_observability_current;
+create policy content_rpc_owner_all
+  on private.scheduled_run_observability_current
+  for all to content_rpc_owner using (true) with check (true);
+drop policy if exists content_backup_select
+  on private.scheduled_run_observability_current;
+create policy content_backup_select
+  on private.scheduled_run_observability_current
+  for select to content_backup using (true);
+
+revoke all on private.scheduled_run_observability_events,
+  private.scheduled_run_observability_current
+  from public, anon, authenticated, service_role, content_ingestor,
+       content_editor, content_controller, content_reader, content_deployer;
+grant select, insert on private.scheduled_run_observability_events
+  to content_rpc_owner;
+grant select, insert, update on private.scheduled_run_observability_current
+  to content_rpc_owner;
+grant usage, select on sequence
+  private.scheduled_run_observability_events_id_seq
+  to content_rpc_owner;
+grant select on private.scheduled_run_observability_events,
+  private.scheduled_run_observability_current
+  to content_backup;
+
+set local role content_rpc_owner;
+
+create or replace function private.record_scheduled_run_trace_v1(
+  p_run_id text,
+  p_scheduled_at timestamptz,
+  p_event_type text,
+  p_evidence jsonb
+)
+returns jsonb
+language plpgsql
+volatile
+security definer
+set search_path = ''
+as $$
+declare
+  v_expected_run_id text;
+  v_local timestamp;
+  v_local_hour integer;
+  v_report_date date;
+  v_batch_id text;
+  v_publication_batch_id text;
+  v_status text;
+  v_stage text;
+  v_started_at timestamptz;
+  v_finished_at timestamptz;
+  v_source_result jsonb;
+  v_content_sha256 text;
+  v_no_op boolean;
+  v_site_release_id uuid;
+  v_dispatch_id uuid;
+  v_evidence_sha256 text;
+  v_event private.scheduled_run_observability_events%rowtype;
+  v_current private.scheduled_run_observability_current%rowtype;
+begin
+  if p_scheduled_at is null
+    or p_scheduled_at <> date_trunc('hour', p_scheduled_at)
+    or extract(hour from p_scheduled_at at time zone 'UTC')::integer
+      not in (0, 2, 4, 6, 8, 10, 12, 14, 16, 17, 18, 19, 20, 21, 22, 23)
+    or p_scheduled_at < timestamptz '2020-01-01 00:00:00+00'
+    or p_scheduled_at > clock_timestamp() + interval '5 minutes'
+    or p_event_type not in ('started', 'release_registered', 'succeeded', 'failed')
+    or jsonb_typeof(p_evidence) is distinct from 'object'
+    or octet_length(p_evidence::text) > 32768 then
+    raise exception 'Invalid scheduled run trace' using errcode = '22023';
+  end if;
+
+  v_expected_run_id := 'scheduled:' ||
+    ((extract(epoch from p_scheduled_at) * 1000)::bigint)::text;
+  if p_run_id is distinct from v_expected_run_id then
+    raise exception 'Invalid scheduled run trace' using errcode = '22023';
+  end if;
+
+  v_local := p_scheduled_at at time zone 'Asia/Shanghai';
+  v_local_hour := extract(hour from v_local)::integer;
+  v_batch_id := case
+    when v_local_hour >= 2 and v_local_hour < 5 then 'lateNight'
+    when v_local_hour >= 22 or v_local_hour < 2 then 'night'
+    when v_local_hour >= 14 and v_local_hour < 22 then 'afternoon'
+    else 'morning'
+  end;
+  v_publication_batch_id := case
+    when v_batch_id = 'lateNight' and v_local_hour = 3
+      then 'lateNightSupplement'
+    else v_batch_id
+  end;
+  v_report_date := v_local::date -
+    case when v_batch_id = 'lateNight' then 1 else 0 end;
+
+  v_status := case
+    when p_event_type in ('started', 'release_registered') then 'started'
+    else p_event_type
+  end;
+  if p_event_type <> 'release_registered'
+    and p_evidence ->> 'status' is distinct from v_status then
+    raise exception 'Invalid scheduled run trace' using errcode = '22023';
+  end if;
+  v_stage := nullif(btrim(p_evidence ->> 'stage'), '');
+  if v_stage is null or length(v_stage) > 128 then
+    raise exception 'Invalid scheduled run trace' using errcode = '22023';
+  end if;
+
+  begin
+    v_started_at := nullif(p_evidence ->> 'started_at', '')::timestamptz;
+    v_finished_at := nullif(p_evidence ->> 'finished_at', '')::timestamptz;
+  exception when others then
+    raise exception 'Invalid scheduled run trace' using errcode = '22023';
+  end;
+  if p_event_type = 'started' and v_finished_at is not null then
+    raise exception 'Invalid scheduled run trace' using errcode = '22023';
+  end if;
+  if p_event_type in ('succeeded', 'failed')
+    and (v_started_at is null or v_finished_at is null
+      or v_finished_at < v_started_at) then
+    raise exception 'Invalid scheduled run trace' using errcode = '22023';
+  end if;
+
+  v_source_result := p_evidence -> 'source_result';
+  if v_source_result is not null
+    and jsonb_typeof(v_source_result) is distinct from 'object' then
+    raise exception 'Invalid scheduled run trace' using errcode = '22023';
+  end if;
+  v_content_sha256 := nullif(p_evidence ->> 'content_sha256', '');
+  if v_content_sha256 is not null
+    and v_content_sha256 !~ '^[a-f0-9]{64}$' then
+    raise exception 'Invalid scheduled run trace' using errcode = '22023';
+  end if;
+  v_no_op := coalesce((p_evidence ->> 'no_op')::boolean, false);
+
+  begin
+    v_site_release_id := nullif(p_evidence ->> 'site_release_id', '')::uuid;
+    v_dispatch_id := nullif(p_evidence ->> 'dispatch_id', '')::uuid;
+  exception when others then
+    raise exception 'Invalid scheduled run trace' using errcode = '22023';
+  end;
+  if (v_site_release_id is null) <> (v_dispatch_id is null)
+    or (v_site_release_id is not null and not exists (
+      select 1
+      from private.content_outbox value
+      where value.site_release_id = v_site_release_id
+        and value.dispatch_id = v_dispatch_id
+    )) then
+    raise exception 'Invalid scheduled run release identity'
+      using errcode = '22023';
+  end if;
+  if p_event_type = 'release_registered'
+    and v_site_release_id is null then
+    raise exception 'Invalid scheduled run release identity'
+      using errcode = '22023';
+  end if;
+
+  v_evidence_sha256 := private.sha256_jsonb_v1(jsonb_build_object(
+    'run_id', p_run_id,
+    'event_type', p_event_type,
+    'evidence', p_evidence
+  ));
+  insert into private.scheduled_run_observability_events(
+    run_id, scheduled_at, report_date, batch_id, publication_batch_id,
+    event_type, content_sha256, no_op, site_release_id, dispatch_id,
+    evidence, evidence_sha256
+  ) values (
+    p_run_id, p_scheduled_at, v_report_date, v_batch_id,
+    v_publication_batch_id, p_event_type, v_content_sha256, v_no_op,
+    v_site_release_id, v_dispatch_id, p_evidence, v_evidence_sha256
+  )
+  on conflict (run_id, event_type, evidence_sha256) do nothing
+  returning * into v_event;
+  if v_event.id is null then
+    select * into v_event
+    from private.scheduled_run_observability_events value
+    where value.run_id = p_run_id
+      and value.event_type = p_event_type
+      and value.evidence_sha256 = v_evidence_sha256;
+  end if;
+
+  select * into v_current
+  from private.scheduled_run_observability_current value
+  where value.run_id = p_run_id
+  for update;
+
+  if not found then
+    insert into private.scheduled_run_observability_current(
+      run_id, scheduled_at, report_date, batch_id, publication_batch_id,
+      status, stage, started_at, finished_at, source_result,
+      content_sha256, no_op, site_release_id, dispatch_id, last_event_id
+    ) values (
+      p_run_id, p_scheduled_at, v_report_date, v_batch_id,
+      v_publication_batch_id, v_status, v_stage,
+      coalesce(v_started_at, p_scheduled_at),
+      case when v_status = 'started' then null else v_finished_at end,
+      v_source_result, v_content_sha256, v_no_op,
+      v_site_release_id, v_dispatch_id, v_event.id
+    );
+  else
+    if v_current.scheduled_at <> p_scheduled_at
+      or v_current.report_date <> v_report_date
+      or v_current.batch_id <> v_batch_id
+      or (v_current.site_release_id is not null
+        and v_site_release_id is not null
+        and v_current.site_release_id <> v_site_release_id)
+      or (v_current.dispatch_id is not null
+        and v_dispatch_id is not null
+        and v_current.dispatch_id <> v_dispatch_id) then
+      raise exception 'Scheduled run trace identity collision';
+    end if;
+
+    if p_event_type = 'release_registered' then
+      update private.scheduled_run_observability_current value
+      set stage = case
+            when value.status = 'started' then v_stage else value.stage
+          end,
+          content_sha256 = coalesce(value.content_sha256, v_content_sha256),
+          no_op = value.no_op or v_no_op,
+          site_release_id = coalesce(value.site_release_id, v_site_release_id),
+          dispatch_id = coalesce(value.dispatch_id, v_dispatch_id),
+          last_event_id = v_event.id,
+          updated_at = clock_timestamp()
+      where value.run_id = p_run_id;
+    elsif p_event_type = 'started' then
+      update private.scheduled_run_observability_current value
+      set started_at = least(
+            coalesce(value.started_at, v_started_at, p_scheduled_at),
+            coalesce(v_started_at, p_scheduled_at)
+          ),
+          last_event_id = v_event.id,
+          updated_at = clock_timestamp()
+      where value.run_id = p_run_id
+        and value.status = 'started';
+    elsif v_current.status = 'started'
+      or (v_current.status = 'failed' and v_status = 'succeeded')
+      or (v_current.status = v_status
+        and v_finished_at >= v_current.finished_at) then
+      update private.scheduled_run_observability_current value
+      set status = v_status,
+          stage = v_stage,
+          started_at = least(
+            coalesce(value.started_at, v_started_at),
+            v_started_at
+          ),
+          finished_at = v_finished_at,
+          source_result = coalesce(v_source_result, value.source_result),
+          content_sha256 = coalesce(v_content_sha256, value.content_sha256),
+          no_op = v_no_op,
+          site_release_id = coalesce(v_site_release_id, value.site_release_id),
+          dispatch_id = coalesce(v_dispatch_id, value.dispatch_id),
+          last_event_id = v_event.id,
+          updated_at = clock_timestamp()
+      where value.run_id = p_run_id;
+    end if;
+  end if;
+
+  return (
+    select jsonb_build_object(
+      'run_id', value.run_id,
+      'scheduled_at', value.scheduled_at,
+      'status', value.status,
+      'event_id', v_event.id,
+      'recorded_at', v_event.recorded_at
+    )
+    from private.scheduled_run_observability_current value
+    where value.run_id = p_run_id
+  );
+end;
+$$;
+
+create or replace function private.finalize_site_release_v1(
+  reservation_id uuid,
+  manifest_object_key text,
+  manifest_byte_length bigint,
+  manifest_sha256 text,
+  content_root_sha256 text,
+  schema_version integer,
+  taxonomy_version integer,
+  serializer_version text,
+  search_contract_version text,
+  source_contract_version text,
+  structured_cutover_date date,
+  no_report_days date[],
+  dispatch_id uuid,
+  dispatch_payload jsonb
+)
+returns jsonb
+language plpgsql
+volatile
+security definer
+set search_path = ''
+as $$
+declare
+  reservation private.site_release_reservations%rowtype;
+  snapshot private.report_snapshots%rowtype;
+  dispatch_mode text;
+  existing_dispatch_id uuid;
+  scheduled_trigger text;
+  scheduled_started_at timestamptz;
+  scheduled_at timestamptz;
+begin
+  perform pg_advisory_xact_lock(42002);
+  select * into reservation
+  from private.site_release_reservations
+  where id = reservation_id
+  for update;
+  if not found then raise exception 'Unknown site release reservation'; end if;
+  if reservation.status = 'finalized' then
+    select value.dispatch_id into existing_dispatch_id
+    from private.content_outbox value
+    where value.site_release_id = reservation.id
+    order by value.inserted_at, value.id
+    limit 1;
+    if existing_dispatch_id is null then
+      raise exception 'Finalized site release is missing its dispatch identity';
+    end if;
+    return (select jsonb_build_object(
+      'site_release_id', id, 'site_release_sequence', sequence,
+      'expected_predecessor_id', expected_predecessor_id,
+      'dispatch_id', existing_dispatch_id, 'idempotent', true
+    ) from private.site_releases where id = reservation_id);
+  end if;
+  if reservation.status <> 'reserved'
+    or reservation.expires_at <= clock_timestamp() then
+    raise exception 'Expired or unusable site release reservation';
+  end if;
+  dispatch_mode := dispatch_payload ->> 'mode';
+  if dispatch_mode = 'shadow' then
+    perform private.require_setting_v1('shadow_build');
+  elsif dispatch_mode = 'production' then
+    perform private.require_setting_v1('publication');
+  else
+    raise exception using
+      errcode = '22023',
+      message = 'Invalid content release dispatch mode';
+  end if;
+  if jsonb_typeof(dispatch_payload) <> 'object'
+    or dispatch_payload ->> 'dispatch_id' <> dispatch_id::text
+    or dispatch_payload ->> 'site_release_id' <> reservation.id::text
+    or (dispatch_payload ->> 'site_release_sequence')::bigint
+      <> reservation.sequence
+    or dispatch_payload ->> 'expected_predecessor_id'
+      is distinct from reservation.expected_predecessor_id::text
+    or dispatch_payload ->> 'expected_content_sha' <> content_root_sha256
+    or dispatch_payload ->> 'code_sha' !~ '^[a-f0-9]{40}$'
+    or nullif(
+      btrim(dispatch_payload ->> 'build_environment_version'), ''
+    ) is null then
+    raise exception using
+      errcode = '22023',
+      message = 'Content release dispatch identity mismatch';
+  end if;
+  if manifest_sha256 !~ '^[a-f0-9]{64}$'
+    or manifest_object_key
+      <> 'site-manifests/sha256/' || manifest_sha256 || '.json'
+    or content_root_sha256 !~ '^[a-f0-9]{64}$'
+    or manifest_byte_length <= 0
+    or schema_version < 1
+    or taxonomy_version < 1
+    or serializer_version !~ '^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$'
+    or search_contract_version !~ '^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$'
+    or source_contract_version !~ '^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$'
+  then
+    raise exception 'Invalid verified site manifest metadata';
+  end if;
+  if reservation.expected_predecessor_id is distinct from coalesce(
+    (select target_site_release_id
+     from private.release_current_pointer where singleton),
+    (select id from private.site_releases order by sequence desc limit 1)
+  ) then
+    raise exception 'Site release predecessor changed';
+  end if;
+
+  select * into snapshot
+  from private.report_snapshots
+  where id = reservation.report_snapshot_id;
+  insert into private.site_releases(
+    id, sequence, expected_predecessor_id, manifest_object_key,
+    manifest_byte_length, manifest_sha256, content_root_sha256,
+    schema_version, taxonomy_version, serializer_version,
+    search_contract_version, source_contract_version,
+    structured_cutover_date, no_report_days
+  ) values (
+    reservation.id, reservation.sequence,
+    reservation.expected_predecessor_id, manifest_object_key,
+    manifest_byte_length, manifest_sha256, content_root_sha256,
+    schema_version, taxonomy_version, serializer_version,
+    search_contract_version, source_contract_version,
+    structured_cutover_date, coalesce(no_report_days, '{}')
+  );
+
+  if reservation.expected_predecessor_id is not null then
+    insert into private.site_release_reports(
+      site_release_id, report_date, report_snapshot_id, byte_sha256
+    )
+    select reservation.id, report_date, report_snapshot_id, byte_sha256
+    from private.site_release_reports
+    where site_release_id = reservation.expected_predecessor_id
+      and report_date <> snapshot.report_date;
+  end if;
+  insert into private.site_release_reports(
+    site_release_id, report_date, report_snapshot_id, byte_sha256
+  ) values (
+    reservation.id, snapshot.report_date, snapshot.id, snapshot.byte_sha256
+  );
+
+  insert into private.content_outbox(site_release_id, dispatch_id, payload)
+  values (reservation.id, dispatch_id, dispatch_payload);
+  insert into private.release_deployment_attempts(
+    site_release_id, dispatch_id, event_type
+  ) values (reservation.id, dispatch_id, 'queued');
+  update private.site_release_reservations
+  set status = 'finalized'
+  where id = reservation.id;
+  update private.publication_slots slot
+  set site_release_id = reservation.id, updated_at = clock_timestamp()
+  where slot.reservation_id = reservation.id;
+
+  select attempt.trigger_kind, attempt.started_at
+  into scheduled_trigger, scheduled_started_at
+  from private.publication_slots slot
+  join private.publication_attempts attempt
+    on attempt.report_date = slot.report_date
+   and attempt.batch_id = slot.batch_id
+   and attempt.input_sha256 = slot.input_sha256
+   and attempt.status = 'started'
+  where slot.reservation_id = reservation.id
+    and attempt.trigger_kind ~ '^scheduled:[0-9]{13}$'
+  order by attempt.attempt_number desc, attempt.started_at desc
+  limit 1;
+
+  update private.publication_attempts attempt
+  set status = 'succeeded',
+      error_code = null,
+      error_detail = null,
+      finished_at = clock_timestamp()
+  from private.publication_slots slot
+  where slot.reservation_id = reservation.id
+    and attempt.report_date = slot.report_date
+    and attempt.batch_id = slot.batch_id
+    and attempt.input_sha256 = slot.input_sha256
+    and attempt.status = 'started';
+
+  -- The release/run association is committed in the same transaction as the
+  -- outbox row. A Worker crash after finalize can no longer create a release
+  -- that is invisible to run-level observability.
+  if scheduled_trigger is not null then
+    scheduled_at := timestamptz 'epoch' +
+      (substring(scheduled_trigger from 11)::bigint
+        * interval '1 millisecond');
+    perform private.record_scheduled_run_trace_v1(
+      scheduled_trigger,
+      scheduled_at,
+      'release_registered',
+      jsonb_build_object(
+        'status', 'started',
+        'stage', 'release_registered',
+        'started_at', coalesce(scheduled_started_at, scheduled_at),
+        'finished_at', null,
+        'content_sha256', snapshot.byte_sha256,
+        'no_op', false,
+        'site_release_id', reservation.id,
+        'dispatch_id', dispatch_id
+      )
+    );
+  end if;
+
+  return jsonb_build_object(
+    'site_release_id', reservation.id,
+    'site_release_sequence', reservation.sequence,
+    'expected_predecessor_id', reservation.expected_predecessor_id,
+    'dispatch_id', dispatch_id,
+    'idempotent', false
+  );
+end;
+$$;
+
+-- Preserve the previous implementations as private building blocks so this
+-- migration can add run-level evidence without duplicating their mature
+-- release, slot, and incident projections.
+do $$
+begin
+  if to_regprocedure('private.get_content_observability_base_v1()') is null then
+    alter function private.get_content_observability_v1()
+      rename to get_content_observability_base_v1;
+  end if;
+  if to_regprocedure(
+    'private.get_content_observation_window_base_v1(date)'
+  ) is null then
+    alter function private.get_content_observation_window_v1(date)
+      rename to get_content_observation_window_base_v1;
+  end if;
+end;
+$$;
+
+create or replace function private.get_content_observability_v1()
+returns jsonb
+language sql
+stable
+security definer
+set search_path = ''
+as $$
+  select private.get_content_observability_base_v1() || jsonb_build_object(
+    'publication_attempts', coalesce((
+      select jsonb_agg(to_jsonb(latest) order by latest.started_at)
+      from (
+        select distinct on (attempt.trigger_kind)
+          attempt.report_date,
+          attempt.batch_id,
+          attempt.input_sha256,
+          attempt.trigger_kind,
+          attempt.status,
+          attempt.attempt_number,
+          attempt.started_at,
+          attempt.finished_at,
+          attempt.error_code
+        from private.publication_attempts attempt
+        where attempt.started_at >= current_timestamp - interval '3 days'
+        order by attempt.trigger_kind, attempt.attempt_number desc,
+          attempt.started_at desc
+      ) latest
+    ), '[]'::jsonb),
+    'scheduled_runs', coalesce((
+      select jsonb_agg(jsonb_build_object(
+        'run_id', run.run_id,
+        'scheduled_at', run.scheduled_at,
+        'report_date', run.report_date,
+        'batch_id', run.batch_id,
+        'publication_batch_id', run.publication_batch_id,
+        'status', run.status,
+        'stage', run.stage,
+        'started_at', run.started_at,
+        'finished_at', run.finished_at,
+        'source_result', run.source_result,
+        'content_sha256', run.content_sha256,
+        'no_op', run.no_op,
+        'database_mirror', jsonb_build_object(
+          'status', case
+            when run.status = 'failed' and run.stage = 'database_mirror_failed'
+              then 'failed'
+            when run.site_release_id is not null and run.dispatch_id is not null
+              then 'mirrored'
+            else 'unknown'
+          end
+        ),
+        'site_release_id', run.site_release_id,
+        'site_release_sequence', release.sequence,
+        'dispatch_id', run.dispatch_id,
+        'stable_verified_at', edge.stable_verified_at
+      ) order by run.scheduled_at, run.run_id)
+      from private.scheduled_run_observability_current run
+      left join private.site_releases release
+        on release.id = run.site_release_id
+      left join lateral (
+        select min(event.evidence ->> 'stable_verified_at')
+          as stable_verified_at
+        from private.release_deployment_attempts event
+        where event.site_release_id = run.site_release_id
+          and event.event_type = 'edge_verified'
+          and event.evidence -> 'stability_offsets'
+            = '[15000, 45000, 120000]'::jsonb
+          and event.evidence ->> 'stable_verified_at'
+            ~ '^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9:.]+Z$'
+          and jsonb_array_length(case
+            when jsonb_typeof(event.evidence -> 'stability_rounds') = 'array'
+              then event.evidence -> 'stability_rounds'
+            else '[]'::jsonb
+          end) = 3
+      ) edge on true
+      where run.scheduled_at >= current_timestamp - interval '3 days'
+    ), '[]'::jsonb)
+  )
+$$;
+
+create or replace function private.get_content_observation_window_v1(
+  start_date date
+)
+returns jsonb
+language plpgsql
+stable
+security definer
+set search_path = ''
+as $$
+declare
+  base jsonb;
+  end_at timestamptz;
+  ready_at timestamptz;
+begin
+  base := private.get_content_observation_window_base_v1(start_date);
+  end_at := (start_date + 2)::timestamp at time zone 'Asia/Shanghai';
+  -- The final 04:00 Asia/Shanghai late-night run owns the previous report
+  -- date. Its ten-minute terminal deadline closes the two-day gate.
+  ready_at := end_at + interval '4 hours 10 minutes';
+  return base || jsonb_build_object(
+    'ready_at', ready_at,
+    'window_complete', current_timestamp >= ready_at,
+    'scheduled_runs', coalesce((
+      select jsonb_agg(jsonb_build_object(
+        'run_id', run.run_id,
+        'scheduled_at', run.scheduled_at,
+        'report_date', run.report_date,
+        'batch_id', run.batch_id,
+        'publication_batch_id', run.publication_batch_id,
+        'status', run.status,
+        'stage', run.stage,
+        'started_at', run.started_at,
+        'finished_at', run.finished_at,
+        'source_result', run.source_result,
+        'content_sha256', run.content_sha256,
+        'no_op', run.no_op,
+        'database_mirror', jsonb_build_object(
+          'status', case
+            when run.status = 'failed' and run.stage = 'database_mirror_failed'
+              then 'failed'
+            when run.site_release_id is not null and run.dispatch_id is not null
+              then 'mirrored'
+            else 'unknown'
+          end
+        ),
+        'site_release_id', run.site_release_id,
+        'site_release_sequence', release.sequence,
+        'dispatch_id', run.dispatch_id,
+        'stable_verified_at', edge.stable_verified_at
+      ) order by run.scheduled_at, run.run_id)
+      from private.scheduled_run_observability_current run
+      left join private.site_releases release
+        on release.id = run.site_release_id
+      left join lateral (
+        select min(event.evidence ->> 'stable_verified_at')
+          as stable_verified_at
+        from private.release_deployment_attempts event
+        where event.site_release_id = run.site_release_id
+          and event.event_type = 'edge_verified'
+          and event.evidence -> 'stability_offsets'
+            = '[15000, 45000, 120000]'::jsonb
+          and event.evidence ->> 'stable_verified_at'
+            ~ '^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9:.]+Z$'
+          and jsonb_array_length(case
+            when jsonb_typeof(event.evidence -> 'stability_rounds') = 'array'
+              then event.evidence -> 'stability_rounds'
+            else '[]'::jsonb
+          end) = 3
+      ) edge on true
+      where run.report_date >= start_date
+        and run.report_date < start_date + 2
+    ), '[]'::jsonb)
+  );
+end;
+$$;
+
+revoke all on function private.get_content_observability_base_v1()
+  from public, anon, authenticated, service_role, content_backup,
+       content_ingestor, content_editor, content_controller,
+       content_reader, content_deployer;
+revoke all on function private.get_content_observation_window_base_v1(date)
+  from public, anon, authenticated, service_role, content_backup,
+       content_ingestor, content_editor, content_controller,
+       content_reader, content_deployer;
+revoke all on function private.record_scheduled_run_trace_v1(
+  text, timestamptz, text, jsonb
+) from public, anon, authenticated, service_role, content_backup,
+       content_editor, content_controller, content_reader, content_deployer;
+grant execute on function private.record_scheduled_run_trace_v1(
+  text, timestamptz, text, jsonb
+) to content_ingestor;
+revoke all on function private.get_content_observability_v1()
+  from public, anon, authenticated, service_role, content_backup,
+       content_ingestor, content_editor, content_controller, content_reader;
+grant execute on function private.get_content_observability_v1()
+  to content_deployer;
+revoke all on function private.get_content_observation_window_v1(date)
+  from public, anon, authenticated, service_role, content_backup,
+       content_ingestor, content_editor, content_controller, content_reader;
+grant execute on function private.get_content_observation_window_v1(date)
+  to content_deployer;
+revoke all on function private.finalize_site_release_v1(
+  uuid, text, bigint, text, text, integer, integer, text, text, text,
+  date, date[], uuid, jsonb
+) from public, anon, authenticated, service_role, content_backup,
+       content_controller, content_reader, content_deployer;
+grant execute on function private.finalize_site_release_v1(
+  uuid, text, bigint, text, text, integer, integer, text, text, text,
+  date, date[], uuid, jsonb
+) to content_ingestor, content_editor;
+
+commit;

--- a/supabase/post_deploy/20260724_revoke_legacy_production_promotion.sql
+++ b/supabase/post_deploy/20260724_revoke_legacy_production_promotion.sql
@@ -1,0 +1,19 @@
+-- Contract phase for the attempt-fenced Broker rollout.
+--
+-- Do not run this with the expand migration. Apply it only after every
+-- production Broker instance is confirmed to call
+-- authorize_attempt_production_promotion_v1. Keeping this outside
+-- supabase/migrations prevents an automatic db push from breaking an older
+-- Broker during the DB-to-Worker deployment window.
+
+begin;
+
+revoke execute on function private.authorize_production_promotion_v1(
+  uuid, bigint, text, integer
+) from content_deployer;
+
+revoke execute on function private.commit_production_promotion_v1(
+  uuid, bigint, bigint, text, text, text, text, jsonb
+) from content_deployer;
+
+commit;

--- a/supabase/tests/database/production_attempt_fencing.test.sql
+++ b/supabase/tests/database/production_attempt_fencing.test.sql
@@ -1,0 +1,325 @@
+begin;
+
+create extension if not exists pgtap with schema extensions;
+select plan(21);
+
+select has_function(
+  'private',
+  'authorize_attempt_production_promotion_v1',
+  array['uuid', 'uuid', 'uuid', 'bigint', 'bigint', 'text', 'integer', 'integer'],
+  'attempt-fenced production authorization exists'
+);
+select has_function(
+  'private',
+  'commit_attempt_production_promotion_v1',
+  array[
+    'uuid', 'uuid', 'uuid', 'bigint', 'bigint', 'bigint',
+    'text', 'text', 'text', 'text', 'jsonb'
+  ],
+  'attempt-fenced production commit exists'
+);
+select has_function(
+  'private',
+  'commit_reconciled_production_promotion_v1',
+  array[
+    'uuid', 'bigint', 'bigint', 'text', 'text', 'text', 'text', 'jsonb'
+  ],
+  'reconciler production commit uses a dedicated fenced wrapper'
+);
+select ok(
+  has_function_privilege(
+    'content_deployer',
+    'private.authorize_attempt_production_promotion_v1(uuid,uuid,uuid,bigint,bigint,text,integer,integer)',
+    'execute'
+  ),
+  'the deployer can invoke only the expanded attempt-fenced authorization path'
+);
+select ok(
+  has_function_privilege(
+    'content_deployer',
+    'private.commit_attempt_production_promotion_v1(uuid,uuid,uuid,bigint,bigint,bigint,text,text,text,text,jsonb)',
+    'execute'
+  ),
+  'the deployer can commit with attempt identity'
+);
+select ok(
+  has_function_privilege(
+    'content_deployer',
+    'private.commit_reconciled_production_promotion_v1(uuid,bigint,bigint,text,text,text,text,jsonb)',
+    'execute'
+  ),
+  'the deployer can finish only a fenced reconciler promotion'
+);
+
+create temporary table promotion_results (
+  label text primary key,
+  result jsonb not null
+);
+grant all on promotion_results to content_rpc_owner, content_deployer;
+
+set local role content_rpc_owner;
+update private.content_settings
+set enabled = true
+where setting_key = 'publication';
+delete from private.production_promotion_slot
+where project_key = 'bubble-brain-pages';
+delete from private.release_current_pointer where singleton;
+insert into private.site_releases(
+  id, sequence, manifest_object_key, manifest_byte_length, manifest_sha256,
+  content_root_sha256, schema_version, taxonomy_version, serializer_version,
+  search_contract_version, source_contract_version, structured_cutover_date,
+  no_report_days
+) values (
+  '73000000-0000-4000-8000-000000000001', 972001,
+  'site-manifests/sha256/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.json',
+  100, repeat('a', 64), repeat('b', 64), 1, 1,
+  'daily-json-c14n-v1', 'search-v1', 'daily-source-v1', '2026-07-16', '{}'
+);
+insert into private.release_artifacts(
+  site_release_id, object_key, byte_length, artifact_sha256,
+  artifact_fingerprint_sha256, hash_algorithm, code_sha,
+  build_environment_version
+) values (
+  '73000000-0000-4000-8000-000000000001',
+  'artifacts/sha256/cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc.json',
+  100, repeat('c', 64), repeat('d', 64),
+  'sha256-content-addressed-pages-v1', repeat('e', 40),
+  'node22.17-astro7-hugo0.147.9-v1'
+);
+insert into private.content_outbox(
+  site_release_id, dispatch_id, payload, status, attempt_token,
+  execution_generation, lease_expires_at, locked_by
+) values (
+  '73000000-0000-4000-8000-000000000001',
+  '74000000-0000-4000-8000-000000000001',
+  '{"mode":"production"}', 'preview_verified',
+  '75000000-0000-4000-8000-000000000001', 7,
+  clock_timestamp() + interval '30 minutes', 'workflow:original'
+);
+insert into private.release_deployment_attempts(
+  site_release_id, dispatch_id, event_type, evidence
+) values (
+  '73000000-0000-4000-8000-000000000001',
+  '74000000-0000-4000-8000-000000000001',
+  'preview_verified', '{"route_parity":true}'
+);
+select throws_ok(
+  $$select private.authorize_attempt_production_promotion_v1(
+    '73000000-0000-4000-8000-000000000001',
+    '74000000-0000-4000-8000-000000000099',
+    '75000000-0000-4000-8000-000000000001',
+    7, 0, 'broker:wrong-dispatch', 900, 600
+  )$$,
+  'P0001',
+  'Stale production deployment attempt',
+  'a mismatched dispatch cannot authorize production'
+);
+select throws_ok(
+  $$select private.authorize_attempt_production_promotion_v1(
+    '73000000-0000-4000-8000-000000000001',
+    '74000000-0000-4000-8000-000000000001',
+    '75000000-0000-4000-8000-000000000099',
+    7, 0, 'broker:wrong-token', 900, 600
+  )$$,
+  'P0001',
+  'Stale production deployment attempt',
+  'a mismatched token cannot authorize production'
+);
+select throws_ok(
+  $$select private.authorize_attempt_production_promotion_v1(
+    '73000000-0000-4000-8000-000000000001',
+    '74000000-0000-4000-8000-000000000001',
+    '75000000-0000-4000-8000-000000000001',
+    8, 0, 'broker:wrong-generation', 900, 600
+  )$$,
+  'P0001',
+  'Stale production deployment attempt',
+  'a mismatched execution generation cannot authorize production'
+);
+
+select is(
+  (
+    select count(*)
+    from private.production_promotion_slot
+    where project_key = 'bubble-brain-pages'
+  ),
+  0::bigint,
+  'failed attempt checks leave the production slot unchanged'
+);
+
+update private.content_outbox
+set lease_expires_at = clock_timestamp() - interval '1 second'
+where site_release_id = '73000000-0000-4000-8000-000000000001';
+select throws_ok(
+  $$select private.authorize_attempt_production_promotion_v1(
+    '73000000-0000-4000-8000-000000000001',
+    '74000000-0000-4000-8000-000000000001',
+    '75000000-0000-4000-8000-000000000001',
+    7, 0,
+    'broker:74000000-0000-4000-8000-000000000001:75000000-0000-4000-8000-000000000001',
+    900, 600
+  )$$,
+  'P0001',
+  'Stale production deployment attempt',
+  'an expired attempt cannot authorize production'
+);
+
+set local role content_rpc_owner;
+update private.content_outbox
+set lease_expires_at = clock_timestamp() + interval '30 minutes'
+where site_release_id = '73000000-0000-4000-8000-000000000001';
+
+select throws_ok(
+  $$select private.authorize_attempt_production_promotion_v1(
+    '73000000-0000-4000-8000-000000000001',
+    '74000000-0000-4000-8000-000000000001',
+    '75000000-0000-4000-8000-000000000001',
+    7, 0, 'reconciler:forged', 900, 600
+  )$$,
+  'P0001',
+  'Invalid production broker lock identity',
+  'a workflow attempt cannot forge the reconciler lock namespace'
+);
+
+insert into promotion_results(label, result)
+select 'authorized', private.authorize_attempt_production_promotion_v1(
+  '73000000-0000-4000-8000-000000000001',
+  '74000000-0000-4000-8000-000000000001',
+  '75000000-0000-4000-8000-000000000001',
+  7, 0,
+  'broker:74000000-0000-4000-8000-000000000001:75000000-0000-4000-8000-000000000001',
+  900, 600
+);
+select is(
+  (select result ->> 'already_committed'
+   from promotion_results where label = 'authorized'),
+  'false',
+  'the current live attempt receives a forward authorization'
+);
+
+select is(
+  (
+    select status
+    from private.content_outbox
+    where site_release_id = '73000000-0000-4000-8000-000000000001'
+  ),
+  'promoting',
+  'authorization atomically marks the current attempt promoting'
+);
+select ok(
+  (
+    select lease_expires_at >= clock_timestamp() + interval '14 minutes'
+    from private.content_outbox
+    where site_release_id = '73000000-0000-4000-8000-000000000001'
+  ),
+  'authorization renews the attempt beyond the production slot window'
+);
+
+update private.content_outbox
+set attempt_token = '75000000-0000-4000-8000-000000000002',
+    execution_generation = 8,
+    status = 'claimed',
+    lease_expires_at = clock_timestamp() + interval '30 minutes'
+where site_release_id = '73000000-0000-4000-8000-000000000001';
+select throws_ok(
+  format(
+    $sql$select private.commit_attempt_production_promotion_v1(
+      %L::uuid, %L::uuid, %L::uuid, 7, %L::bigint, 0,
+      %L, %L, %L, %L, %L::jsonb
+    )$sql$,
+    '73000000-0000-4000-8000-000000000001',
+    '74000000-0000-4000-8000-000000000001',
+    '75000000-0000-4000-8000-000000000001',
+    (select result ->> 'fencing_token'
+     from promotion_results where label = 'authorized'),
+    '76000000-0000-4000-8000-000000000001',
+    repeat('a', 64),
+    repeat('c', 64),
+    'node22.17-astro7-hugo0.147.9-v1',
+    jsonb_build_object('multi_edge_verified', true)::text
+  ),
+  'P0001',
+  'Stale production deployment attempt',
+  'a reclaimed attempt fences the old production commit'
+);
+
+select is(
+  (select count(*) from private.release_current_pointer),
+  0::bigint,
+  'a fenced old commit cannot advance the production pointer'
+);
+
+update private.content_outbox
+set attempt_token = '75000000-0000-4000-8000-000000000001',
+    execution_generation = 7,
+    status = 'promoting',
+    lease_expires_at = clock_timestamp() + interval '15 minutes'
+where site_release_id = '73000000-0000-4000-8000-000000000001';
+select private.mark_promotion_deploying_v1(
+  '73000000-0000-4000-8000-000000000001',
+  (select (result ->> 'fencing_token')::bigint
+   from promotion_results where label = 'authorized'),
+  0
+);
+select private.mark_promotion_verifying_v1(
+  '73000000-0000-4000-8000-000000000001',
+  (select (result ->> 'fencing_token')::bigint
+   from promotion_results where label = 'authorized'),
+  0,
+  '76000000-0000-4000-8000-000000000001'
+);
+insert into promotion_results(label, result)
+select 'committed', private.commit_attempt_production_promotion_v1(
+  '73000000-0000-4000-8000-000000000001',
+  '74000000-0000-4000-8000-000000000001',
+  '75000000-0000-4000-8000-000000000001',
+  7,
+  (select (result ->> 'fencing_token')::bigint
+   from promotion_results where label = 'authorized'),
+  0,
+  '76000000-0000-4000-8000-000000000001',
+  repeat('a', 64),
+  repeat('c', 64),
+  'node22.17-astro7-hugo0.147.9-v1',
+  '{"multi_edge_verified":true}'
+);
+
+select is(
+  (select target_site_release_id::text from private.release_current_pointer),
+  '73000000-0000-4000-8000-000000000001',
+  'the current attempt can commit the exact release'
+);
+select is(
+  (
+    select status
+    from private.content_outbox
+    where site_release_id = '73000000-0000-4000-8000-000000000001'
+  ),
+  'deployed',
+  'the fenced commit marks only the current attempt deployed'
+);
+select is(
+  (select result ->> 'execution_generation'
+   from promotion_results where label = 'committed'),
+  '7',
+  'commit evidence retains the execution generation'
+);
+
+insert into promotion_results(label, result)
+select 'retry', private.authorize_attempt_production_promotion_v1(
+  '73000000-0000-4000-8000-000000000001',
+  '74000000-0000-4000-8000-000000000001',
+  '75000000-0000-4000-8000-000000000001',
+  7, 1,
+  'broker:74000000-0000-4000-8000-000000000001:75000000-0000-4000-8000-000000000001',
+  900, 600
+);
+select is(
+  (select result ->> 'already_committed'
+   from promotion_results where label = 'retry'),
+  'true',
+  'the exact committed attempt receives a no-side-effect idempotent result'
+);
+
+select * from finish();
+rollback;

--- a/supabase/tests/database/release_attempt_checkpoints.test.sql
+++ b/supabase/tests/database/release_attempt_checkpoints.test.sql
@@ -1,0 +1,349 @@
+begin;
+
+create extension if not exists pgtap with schema extensions;
+select plan(22);
+
+select has_column(
+  'private', 'content_outbox', 'attempt_token',
+  'outbox stores the active attempt token'
+);
+select has_column(
+  'private', 'content_outbox', 'execution_generation',
+  'outbox stores the monotonic execution generation'
+);
+select has_column(
+  'private', 'release_deployment_checkpoints', 'originating_attempt_token',
+  'checkpoints retain the attempt token that first produced the evidence'
+);
+select has_column(
+  'private', 'release_deployment_checkpoints',
+  'originating_execution_generation',
+  'checkpoints retain the generation that first produced the evidence'
+);
+select ok(
+  exists (
+    select 1
+    from pg_index index_row
+    join pg_class relation on relation.oid = index_row.indrelid
+    join pg_namespace namespace on namespace.oid = relation.relnamespace
+    where namespace.nspname = 'private'
+      and relation.relname = 'content_outbox'
+      and index_row.indisunique
+      and position(
+        'attempt_token IS NOT NULL'
+        in pg_get_expr(index_row.indpred, index_row.indrelid)
+      ) > 0
+  ),
+  'non-null attempt tokens are unique across outbox rows'
+);
+select ok(
+  (
+    select relrowsecurity and relforcerowsecurity
+    from pg_class relation
+    join pg_namespace namespace on namespace.oid = relation.relnamespace
+    where namespace.nspname = 'private'
+      and relation.relname = 'release_deployment_checkpoints'
+  ),
+  'checkpoint evidence is protected by forced RLS'
+);
+select ok(
+  has_table_privilege(
+    'content_rpc_owner', 'private.release_deployment_checkpoints', 'select'
+  )
+    and has_table_privilege(
+      'content_rpc_owner', 'private.release_deployment_checkpoints', 'insert'
+    )
+    and has_table_privilege(
+      'content_rpc_owner', 'private.release_deployment_checkpoints', 'update'
+    ),
+  'the no-login RPC owner can maintain checkpoints'
+);
+select ok(
+  has_table_privilege(
+    'content_backup', 'private.release_deployment_checkpoints', 'select'
+  )
+    and not has_table_privilege(
+      'content_backup', 'private.release_deployment_checkpoints', 'insert'
+    )
+    and not has_table_privilege(
+      'content_backup', 'private.release_deployment_checkpoints', 'update'
+    )
+    and not has_table_privilege(
+      'content_backup', 'private.release_deployment_checkpoints', 'delete'
+    ),
+  'the backup role remains read-only'
+);
+select ok(
+  not exists (
+    select 1
+    from unnest(array[
+      'anon', 'authenticated', 'service_role', 'content_ingestor',
+      'content_editor', 'content_controller', 'content_reader',
+      'content_deployer'
+    ]) role_name
+    where has_table_privilege(
+      role_name, 'private.release_deployment_checkpoints', 'select'
+    )
+      or has_table_privilege(
+        role_name, 'private.release_deployment_checkpoints', 'insert'
+      )
+      or has_table_privilege(
+        role_name, 'private.release_deployment_checkpoints', 'update'
+      )
+      or has_table_privilege(
+        role_name, 'private.release_deployment_checkpoints', 'delete'
+      )
+  ),
+  'runtime roles cannot access checkpoint rows directly'
+);
+
+create temporary table checkpoint_claims (
+  label text primary key,
+  result jsonb not null
+);
+create temporary table checkpoint_plans (
+  label text primary key,
+  result jsonb not null
+);
+grant all on checkpoint_claims, checkpoint_plans
+  to content_rpc_owner, content_deployer;
+
+set local role content_rpc_owner;
+insert into private.site_releases(
+  id, sequence, manifest_object_key, manifest_byte_length, manifest_sha256,
+  content_root_sha256, schema_version, taxonomy_version, serializer_version,
+  search_contract_version, source_contract_version, structured_cutover_date,
+  no_report_days
+) values (
+  '71000000-0000-4000-8000-000000000001', 971001,
+  'site-manifests/sha256/bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb.json',
+  100, repeat('b', 64), repeat('c', 64), 1, 1,
+  'daily-json-c14n-v1', 'search-v1', 'daily-source-v1', '2026-07-16', '{}'
+);
+insert into private.release_artifacts(
+  site_release_id, object_key, byte_length, artifact_sha256,
+  artifact_fingerprint_sha256, hash_algorithm, code_sha,
+  build_environment_version
+) values (
+  '71000000-0000-4000-8000-000000000001',
+  'artifacts/sha256/dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd.json',
+  100, repeat('d', 64), repeat('e', 64),
+  'sha256-content-addressed-pages-v1', repeat('3', 40),
+  'node22.17-astro7-hugo0.147.9-v1'
+);
+insert into private.content_outbox(
+  site_release_id, dispatch_id, payload
+) values (
+  '71000000-0000-4000-8000-000000000001',
+  '72000000-0000-4000-8000-000000000001',
+  '{"mode":"production"}'
+);
+reset role;
+
+set local role content_rpc_owner;
+insert into checkpoint_claims(label, result)
+select 'first', private.claim_content_outbox_v1('checkpoint-test-first', 1800);
+select private.record_deployment_checkpoint_v2(
+  '71000000-0000-4000-8000-000000000001',
+  '72000000-0000-4000-8000-000000000001',
+  (select (result ->> 'attempt_token')::uuid
+   from checkpoint_claims where label = 'first'),
+  (select (result ->> 'execution_generation')::bigint
+   from checkpoint_claims where label = 'first'),
+  'artifact_registered',
+  jsonb_build_object(
+    'artifact_sha256', repeat('d', 64),
+    'content_sha256', repeat('c', 64),
+    'code_sha', repeat('3', 40),
+    'resume_contract_version', 'r2-materialize-v1'
+  )
+);
+select private.record_deployment_checkpoint_v2(
+  '71000000-0000-4000-8000-000000000001',
+  '72000000-0000-4000-8000-000000000001',
+  (select (result ->> 'attempt_token')::uuid
+   from checkpoint_claims where label = 'first'),
+  (select (result ->> 'execution_generation')::bigint
+   from checkpoint_claims where label = 'first'),
+  'preview_verified',
+  jsonb_build_object(
+    'artifact_sha256', repeat('d', 64),
+    'content_sha256', repeat('c', 64),
+    'code_sha', repeat('3', 40),
+    'preview_url', 'https://first-preview.example.invalid',
+    'resume_contract_version', 'r2-materialize-v1'
+  )
+);
+reset role;
+set local role content_rpc_owner;
+select is(
+  (select (result ->> 'execution_generation')::bigint
+   from checkpoint_claims where label = 'first'),
+  1::bigint,
+  'the first claim starts generation one'
+);
+select is(
+  (select count(*) from private.release_deployment_checkpoints
+   where site_release_id = '71000000-0000-4000-8000-000000000001'),
+  2::bigint,
+  'the first attempt records artifact and preview checkpoints'
+);
+select is(
+  (
+    select count(distinct originating_attempt_token)
+    from private.release_deployment_checkpoints
+    where site_release_id = '71000000-0000-4000-8000-000000000001'
+      and originating_attempt_token = (
+        select (result ->> 'attempt_token')::uuid
+        from checkpoint_claims where label = 'first'
+      )
+      and originating_execution_generation = 1
+  ),
+  1::bigint,
+  'both checkpoints retain the originating fenced attempt'
+);
+
+set local role content_rpc_owner;
+update private.content_outbox
+set lease_expires_at = clock_timestamp() - interval '1 second'
+where site_release_id = '71000000-0000-4000-8000-000000000001';
+reset role;
+
+set local role content_rpc_owner;
+insert into checkpoint_claims(label, result)
+select 'second', private.claim_content_outbox_v1('checkpoint-test-second', 1800);
+select private.record_deployment_checkpoint_v2(
+  '71000000-0000-4000-8000-000000000001',
+  '72000000-0000-4000-8000-000000000001',
+  (select (result ->> 'attempt_token')::uuid
+   from checkpoint_claims where label = 'second'),
+  (select (result ->> 'execution_generation')::bigint
+   from checkpoint_claims where label = 'second'),
+  'preview_verified',
+  jsonb_build_object(
+    'artifact_sha256', repeat('d', 64),
+    'content_sha256', repeat('c', 64),
+    'code_sha', repeat('3', 40),
+    'preview_url', 'https://first-preview.example.invalid',
+    'resume_contract_version', 'r2-materialize-v1'
+  )
+);
+insert into checkpoint_plans(label, result)
+select 'second', private.get_content_release_resume_plan_v1(
+  '71000000-0000-4000-8000-000000000001',
+  '72000000-0000-4000-8000-000000000001',
+  (select (result ->> 'attempt_token')::uuid
+   from checkpoint_claims where label = 'second')
+);
+reset role;
+set local role content_rpc_owner;
+select is(
+  (select (result ->> 'execution_generation')::bigint
+   from checkpoint_claims where label = 'second'),
+  2::bigint,
+  'a reclaimed outbox row advances its execution generation'
+);
+select isnt(
+  (select result ->> 'attempt_token'
+   from checkpoint_claims where label = 'second'),
+  (select result ->> 'attempt_token'
+   from checkpoint_claims where label = 'first'),
+  'a reclaimed outbox row receives a fresh attempt token'
+);
+select is(
+  (select count(*) from private.release_deployment_checkpoints
+   where site_release_id = '71000000-0000-4000-8000-000000000001'),
+  2::bigint,
+  'a later attempt reuses identical checkpoint evidence without replacing it'
+);
+select is(
+  (
+    select originating_attempt_token::text
+    from private.release_deployment_checkpoints
+    where site_release_id = '71000000-0000-4000-8000-000000000001'
+      and stage = 'preview_verified'
+  ),
+  (select result ->> 'attempt_token'
+   from checkpoint_claims where label = 'first'),
+  'checkpoint reuse preserves the original attempt token'
+);
+select is(
+  (
+    select count(*)
+    from private.release_deployment_attempts
+    where site_release_id = '71000000-0000-4000-8000-000000000001'
+      and event_type = 'preview_verified'
+  ),
+  2::bigint,
+  'checkpoint reuse still appends an audit event for the new attempt'
+);
+set local role content_rpc_owner;
+select throws_ok(
+  format(
+    $sql$select private.record_deployment_checkpoint_v2(
+      %L::uuid, %L::uuid, %L::uuid, %L::bigint, 'preview_verified',
+      %L::jsonb
+    )$sql$,
+    '71000000-0000-4000-8000-000000000001',
+    '72000000-0000-4000-8000-000000000001',
+    (select result ->> 'attempt_token'
+     from checkpoint_claims where label = 'second'),
+    (select result ->> 'execution_generation'
+     from checkpoint_claims where label = 'second'),
+    jsonb_build_object(
+      'artifact_sha256', repeat('d', 64),
+      'content_sha256', repeat('c', 64),
+      'code_sha', repeat('3', 40),
+      'preview_url', 'https://different-preview.example.invalid',
+      'resume_contract_version', 'r2-materialize-v1'
+    )::text
+  ),
+  'P0001',
+  'Deployment checkpoint identity collision',
+  'a later attempt cannot replace immutable preview identity'
+);
+reset role;
+set local role content_rpc_owner;
+select is(
+  (select result ->> 'resume_stage'
+   from checkpoint_plans where label = 'second'),
+  'promote',
+  'the server resumes at promotion only after exact checkpoint validation'
+);
+select is(
+  (select result #>> '{preview_checkpoint,artifact_sha256}'
+   from checkpoint_plans where label = 'second'),
+  repeat('d', 64),
+  'the resume plan returns the exact checkpoint artifact identity'
+);
+select is(
+  (select result #>> '{preview_checkpoint,preview_url}'
+   from checkpoint_plans where label = 'second'),
+  'https://first-preview.example.invalid',
+  'the resume plan returns the immutable verified preview URL'
+);
+
+set local role content_rpc_owner;
+update private.release_deployment_checkpoints
+set evidence = evidence - 'resume_contract_version'
+where site_release_id = '71000000-0000-4000-8000-000000000001';
+reset role;
+
+set local role content_rpc_owner;
+insert into checkpoint_plans(label, result)
+select 'legacy', private.get_content_release_resume_plan_v1(
+  '71000000-0000-4000-8000-000000000001',
+  '72000000-0000-4000-8000-000000000001',
+  (select (result ->> 'attempt_token')::uuid
+   from checkpoint_claims where label = 'second')
+);
+reset role;
+select is(
+  (select result ->> 'resume_stage'
+   from checkpoint_plans where label = 'legacy'),
+  'build',
+  'checkpoints without the materializer capability contract fail closed to build'
+);
+
+select * from finish();
+rollback;

--- a/supabase/tests/database/scheduled_run_observability.test.sql
+++ b/supabase/tests/database/scheduled_run_observability.test.sql
@@ -1,0 +1,108 @@
+begin;
+
+create extension if not exists pgtap with schema extensions;
+select plan(10);
+
+select has_table(
+  'private',
+  'scheduled_run_observability_events',
+  'append-only scheduled run evidence table exists'
+);
+select has_table(
+  'private',
+  'scheduled_run_observability_current',
+  'current scheduled run projection exists'
+);
+select ok(
+  has_function_privilege(
+    'content_ingestor',
+    'private.record_scheduled_run_trace_v1(text,timestamptz,text,jsonb)',
+    'execute'
+  ),
+  'ingestor can append scheduled run evidence'
+);
+select ok(
+  not has_function_privilege(
+    'content_editor',
+    'private.record_scheduled_run_trace_v1(text,timestamptz,text,jsonb)',
+    'execute'
+  )
+  and not has_function_privilege(
+    'content_deployer',
+    'private.record_scheduled_run_trace_v1(text,timestamptz,text,jsonb)',
+    'execute'
+  ),
+  'non-ingestor runtime roles cannot forge scheduled run evidence'
+);
+select ok(
+  not has_table_privilege(
+    'content_ingestor',
+    'private.scheduled_run_observability_events',
+    'insert'
+  )
+  and not has_table_privilege(
+    'content_deployer',
+    'private.scheduled_run_observability_current',
+    'update'
+  ),
+  'runtime roles cannot bypass scheduled run RPCs'
+);
+select ok(
+  has_function_privilege(
+    'content_deployer',
+    'private.get_content_observability_v1()',
+    'execute'
+  ),
+  'deployer can read the current run evidence projection'
+);
+select ok(
+  has_function_privilege(
+    'content_deployer',
+    'private.get_content_observation_window_v1(date)',
+    'execute'
+  ),
+  'deployer can read the two-day run evidence window'
+);
+
+set local role content_rpc_owner;
+select throws_ok(
+  $$select private.record_scheduled_run_trace_v1(
+    'scheduled:0',
+    date_trunc('hour', current_timestamp) + interval '30 minutes',
+    'started',
+    '{"status":"started","stage":"started"}'::jsonb
+  )$$,
+  '22023',
+  'Invalid scheduled run trace',
+  'off-contract half-hour traces fail closed'
+);
+select is(
+  (
+    private.get_content_observation_window_v1(
+      (current_timestamp at time zone 'Asia/Shanghai')::date - 2
+    ) ->> 'ready_at'
+  )::timestamptz,
+  (
+    (
+      (current_timestamp at time zone 'Asia/Shanghai')::date
+    )::timestamp at time zone 'Asia/Shanghai'
+  ) + interval '4 hours 10 minutes',
+  'two-day gate closes after the final 04:00 run deadline'
+);
+select ok(
+  position(
+    'Finalized site release is missing its dispatch identity'
+    in (
+      select p.prosrc
+      from pg_proc p
+      join pg_namespace n on n.oid = p.pronamespace
+      where n.nspname = 'private'
+        and p.proname = 'finalize_site_release_v1'
+    )
+  ) > 0,
+  'idempotent finalize returns the existing outbox dispatch identity'
+);
+reset role;
+
+select * from finish();
+rollback;

--- a/tests/worker/contentArtifactMaterialize.test.js
+++ b/tests/worker/contentArtifactMaterialize.test.js
@@ -1,0 +1,167 @@
+import { createHash } from "node:crypto";
+import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { createContentAddressedArtifact } from "../../scripts/create-content-addressed-artifact.mjs";
+import { materializeContentAddressedArtifact } from "../../scripts/materialize-content-addressed-artifact.mjs";
+
+const RELEASE_ID = "22222222-2222-4222-8222-222222222222";
+const CODE_SHA = "b".repeat(40);
+const CONTENT_SHA = "c".repeat(64);
+const temporaryDirectories = [];
+
+function sha256(bytes) {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+class MemoryObjectStore {
+  objects = new Map();
+  reads = [];
+
+  async get(key) {
+    this.reads.push(key);
+    const value = this.objects.get(key);
+    if (!value) throw new Error(`missing object: ${key}`);
+    return Buffer.from(value);
+  }
+}
+
+async function fixture() {
+  const root = await mkdtemp(join(tmpdir(), "content-artifact-materialize-"));
+  temporaryDirectories.push(root);
+  const source = join(root, "source");
+  await mkdir(join(source, "release-manifests"), { recursive: true });
+  const page = Buffer.from("<h1>release</h1>\n");
+  await writeFile(join(source, "index.html"), page);
+  const fingerprint = sha256(
+    Buffer.from(`index.html\0${sha256(page)}\n`, "utf8"),
+  );
+  await writeFile(
+    join(source, "release-manifests/site-route-manifest.json"),
+    `${JSON.stringify({
+      build: {
+        hash_algorithm: "sha256-path-and-content-v1",
+        artifact_sha256: fingerprint,
+        site_release_id: RELEASE_ID,
+        code_sha: CODE_SHA,
+        content_sha256: CONTENT_SHA,
+      },
+    })}\n`,
+  );
+  const artifact = await createContentAddressedArtifact(source);
+  const store = new MemoryObjectStore();
+  store.objects.set(artifact.artifact_object_key, artifact.bytes);
+  for (const file of artifact.manifest.files) {
+    store.objects.set(file.object_key, await readFile(join(source, file.path)));
+  }
+  const descriptor = {
+    site_release_id: RELEASE_ID,
+    object_key: artifact.artifact_object_key,
+    byte_length: artifact.bytes.byteLength,
+    artifact_sha256: artifact.artifact_sha256,
+    artifact_fingerprint_sha256: artifact.manifest.artifact_fingerprint_sha256,
+    hash_algorithm: artifact.manifest.hash_algorithm,
+    code_sha: CODE_SHA,
+    content_sha256: CONTENT_SHA,
+  };
+  return {
+    root,
+    source,
+    target: join(root, "target"),
+    artifact,
+    descriptor,
+    store,
+  };
+}
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryDirectories
+      .splice(0)
+      .map((directory) => rm(directory, { recursive: true, force: true })),
+  );
+});
+
+describe("content-addressed artifact materialization", () => {
+  it("downloads and verifies the exact inventory and every asset", async () => {
+    const value = await fixture();
+    const result = await materializeContentAddressedArtifact({
+      descriptor: value.descriptor,
+      expectedSiteReleaseId: RELEASE_ID,
+      expectedCodeSha: CODE_SHA,
+      expectedContentSha256: CONTENT_SHA,
+      targetRoot: value.target,
+      store: value.store,
+      concurrency: 2,
+    });
+
+    expect(result).toMatchObject({
+      site_release_id: RELEASE_ID,
+      artifact_sha256: value.artifact.artifact_sha256,
+      file_count: 2,
+      unique_object_reads: 2,
+    });
+    expect(await readFile(join(value.target, "index.html"), "utf8")).toBe(
+      "<h1>release</h1>\n",
+    );
+    expect(value.store.reads).toHaveLength(3);
+  });
+
+  it("fails closed when inventory bytes do not match the descriptor", async () => {
+    const value = await fixture();
+    value.store.objects.set(
+      value.artifact.artifact_object_key,
+      Buffer.from("{}\n"),
+    );
+    await expect(
+      materializeContentAddressedArtifact({
+        descriptor: value.descriptor,
+        expectedSiteReleaseId: RELEASE_ID,
+        expectedCodeSha: CODE_SHA,
+        expectedContentSha256: CONTENT_SHA,
+        targetRoot: value.target,
+        store: value.store,
+      }),
+    ).rejects.toThrow("inventory byte identity mismatch");
+  });
+
+  it("fails closed and preserves the previous target on corrupt assets", async () => {
+    const value = await fixture();
+    await mkdir(value.target, { recursive: true });
+    await writeFile(join(value.target, "keep.txt"), "last known good\n");
+    const index = value.artifact.manifest.files.find(
+      (file) => file.path === "index.html",
+    );
+    value.store.objects.set(index.object_key, Buffer.from("corrupt"));
+
+    await expect(
+      materializeContentAddressedArtifact({
+        descriptor: value.descriptor,
+        expectedSiteReleaseId: RELEASE_ID,
+        expectedCodeSha: CODE_SHA,
+        expectedContentSha256: CONTENT_SHA,
+        targetRoot: value.target,
+        store: value.store,
+      }),
+    ).rejects.toThrow("asset identity mismatch");
+    expect(await readFile(join(value.target, "keep.txt"), "utf8")).toBe(
+      "last known good\n",
+    );
+  });
+
+  it("rejects a descriptor for a different release identity", async () => {
+    const value = await fixture();
+    await expect(
+      materializeContentAddressedArtifact({
+        descriptor: value.descriptor,
+        expectedSiteReleaseId: "33333333-3333-4333-8333-333333333333",
+        expectedCodeSha: CODE_SHA,
+        expectedContentSha256: CONTENT_SHA,
+        targetRoot: value.target,
+        store: value.store,
+      }),
+    ).rejects.toThrow("does not match workflow identity");
+    expect(value.store.reads).toHaveLength(0);
+  });
+});

--- a/tests/worker/contentArtifactUpload.test.js
+++ b/tests/worker/contentArtifactUpload.test.js
@@ -14,17 +14,41 @@ function sha256(bytes) {
 
 class MemoryObjectStore {
   objects = new Map();
+  puts = [];
+  gets = [];
 
   async putIfAbsent(key, _path, bytes) {
+    this.puts.push(key);
     if (this.objects.has(key)) throw new Error("precondition failed");
     this.objects.set(key, Buffer.from(bytes));
   }
 
   async get(key) {
+    this.gets.push(key);
     const bytes = this.objects.get(key);
     if (!bytes) throw new Error("object missing");
     return Buffer.from(bytes);
   }
+}
+
+function trustedBaseline(artifact, overrides = {}) {
+  return {
+    descriptor: {
+      production_verified: true,
+      hash_algorithm: "sha256-content-addressed-pages-v1",
+      verification_profile: "r2-full-get-sha256-indefinite-lock-v1",
+      object_key: artifact.artifact_object_key,
+      artifact_sha256: artifact.artifact_sha256,
+      artifact_fingerprint_sha256:
+        artifact.manifest.artifact_fingerprint_sha256,
+      byte_length: artifact.bytes.byteLength,
+      site_release_id: "22222222-2222-4222-8222-222222222222",
+      lock_evidence_sha256: "f".repeat(64),
+      r2_verified_at: "2026-07-24T20:00:00.000Z",
+      ...overrides,
+    },
+    manifestBytes: artifact.bytes,
+  };
 }
 
 async function fixture() {
@@ -44,6 +68,7 @@ async function fixture() {
       build: {
         hash_algorithm: "sha256-path-and-content-v1",
         artifact_sha256: fingerprint,
+        site_release_id: "22222222-2222-4222-8222-222222222222",
       },
     })}\n`,
   );
@@ -95,6 +120,110 @@ describe("content-addressed artifact R2 upload", () => {
         store,
       }),
     ).rejects.toThrow("Critical content-address collision");
+  });
+
+  it("performs zero PUTs and GETs for object keys in a verified baseline", async () => {
+    const value = await fixture();
+    const store = new MemoryObjectStore();
+    const options = {
+      manifestPath: value.manifestPath,
+      distRoot: value.dist,
+      artifactObjectKey: value.artifact.artifact_object_key,
+      expectedManifestSha256: value.artifact.artifact_sha256,
+      store,
+    };
+    await uploadContentAddressedArtifact(options);
+    store.puts = [];
+    store.gets = [];
+
+    const result = await uploadContentAddressedArtifact({
+      ...options,
+      incrementalReuseEnabled: true,
+      trustedBaseline: trustedBaseline(value.artifact),
+    });
+
+    expect(result).toMatchObject({
+      trusted_reused: 2,
+      reused: 1,
+      trusted_baseline_status: "verified",
+    });
+    expect(store.puts).toEqual([value.artifact.artifact_object_key]);
+    expect(store.gets).toEqual([value.artifact.artifact_object_key]);
+  });
+
+  it("falls back to full verification when baseline provenance is incomplete", async () => {
+    const value = await fixture();
+    const store = new MemoryObjectStore();
+    await uploadContentAddressedArtifact({
+      manifestPath: value.manifestPath,
+      distRoot: value.dist,
+      artifactObjectKey: value.artifact.artifact_object_key,
+      expectedManifestSha256: value.artifact.artifact_sha256,
+      store,
+    });
+    store.puts = [];
+    store.gets = [];
+
+    const result = await uploadContentAddressedArtifact({
+      manifestPath: value.manifestPath,
+      distRoot: value.dist,
+      artifactObjectKey: value.artifact.artifact_object_key,
+      expectedManifestSha256: value.artifact.artifact_sha256,
+      store,
+      incrementalReuseEnabled: true,
+      trustedBaseline: trustedBaseline(value.artifact, {
+        production_verified: false,
+      }),
+    });
+
+    expect(result.trusted_reused).toBe(0);
+    expect(result.trusted_baseline_status).toBe(
+      "Trusted baseline provenance is invalid",
+    );
+    expect(store.puts).toHaveLength(3);
+    expect(store.gets).toHaveLength(3);
+  });
+
+  it("fully verifies an object absent from the verified baseline", async () => {
+    const successor = await fixture();
+    const baselineManifest = {
+      ...successor.artifact.manifest,
+      files: successor.artifact.manifest.files.filter(
+        (file) => file.path !== "index.html",
+      ),
+    };
+    baselineManifest.file_count = baselineManifest.files.length;
+    baselineManifest.total_asset_bytes = baselineManifest.files.reduce(
+      (total, file) => total + file.byte_length,
+      0,
+    );
+    const baselineBytes = Buffer.from(
+      `${JSON.stringify(baselineManifest, null, 2)}\n`,
+    );
+    const baseline = {
+      manifest: baselineManifest,
+      artifact_sha256: sha256(baselineBytes),
+      artifact_object_key: `artifacts/sha256/${sha256(baselineBytes)}.json`,
+      bytes: baselineBytes,
+    };
+    const store = new MemoryObjectStore();
+
+    const result = await uploadContentAddressedArtifact({
+      manifestPath: successor.manifestPath,
+      distRoot: successor.dist,
+      artifactObjectKey: successor.artifact.artifact_object_key,
+      expectedManifestSha256: successor.artifact.artifact_sha256,
+      store,
+      incrementalReuseEnabled: true,
+      trustedBaseline: trustedBaseline(baseline),
+    });
+    const newAsset = successor.artifact.manifest.files.find(
+      (file) => file.path === "index.html",
+    );
+
+    expect(result.trusted_reused).toBe(1);
+    expect(store.puts).toContain(newAsset.object_key);
+    expect(store.gets).toContain(newAsset.object_key);
   });
 
   it("rejects local asset drift before writing any object", async () => {

--- a/tests/worker/contentMirror.test.js
+++ b/tests/worker/contentMirror.test.js
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 import {
     mirrorStructuredReport,
     publicationBatchId,
+    recordScheduledRunTrace,
     resolveForwardBuildCodeSha,
 } from '../../workers/content/ingestion/mirror.ts';
 import { canonicalJsonBytes } from '../../workers/content/shared/canonical.ts';
@@ -132,6 +133,53 @@ function input(value = report()) {
 }
 
 describe('structured content database mirror', () => {
+    it('records scheduled run traces through the ingestor-only RPC', async () => {
+        const db = database();
+        db.sql.mockImplementationOnce(async (strings, ...values) => {
+            const query = strings.join(' ');
+            db.calls.push({ query, values });
+            expect(query).toContain('record_scheduled_run_trace_v1');
+            return [{
+                result: {
+                    run_id: 'scheduled:1784001600000',
+                    status: 'started',
+                },
+            }];
+        });
+
+        await expect(recordScheduledRunTrace(
+            enabledEnv(),
+            {
+                runId: 'scheduled:1784001600000',
+                scheduledAt: '2026-07-14T00:00:00.000Z',
+                eventType: 'started',
+                evidence: {
+                    status: 'started',
+                    stage: 'started',
+                    started_at: '2026-07-14T00:00:01.000Z',
+                    finished_at: null,
+                },
+            },
+            { openDatabase: () => db.sql },
+        )).resolves.toBe(true);
+        expect(db.sql.end).toHaveBeenCalledWith({ timeout: 2 });
+    });
+
+    it('does not open the content database when mirroring is disabled', async () => {
+        const openDatabase = vi.fn();
+        await expect(recordScheduledRunTrace(
+            { CONTENT_DATABASE_MIRROR_ENABLED: 'false' },
+            {
+                runId: 'scheduled:1784001600000',
+                scheduledAt: '2026-07-14T00:00:00.000Z',
+                eventType: 'started',
+                evidence: { status: 'started', stage: 'started' },
+            },
+            { openDatabase },
+        )).resolves.toBe(false);
+        expect(openDatabase).not.toHaveBeenCalled();
+    });
+
     it('pins a delayed mirror to current main when the source commit is its ancestor', async () => {
         const mainSha = 'b'.repeat(40);
         const api = vi

--- a/tests/worker/contentObservability.test.js
+++ b/tests/worker/contentObservability.test.js
@@ -1,8 +1,9 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { SHARED_CONTENT_PROJECT_ACK } from "../../scripts/content-database-topology.mjs";
 import {
   dueContentBatches,
   evaluateContentObservability,
+  scheduledRunHealth,
   validateContentObservabilityEnvironment,
 } from "../../scripts/check-content-observability.mjs";
 import {
@@ -24,6 +25,23 @@ const CURRENT = {
 
 function healthyInput() {
   const due = dueContentBatches(NOW);
+  const dispatchId = "33333333-3333-4333-8333-333333333333";
+  const scheduledOutcomes = due.map((batch) => ({
+    run_id: batch.run_id,
+    scheduled_at: batch.scheduled_at,
+    status: "succeeded",
+    started_at: batch.scheduled_at,
+    finished_at: new Date(
+      Date.parse(batch.scheduled_at) + 60_000,
+    ).toISOString(),
+    source_result: { status: "succeeded" },
+    content_sha256: "e".repeat(64),
+    no_op: false,
+    database_mirror: { status: "mirrored" },
+    site_release_id: CURRENT.site_release_id,
+    site_release_sequence: CURRENT.site_release_sequence,
+    dispatch_id: dispatchId,
+  }));
   return {
     analytics: {
       cache_hits: 900,
@@ -33,10 +51,7 @@ function healthyInput() {
     },
     cacheHitMinimum: 0.5,
     cacheSampleMinimum: 100,
-    scheduledOutcomes: due.map((batch) => ({
-      scheduled_at: batch.scheduled_at,
-      status: "succeeded",
-    })),
+    scheduledOutcomes,
     currentEndpoints: [
       { url: "https://api-one.invalid/v1/current", body: CURRENT },
       { url: "https://api-two.invalid/v1/current", body: CURRENT },
@@ -50,7 +65,16 @@ function healthyInput() {
       },
       publication_attempts: due.map((batch) => ({
         ...batch,
+        trigger_kind: batch.run_id,
         status: "succeeded",
+      })),
+      scheduled_runs: scheduledOutcomes.map((outcome) => ({
+        ...outcome,
+        scheduled_at: outcome.scheduled_at.replace(".000Z", "+00:00"),
+        started_at: outcome.started_at.replace(".000Z", "+00:00"),
+        finished_at: outcome.finished_at.replace(".000Z", "+00:00"),
+        database_mirror: { ...outcome.database_mirror },
+        source_result: { ...outcome.source_result },
       })),
       search_latest_report_date: due.at(-1).report_date,
     },
@@ -78,8 +102,11 @@ function healthyInput() {
 }
 
 describe("content observability evaluator", () => {
-  it("maps all five production UTC schedules to their report dates", () => {
-    expect(dueContentBatches(NOW)).toEqual(
+  it("maps every due production run through the shared sixteen-slot contract", () => {
+    const due = dueContentBatches(NOW);
+    expect(due).toHaveLength(19);
+    expect(new Set(due.map((run) => run.run_id)).size).toBe(due.length);
+    expect(due).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
           report_date: "2026-07-17",
@@ -88,7 +115,8 @@ describe("content observability evaluator", () => {
         }),
         expect.objectContaining({
           report_date: "2026-07-17",
-          batch_id: "lateNightSupplement",
+          batch_id: "lateNight",
+          publication_batch_id: "lateNightSupplement",
           scheduled_at: "2026-07-17T19:00:00.000Z",
         }),
         expect.objectContaining({
@@ -111,9 +139,92 @@ describe("content observability evaluator", () => {
     expect(result.analytics.cache_hit_ratio).toBe(0.9);
   });
 
+  it("fails when KV is healthy but the database current run trace is missing", () => {
+    const input = healthyInput();
+    const missing = input.database.scheduled_runs.shift();
+    const result = evaluateContentObservability(input, NOW);
+    expect(result.healthy).toBe(false);
+    expect(result.reasons).toContain(
+      `scheduled_run_database_trace_missing:${missing.run_id}:${dueContentBatches(NOW)[0].report_date}:${dueContentBatches(NOW)[0].batch_id}`,
+    );
+  });
+
+  it("requires a publication attempt for every changed run", () => {
+    const input = healthyInput();
+    const missing = input.database.publication_attempts.shift();
+    const due = dueContentBatches(NOW).find(
+      (run) => run.run_id === missing.trigger_kind,
+    );
+    const result = evaluateContentObservability(input, NOW);
+    expect(result.healthy).toBe(false);
+    expect(result.reasons).toContain(
+      `scheduled_run_database_attempt_missing:${due.run_id}:${due.report_date}:${due.batch_id}`,
+    );
+  });
+
+  it("allows a no-op without a new attempt but still requires its database trace", () => {
+    const input = healthyInput();
+    const noOpRun = input.database.scheduled_runs[0];
+    noOpRun.no_op = true;
+    input.scheduledOutcomes[0].no_op = true;
+    input.database.publication_attempts =
+      input.database.publication_attempts.filter(
+        (attempt) => attempt.trigger_kind !== noOpRun.run_id,
+      );
+
+    expect(evaluateContentObservability(input, NOW).healthy).toBe(true);
+
+    input.database.scheduled_runs.shift();
+    const result = evaluateContentObservability(input, NOW);
+    expect(result.healthy).toBe(false);
+    expect(result.reasons).toEqual(
+      expect.arrayContaining([
+        expect.stringMatching(/^scheduled_run_database_trace_missing:/),
+      ]),
+    );
+  });
+
+  it("fails when KV and database terminal identities diverge", () => {
+    const input = healthyInput();
+    input.database.scheduled_runs[0].dispatch_id =
+      "44444444-4444-4444-8444-444444444444";
+    const result = evaluateContentObservability(input, NOW);
+    expect(result.healthy).toBe(false);
+    expect(result.reasons).toEqual(
+      expect.arrayContaining([
+        expect.stringMatching(/^scheduled_run_database_trace_mismatch:/),
+      ]),
+    );
+  });
+
+  it("paginates a thirty-hour health query without exceeding sixteen slots", async () => {
+    const fetcher = vi.fn(async (url) => ({
+      success: true,
+      slots: url.searchParams.getAll("scheduled_at").map((scheduled_at) => ({
+        scheduled_at,
+        status: "succeeded",
+      })),
+    }));
+    const runs = await scheduledRunHealth(
+      {
+        scheduleHealthUrl: new URL("https://schedule.example.test/health/scheduled"),
+        scheduleHealthToken: "x".repeat(32),
+        startedAt: -Infinity,
+      },
+      NOW,
+      fetcher,
+    );
+
+    expect(fetcher).toHaveBeenCalledTimes(2);
+    expect(fetcher.mock.calls.every(([url]) =>
+      url.searchParams.getAll("scheduled_at").length <= 16
+    )).toBe(true);
+    expect(runs).toHaveLength(dueContentBatches(NOW).length);
+  });
+
   it("fails closed on missing batches, manifest drift, stale search and bad API signals", () => {
     const input = healthyInput();
-    input.database.publication_attempts.pop();
+    input.scheduledOutcomes.pop();
     input.database.search_latest_report_date = "2026-07-16";
     input.currentEndpoints[0].body = { ...CURRENT, site_release_sequence: 41 };
     input.staticManifests[0].body.build = {
@@ -132,7 +243,7 @@ describe("content observability evaluator", () => {
     expect(result.healthy).toBe(false);
     expect(result.reasons).toEqual(
       expect.arrayContaining([
-        expect.stringMatching(/^batch_terminal_missing:/),
+        expect.stringMatching(/^scheduled_run_missing:/),
         expect.stringMatching(/^current_manifest_drift:/),
         expect.stringMatching(/^static_manifest_drift:/),
         expect.stringMatching(/^search_stale:/),
@@ -245,7 +356,7 @@ describe("content observability production identity", () => {
 });
 
 const WINDOW_START = "2026-07-17";
-const WINDOW_NOW = Date.parse("2026-07-18T20:00:00.000Z");
+const WINDOW_NOW = Date.parse("2026-07-18T21:00:00.000Z");
 
 function healthyWindowInput() {
   const expected = expectedObservationSlots(WINDOW_START);
@@ -262,6 +373,9 @@ function healthyWindowInput() {
       code_sha: "f".repeat(40),
       edge_verified_at: new Date(
         Date.parse(entry.deadline) + 60_000,
+      ).toISOString(),
+      stable_verified_at: new Date(
+        Date.parse(entry.deadline) + 90_000,
       ).toISOString(),
       input_sha256: "e".repeat(64),
       outbox_active_leases: 0,
@@ -312,6 +426,7 @@ function healthyWindowInput() {
         site_release_sequence: slot.site_release_sequence,
       },
       due_batches: [expected[index]],
+      due_runs: [expected[index]],
       healthy: true,
       outbox: {},
       reasons: [],
@@ -326,7 +441,23 @@ function healthyWindowInput() {
       status: "succeeded",
       trigger_kind: entry.expected_trigger_kind,
     })),
-    ready_at: "2026-07-18T19:10:00.000Z",
+    scheduled_runs: expected.map((entry, index) => ({
+      run_id: entry.run_id,
+      scheduled_at: entry.scheduled_at,
+      started_at: entry.scheduled_at,
+      finished_at: new Date(
+        Date.parse(entry.scheduled_at) + 60_000,
+      ).toISOString(),
+      status: "succeeded",
+      source_result: { status: "succeeded" },
+      content_sha256: "e".repeat(64),
+      database_mirror: { status: "mirrored" },
+      no_op: false,
+      site_release_id: slots[index].site_release_id,
+      dispatch_id: `33333333-3333-4333-8${String(index).padStart(3, "0")}-${String(index + 1).padStart(12, "0")}`,
+      stable_verified_at: slots[index].stable_verified_at,
+    })),
+    ready_at: "2026-07-18T20:10:00.000Z",
     slots,
     start_at: "2026-07-16T16:00:00.000Z",
     start_date: WINDOW_START,
@@ -335,18 +466,19 @@ function healthyWindowInput() {
 }
 
 describe("two-day production observation gate", () => {
-  it("derives eight real canonical scheduled triggers including lateNight", () => {
+  it("derives all thirty-two real scheduled triggers including lateNight", () => {
     const slots = expectedObservationSlots(WINDOW_START);
-    expect(slots).toHaveLength(8);
-    expect(slots[3]).toMatchObject({
+    expect(slots).toHaveLength(32);
+    expect(slots).toContainEqual(expect.objectContaining({
       batch_id: "lateNight",
+      publication_batch_id: "lateNightSupplement",
       expected_trigger_kind: `scheduled:${Date.parse("2026-07-17T19:00:00.000Z")}`,
       report_date: "2026-07-17",
-    });
-    expect(slots[7].deadline).toBe("2026-07-18T19:10:00.000Z");
+    }));
+    expect(slots.at(-1).deadline).toBe("2026-07-18T20:10:00.000Z");
   });
 
-  it("passes only when all eight releases have immutable, edge and monitor evidence", () => {
+  it("passes only when all thirty-two runs have immutable, edge and monitor evidence", () => {
     const result = evaluateContentObservationWindow(
       healthyWindowInput(),
       WINDOW_NOW,
@@ -390,9 +522,9 @@ describe("two-day production observation gate", () => {
         "observation_contains_unhealthy_check",
         "manual_repair_actions:1",
         "production_failure_or_rollback_events:1",
-        "slot_noncanonical_trigger:2026-07-17:morning",
-        "slot_edge_evidence_invalid:2026-07-17:afternoon",
-        "slot_healthy_observation_missing:2026-07-17:night",
+        expect.stringMatching(/^scheduled_run_attempt_missing:/),
+        expect.stringMatching(/^slot_edge_evidence_invalid:/),
+        expect.stringMatching(/^slot_healthy_observation_missing:/),
       ]),
     );
   });

--- a/tests/worker/contentProductionConfig.test.js
+++ b/tests/worker/contentProductionConfig.test.js
@@ -346,6 +346,7 @@ describe("Supabase migration writer compatibility", () => {
       "20260717000900_content_publish_control_boundary.sql",
       "20260717001000_content_observability.sql",
       "20260717001100_content_observation_evidence.sql",
+      "20260724000400_scheduled_run_observability.sql",
     ];
     for (const migration of migrations) {
       const sql = readFileSync(`supabase/migrations/${migration}`, "utf8");

--- a/tests/worker/contentReleaseWorkflow.test.js
+++ b/tests/worker/contentReleaseWorkflow.test.js
@@ -1,0 +1,59 @@
+import { readFile } from "node:fs/promises";
+import { describe, expect, it } from "vitest";
+
+describe("fenced content release workflow", () => {
+  it("derives resume stages from the deployer and materializes R2 checkpoints", async () => {
+    const [workflow, deployerConfig] = await Promise.all([
+      readFile(
+        new URL("../../.github/workflows/content-release.yml", import.meta.url),
+        "utf8",
+      ),
+      readFile(
+        new URL("../../wrangler.content-deployer.toml", import.meta.url),
+        "utf8",
+      ),
+    ]);
+
+    expect(workflow).toContain("attempt_token:");
+    expect(workflow).toContain("execution_generation:");
+    expect(workflow).toContain(
+      'if [[ "$DEPLOYMENT_MODE" == "production" || -n "$DEPLOYMENT_ATTEMPT_TOKEN" || -n "$DEPLOYMENT_EXECUTION_GENERATION" ]]',
+    );
+    expect(workflow).toContain('--arg attempt "$DEPLOYMENT_ATTEMPT_TOKEN"');
+    expect(workflow).toContain(
+      '--argjson execution_generation "$DEPLOYMENT_EXECUTION_GENERATION"',
+    );
+    expect(workflow).toContain(
+      "attempt_token:$attempt,execution_generation:$execution_generation",
+    );
+    expect(workflow).not.toMatch(/^\s{6}resume_stage:/m);
+    expect(workflow).not.toMatch(/^\s{6}resume_plan:/m);
+    expect(workflow).toContain(
+      'node "$RUNNER_TEMP/content-release-helper.mjs" plan > server-resume-plan.json',
+    );
+    expect(
+      workflow.indexOf("Create immutable fenced release helper"),
+    ).toBeLessThan(workflow.indexOf("Checkout exact code SHA"));
+    expect(workflow).toContain(
+      "node scripts/materialize-content-addressed-artifact.mjs server-resume-plan.json astro/dist/client",
+    );
+    expect(workflow).toContain(
+      "if: ${{ steps.resume.outputs.stage == 'build' }}",
+    );
+    expect(workflow).toContain(
+      "if: ${{ steps.resume.outputs.stage != 'promote' }}",
+    );
+    expect(workflow).toContain(
+      'node scripts/verify-preview.mjs "$PREVIEW_URL" "$EXACT_CODE_SHA"',
+    );
+    expect(deployerConfig).toContain(
+      'CONTENT_RELEASE_RESUME_ENABLED = "false"',
+    );
+    expect(deployerConfig).toContain(
+      'CONTENT_RELEASE_INCREMENTAL_REUSE_ENABLED = "false"',
+    );
+    expect(deployerConfig).toContain(
+      'CONTENT_RELEASE_REQUIRE_FENCED_CALLBACKS = "false"',
+    );
+  });
+});

--- a/tests/worker/scheduleContract.test.js
+++ b/tests/worker/scheduleContract.test.js
@@ -1,0 +1,78 @@
+import { readFile } from 'node:fs/promises';
+import { describe, expect, it } from 'vitest';
+import {
+    chunkScheduledRuns,
+    dueScheduledRuns,
+    resolveScheduledRun,
+    SCHEDULE_UTC_HOURS,
+    scheduledRunsForReportDate,
+} from '../../src/daily/scheduleContract.js';
+
+describe('production schedule contract', () => {
+    it('defines all sixteen production UTC hours once', () => {
+        expect(SCHEDULE_UTC_HOURS).toEqual([
+            0, 2, 4, 6, 8, 10, 12, 14, 16, 17, 18, 19, 20, 21, 22, 23,
+        ]);
+        expect(new Set(SCHEDULE_UTC_HOURS).size).toBe(16);
+    });
+
+    it('keeps wrangler cron hours exactly aligned with the shared contract', async () => {
+        const config = await readFile(
+            new URL('../../wrangler.toml', import.meta.url),
+            'utf8',
+        );
+        const cron = config.match(/crons\s*=\s*\["0 ([0-9,]+) \* \* \*"\]/)?.[1];
+        expect(cron).toBe(SCHEDULE_UTC_HOURS.join(','));
+    });
+
+    it('maps every run for one Beijing report date to its cumulative batch', () => {
+        const runs = scheduledRunsForReportDate('2026-07-24');
+
+        expect(runs).toHaveLength(16);
+        expect(runs.map(run => [run.scheduled_at, run.batch_id])).toEqual([
+            ['2026-07-23T16:00:00.000Z', 'night'],
+            ['2026-07-23T17:00:00.000Z', 'night'],
+            ['2026-07-23T21:00:00.000Z', 'morning'],
+            ['2026-07-23T22:00:00.000Z', 'morning'],
+            ['2026-07-23T23:00:00.000Z', 'morning'],
+            ['2026-07-24T00:00:00.000Z', 'morning'],
+            ['2026-07-24T02:00:00.000Z', 'morning'],
+            ['2026-07-24T04:00:00.000Z', 'morning'],
+            ['2026-07-24T06:00:00.000Z', 'afternoon'],
+            ['2026-07-24T08:00:00.000Z', 'afternoon'],
+            ['2026-07-24T10:00:00.000Z', 'afternoon'],
+            ['2026-07-24T12:00:00.000Z', 'afternoon'],
+            ['2026-07-24T14:00:00.000Z', 'night'],
+            ['2026-07-24T18:00:00.000Z', 'lateNight'],
+            ['2026-07-24T19:00:00.000Z', 'lateNight'],
+            ['2026-07-24T20:00:00.000Z', 'lateNight'],
+        ]);
+        expect(runs[14]).toMatchObject({
+            publication_batch_id: 'lateNightSupplement',
+            report_date: '2026-07-24',
+            run_id: `scheduled:${Date.parse('2026-07-24T19:00:00.000Z')}`,
+        });
+    });
+
+    it('normalizes cron jitter but rejects an hour outside production', () => {
+        expect(resolveScheduledRun('2026-07-24T10:00:42.000Z')).toMatchObject({
+            batch_id: 'afternoon',
+            scheduled_at: '2026-07-24T10:00:00.000Z',
+        });
+        expect(() => resolveScheduledRun('2026-07-24T11:00:00.000Z')).toThrow(
+            /not in the production schedule/,
+        );
+    });
+
+    it('covers a thirty-hour lookback in pages of at most sixteen runs', () => {
+        const due = dueScheduledRuns(
+            Date.parse('2026-07-24T20:15:00.000Z'),
+            30,
+        );
+        const pages = chunkScheduledRuns(due);
+
+        expect(due.length).toBeGreaterThan(16);
+        expect(pages.flat()).toEqual(due);
+        expect(pages.every(page => page.length <= 16)).toBe(true);
+    });
+});

--- a/tests/worker/scheduledRunMigration.test.js
+++ b/tests/worker/scheduledRunMigration.test.js
@@ -1,0 +1,55 @@
+import { readFile } from 'node:fs/promises';
+import { beforeAll, describe, expect, it } from 'vitest';
+
+describe('scheduled run observability migration', () => {
+    let sql;
+
+    beforeAll(async () => {
+        sql = await readFile(
+            new URL(
+                '../../supabase/migrations/20260724000400_scheduled_run_observability.sql',
+                import.meta.url,
+            ),
+            'utf8',
+        );
+    });
+
+    it('keeps an append-only audit and a monotonic current projection', () => {
+        expect(sql).toContain('private.scheduled_run_observability_events');
+        expect(sql).toContain('private.scheduled_run_observability_current');
+        expect(sql).toContain("v_current.status = 'failed' and v_status = 'succeeded'");
+        expect(sql).toContain("v_current.status = v_status");
+    });
+
+    it('accepts only exact production schedule hours', () => {
+        expect(sql).toContain("p_scheduled_at <> date_trunc('hour', p_scheduled_at)");
+        expect(sql).toContain(
+            'not in (0, 2, 4, 6, 8, 10, 12, 14, 16, 17, 18, 19, 20, 21, 22, 23)',
+        );
+    });
+
+    it('associates fresh releases with their run in the finalize transaction', () => {
+        const finalize = sql.slice(
+            sql.indexOf('create or replace function private.finalize_site_release_v1'),
+            sql.indexOf('-- Preserve the previous implementations'),
+        );
+        expect(finalize).toContain("'release_registered'");
+        expect(finalize).toContain('private.record_scheduled_run_trace_v1');
+        expect(finalize).toContain("'dispatch_id', existing_dispatch_id");
+    });
+
+    it('derives stability only from complete multi-round edge evidence', () => {
+        expect(sql).toContain("'[15000, 45000, 120000]'::jsonb");
+        expect(sql).toContain("event.evidence ->> 'stable_verified_at'");
+        expect(sql).toContain("'stability_rounds'");
+    });
+
+    it('keeps write and read capabilities separated', () => {
+        expect(sql).toMatch(
+            /grant execute on function private\.record_scheduled_run_trace_v1\([\s\S]*?\) to content_ingestor;/,
+        );
+        expect(sql).toMatch(
+            /grant execute on function private\.get_content_observability_v1\(\)[\s\S]*?to content_deployer;/,
+        );
+    });
+});

--- a/tests/worker/structuredWorkflow.test.js
+++ b/tests/worker/structuredWorkflow.test.js
@@ -53,9 +53,14 @@ function dependencies(overrides = {}) {
         resolveSnapshot: vi.fn(async () => snapshotA),
         createReader: vi.fn(() => reader),
         getFoloCookie: vi.fn(async () => 'cookie'),
-        fetchData: vi.fn(async () => ({ structuredItems: [], errors: [] })),
+        fetchData: vi.fn(async () => ({
+            structuredItems: [],
+            errors: [],
+            sourceCounts: { news: 0, project: 0, paper: 0, socialMedia: 0 },
+        })),
         build: vi.fn(async () => ({
             files: files(),
+            json: `${JSON.stringify({ date: runInput.reportDate })}\n`,
             noOp: false,
             metrics: { raw_count: 0 },
         })),
@@ -517,7 +522,7 @@ describe('structured publication workflow', () => {
                 },
                 {
                     ...runInput,
-                    triggerId: 'scheduled:mirror-failure',
+                    triggerId: `scheduled:${Date.parse(runInput.runAt)}`,
                 },
                 deps,
             ),
@@ -526,6 +531,12 @@ describe('structured publication workflow', () => {
             pending: true,
             commit_sha: sha('e'),
             database_mirror: { status: 'failed', error_type: 'Error' },
+            run_id: `scheduled:${Date.parse(runInput.runAt)}`,
+            stage: 'database_mirror_failed',
+            source_result: {
+                status: 'succeeded',
+                counts: { news: 0, project: 0, paper: 0, socialMedia: 0 },
+            },
         });
         expect(deps.commit).toHaveBeenCalledOnce();
         expect(mirror).toHaveBeenCalledOnce();

--- a/tests/worker/workerRegression.test.js
+++ b/tests/worker/workerRegression.test.js
@@ -3,31 +3,47 @@ import { describe, expect, it, vi } from 'vitest';
 import { createWorker } from '../../src/index.js';
 
 describe('worker regression guards', () => {
-    it('keeps scheduled events wired directly to the legacy incremental workflow', async () => {
+    it('records started and terminal evidence around each scheduled workflow', async () => {
         const workflowPromise = Promise.resolve({ success: true });
         const scheduledWorkflow = vi.fn(() => workflowPromise);
         const waitUntil = vi.fn();
         const DATA_KV = { put: vi.fn(async () => undefined) };
         const env = { marker: 'production-env', EXTERNAL_WRITES_ENABLED: 'true', DATA_KV };
-        const worker = createWorker({ scheduledWorkflow });
+        const scheduledTrace = vi.fn(async () => true);
+        const worker = createWorker({ scheduledWorkflow, scheduledTrace });
 
         await worker.scheduled({ scheduledTime: Date.UTC(2026, 6, 14) }, env, { waitUntil });
 
+        await expect(waitUntil.mock.calls[0][0]).resolves.toEqual({ success: true });
         expect(scheduledWorkflow).toHaveBeenCalledOnce();
         expect(scheduledWorkflow).toHaveBeenCalledWith(env, {
             triggerId: `scheduled:${Date.UTC(2026, 6, 14)}`,
             runAt: '2026-07-14T00:00:00.000Z',
         });
         expect(waitUntil).toHaveBeenCalledOnce();
-        await expect(waitUntil.mock.calls[0][0]).resolves.toEqual({ success: true });
-        expect(DATA_KV.put).toHaveBeenCalledOnce();
-        expect(DATA_KV.put.mock.calls[0][0]).toBe(
+        expect(DATA_KV.put).toHaveBeenCalledTimes(2);
+        expect(scheduledTrace.mock.calls.map(([, value]) => value.eventType))
+            .toEqual(['started', 'succeeded']);
+        expect(scheduledTrace.mock.calls[1][1]).toMatchObject({
+            runId: `scheduled:${Date.UTC(2026, 6, 14)}`,
+            scheduledAt: '2026-07-14T00:00:00.000Z',
+            evidence: { status: 'succeeded' },
+        });
+        expect(JSON.parse(DATA_KV.put.mock.calls[0][1])).toMatchObject({
+            scheduled_at: '2026-07-14T00:00:00.000Z',
+            run_id: `scheduled:${Date.UTC(2026, 6, 14)}`,
+            status: 'started',
+            stage: 'started',
+        });
+        expect(DATA_KV.put.mock.calls[1][0]).toBe(
             'scheduled:outcome:2026-07-14T00:00:00.000Z',
         );
-        expect(JSON.parse(DATA_KV.put.mock.calls[0][1])).toEqual({
+        expect(JSON.parse(DATA_KV.put.mock.calls[1][1])).toMatchObject({
             scheduled_at: '2026-07-14T00:00:00.000Z',
             status: 'succeeded',
             run_at: '2026-07-14T00:00:00.000Z',
+            run_id: `scheduled:${Date.UTC(2026, 6, 14)}`,
+            stable_verified_at: null,
         });
     });
 
@@ -58,15 +74,17 @@ describe('worker regression guards', () => {
 
         expect(waitUntil).toHaveBeenCalledOnce();
         await expect(waitUntil.mock.calls[0][0]).rejects.toBe(error);
-        expect(DATA_KV.put).toHaveBeenCalledTimes(2);
+        expect(DATA_KV.put).toHaveBeenCalledTimes(3);
         const [markerKey, rawMarker, options] = DATA_KV.put.mock.calls.find(
             ([key]) => key.startsWith('structured:attempt-failure:'),
         );
         const marker = JSON.parse(rawMarker);
-        expect(marker).toEqual({
+        expect(marker).toMatchObject({
             success: false,
             status: 'failed',
+            stage: 'failed',
             trigger_type: 'scheduled',
+            run_id: `scheduled:${Date.UTC(2026, 6, 14)}`,
             run_at: '2026-07-14T00:00:00.000Z',
             error_type: 'structured_source_fetch_failed',
             failure_stage: 'fetch',
@@ -80,11 +98,12 @@ describe('worker regression guards', () => {
         });
         expect(markerKey).toMatch(/^structured:attempt-failure:[a-f0-9]{64}$/);
         expect(options).toEqual({ expirationTtl: 14 * 24 * 60 * 60 });
-        const outcome = DATA_KV.put.mock.calls.find(
+        const outcome = DATA_KV.put.mock.calls.filter(
             ([key]) => key === 'scheduled:outcome:2026-07-14T00:00:00.000Z',
-        );
+        ).at(-1);
         expect(JSON.parse(outcome[1])).toMatchObject({
             scheduled_at: '2026-07-14T00:00:00.000Z',
+            run_id: `scheduled:${Date.UTC(2026, 6, 14)}`,
             status: 'failed',
             failure_stage: 'fetch',
         });
@@ -212,7 +231,7 @@ describe('worker regression guards', () => {
         }), env);
         const body = await response.json();
         expect(response.status).toBe(200);
-        expect(body).toEqual({
+        expect(body).toMatchObject({
             success: true,
             slots: [{
                 scheduled_at: '2026-07-20T19:00:00.000Z',
@@ -223,6 +242,57 @@ describe('worker regression guards', () => {
             }],
         });
         expect(JSON.stringify(body)).not.toContain('must-not-leak');
+    });
+
+    it('does not mark a production run succeeded when its database mirror failed', async () => {
+        const waitUntil = vi.fn();
+        const DATA_KV = { put: vi.fn(async () => undefined) };
+        const scheduledTrace = vi.fn(async () => true);
+        const worker = createWorker({
+            scheduledWorkflow: vi.fn(async () => ({
+                success: true,
+                no_op: false,
+                content_sha256: 'a'.repeat(64),
+                source_result: {
+                    status: 'succeeded',
+                    counts: { news: 3 },
+                },
+                database_mirror: { status: 'failed' },
+                stage: 'database_mirror_failed',
+            })),
+            scheduledTrace,
+        });
+
+        await worker.scheduled(
+            { scheduledTime: Date.UTC(2026, 6, 14) },
+            {
+                EXTERNAL_WRITES_ENABLED: 'true',
+                CONTENT_DATABASE_MIRROR_ENABLED: 'true',
+                DATA_KV,
+            },
+            { waitUntil },
+        );
+
+        await expect(waitUntil.mock.calls[0][0]).rejects.toMatchObject({
+            name: 'ScheduledDatabaseMirrorError',
+        });
+        const outcome = DATA_KV.put.mock.calls
+            .filter(([key]) => key === 'scheduled:outcome:2026-07-14T00:00:00.000Z')
+            .map(([, value]) => JSON.parse(value))
+            .at(-1);
+        expect(outcome).toMatchObject({
+            status: 'failed',
+            stage: 'database_mirror_failed',
+            error_type: 'database_mirror_failed',
+            failure_stage: 'database_mirror',
+            content_sha256: 'a'.repeat(64),
+            source_result: {
+                status: 'failed',
+                counts: { news: 3 },
+            },
+        });
+        expect(scheduledTrace.mock.calls.map(([, value]) => value.eventType))
+            .toEqual(['started', 'failed']);
     });
 
     it('preserves the production cron and GitHub main branch configuration', async () => {

--- a/workers/content/broker/index.test.ts
+++ b/workers/content/broker/index.test.ts
@@ -1,17 +1,371 @@
 import { createHash } from "node:crypto";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import {
+import contentBroker, {
   deploymentMatchesContext,
   handleRollbackRequest,
   isCommittedPromotionContext,
   pagesAssetHash,
   parseContentAddressedArtifact,
   parseDeterministicTar,
+  performPromotion,
+  ProductionCoordinator,
   purgeContentCaches,
   reconcileProduction,
   uploadPages,
+  validatePromotion,
   verifyDeployment,
+  verifyOrRepairCurrentDeployment,
 } from "./index";
+
+function fakeCoordinatorState() {
+  const values = new Map<string, unknown>();
+  const alarms: number[] = [];
+  const storage = {
+    get: vi.fn(async (key: string) => values.get(key)),
+    put: vi.fn(async (key: string, value: unknown) => {
+      values.set(key, structuredClone(value));
+    }),
+    delete: vi.fn(async (key: string) => {
+      values.delete(key);
+    }),
+    setAlarm: vi.fn(async (timestamp: number) => {
+      alarms.push(timestamp);
+    }),
+    deleteAlarm: vi.fn(async () => undefined),
+    transaction: vi.fn(
+      async (operation: (transaction: typeof storage) => Promise<unknown>) =>
+        operation(storage),
+    ),
+  };
+  return { state: { storage } as never, values, alarms };
+}
+
+describe("production coordinator", () => {
+  it("enqueues scheduled reconcile once without polling operation status", async () => {
+    const operationId = "123e4567-e89b-42d3-a456-426614174000";
+    const fetch = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ operation_id: operationId }), {
+          status: 202,
+          headers: { "Content-Type": "application/json" },
+        }),
+    );
+    const env = {
+      PAGES_PROJECT: "content-pages",
+      PRODUCTION_COORDINATOR: {
+        idFromName: vi.fn(() => ({ name: "coordinator" })),
+        get: vi.fn(() => ({ fetch })),
+      },
+    } as never;
+    let pending: Promise<unknown> | undefined;
+    const context = {
+      waitUntil: vi.fn((value: Promise<unknown>) => {
+        pending = value;
+      }),
+    } as never;
+
+    contentBroker.scheduled({} as never, env, context);
+    await pending;
+
+    expect(fetch).toHaveBeenCalledOnce();
+    const request = fetch.mock.calls[0][0] as Request;
+    expect(new URL(request.url).pathname).toBe("/internal/enqueue");
+    await expect(request.json()).resolves.toEqual({
+      kind: "reconcile",
+      payload: null,
+    });
+    expect(
+      fetch.mock.calls.some(([candidate]) =>
+        new URL(String((candidate as Request).url)).pathname.startsWith(
+          "/internal/operations/",
+        ),
+      ),
+    ).toBe(false);
+  });
+
+  it("serializes queued Pages mutations even when another alarm fires", async () => {
+    const { state } = fakeCoordinatorState();
+    let releaseFirst!: () => void;
+    let firstStarted!: () => void;
+    const firstGate = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+    const started = new Promise<void>((resolve) => {
+      firstStarted = resolve;
+    });
+    const executionOrder: string[] = [];
+    const execute = vi.fn(async (operation: { id: string }) => {
+      executionOrder.push(operation.id);
+      if (executionOrder.length === 1) {
+        firstStarted();
+        await firstGate;
+      }
+      return new Response(JSON.stringify({ ok: true }), { status: 200 });
+    });
+    const coordinator = new ProductionCoordinator(
+      state,
+      {} as never,
+      execute as never,
+    );
+
+    const first = await coordinator.fetch(
+      new Request("https://coordinator.internal/internal/enqueue", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ kind: "promote", payload: { release: "a" } }),
+      }),
+    );
+    const second = await coordinator.fetch(
+      new Request("https://coordinator.internal/internal/enqueue", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ kind: "rollback", payload: { release: "b" } }),
+      }),
+    );
+    const firstId = String(
+      ((await first.json()) as { operation_id: string }).operation_id,
+    );
+    const secondId = String(
+      ((await second.json()) as { operation_id: string }).operation_id,
+    );
+
+    const activeAlarm = coordinator.alarm();
+    await started;
+    await coordinator.alarm();
+    expect(executionOrder).toEqual([firstId]);
+
+    releaseFirst();
+    await activeAlarm;
+    await coordinator.alarm();
+    expect(executionOrder).toEqual([firstId, secondId]);
+  });
+
+  it("retries the same active operation before later work after an alarm crash", async () => {
+    const { state, values, alarms } = fakeCoordinatorState();
+    const storage = state.storage as unknown as {
+      put: ReturnType<typeof vi.fn>;
+    };
+    const originalPut = storage.put.getMockImplementation();
+    let failCompletedWrite = true;
+    storage.put.mockImplementation(async (key: string, value: unknown) => {
+      if (
+        failCompletedWrite &&
+        key.startsWith("production-operation:") &&
+        (value as { status?: string }).status === "completed"
+      ) {
+        failCompletedWrite = false;
+        throw new Error("simulated isolate reset after execution");
+      }
+      return originalPut?.(key, value);
+    });
+    const executed: string[] = [];
+    const execute = vi.fn(async (operation: { id: string }) => {
+      executed.push(operation.id);
+      return new Response(JSON.stringify({ ok: true }), { status: 200 });
+    });
+    const firstCoordinator = new ProductionCoordinator(
+      state,
+      {} as never,
+      execute as never,
+    );
+    const accepted = await firstCoordinator.fetch(
+      new Request("https://coordinator.internal/internal/enqueue", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ kind: "reconcile", payload: null }),
+      }),
+    );
+    const operationId = String(
+      ((await accepted.json()) as { operation_id: string }).operation_id,
+    );
+
+    await expect(firstCoordinator.alarm()).rejects.toThrow(
+      "simulated isolate reset",
+    );
+    expect(values.get("production-operation-active")).toBe(operationId);
+    expect(
+      (values.get(`production-operation:${operationId}`) as { status: string })
+        .status,
+    ).toBe("running");
+    expect(alarms.some((alarm) => alarm > Date.now())).toBe(true);
+
+    const restartedCoordinator = new ProductionCoordinator(
+      state,
+      {} as never,
+      execute as never,
+    );
+    await restartedCoordinator.alarm();
+    expect(executed).toEqual([operationId, operationId]);
+    expect(
+      values.get(`production-operation:${operationId}`) as {
+        status: string;
+        attempts: number;
+      },
+    ).toMatchObject({ status: "completed", attempts: 2 });
+    expect(values.has("production-operation-active")).toBe(false);
+  });
+
+  it("deduplicates queued reconciles and prunes expired operation results", async () => {
+    const { state, values } = fakeCoordinatorState();
+    const expiredId = "123e4567-e89b-42d3-a456-426614174099";
+    values.set(`production-operation:${expiredId}`, {
+      id: expiredId,
+      kind: "reconcile",
+      payload: null,
+      status: "completed",
+      attempts: 1,
+      created_at: "2026-01-01T00:00:00.000Z",
+      updated_at: "2026-01-01T00:00:01.000Z",
+      completed_at: "2026-01-01T00:00:01.000Z",
+    });
+    values.set("production-operation-completed", [
+      { id: expiredId, completed_at: "2026-01-01T00:00:01.000Z" },
+    ]);
+    const coordinator = new ProductionCoordinator(
+      state,
+      {} as never,
+      vi.fn() as never,
+    );
+    const request = () =>
+      new Request("https://coordinator.internal/internal/enqueue", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ kind: "reconcile", payload: null }),
+      });
+    const first = (await (await coordinator.fetch(request())).json()) as {
+      operation_id: string;
+      deduplicated?: boolean;
+    };
+    const second = (await (await coordinator.fetch(request())).json()) as {
+      operation_id: string;
+      deduplicated?: boolean;
+    };
+
+    expect(second).toMatchObject({
+      operation_id: first.operation_id,
+      deduplicated: true,
+    });
+    expect(values.has(`production-operation:${expiredId}`)).toBe(false);
+  });
+});
+
+describe("same-release production repair", () => {
+  const context = {
+    site_release_id: "123e4567-e89b-42d3-a456-426614174001",
+    site_release_sequence: 167,
+    code_sha: "a".repeat(40),
+  } as never;
+  const expectedDeploymentId = "123e4567-e89b-42d3-a456-426614174010";
+  const exactDeploymentId = "123e4567-e89b-42d3-a456-426614174011";
+
+  function repairSql() {
+    const queries: string[] = [];
+    const sql = vi.fn(async (strings: TemplateStringsArray) => {
+      const query = strings.join("?");
+      queries.push(query);
+      if (query.includes("get_current_pages_deployment_v1")) {
+        return [
+          {
+            result: {
+              pointer_generation: 56,
+              pages_deployment_id: expectedDeploymentId,
+            },
+          },
+        ];
+      }
+      if (query.includes("record_current_pages_repair_v1")) {
+        return [
+          {
+            result: {
+              site_release_id: context.site_release_id,
+              generation: 57,
+            },
+          },
+        ];
+      }
+      throw new Error(`Unexpected SQL: ${query}`);
+    });
+    Object.assign(sql, { json: vi.fn((value: unknown) => value) });
+    return { sql, queries };
+  }
+
+  it("adopts an exact same-release deployment instead of rolling it back", async () => {
+    const { sql, queries } = repairSql();
+    const rollbackDeployment = vi.fn();
+    const purge = vi.fn(async () => ({ urls: [] }));
+    const evidence = {
+      multi_edge_verified: true,
+      site_release_id: context.site_release_id,
+    };
+
+    await expect(
+      verifyOrRepairCurrentDeployment(context, sql as never, {} as never, {
+        loadArtifact: vi.fn(async () => ({ kind: "tar", files: [] }) as never),
+        latestDeployment: vi.fn(async () => ({
+          id: exactDeploymentId,
+          url: "https://exact-current.pages.dev",
+          commitHash: "a".repeat(40),
+          commitMessage: "content release 167",
+        })),
+        verify: vi.fn(async () => evidence),
+        rollbackDeployment,
+        purge,
+      }),
+    ).resolves.toMatchObject({
+      healthy: true,
+      repaired: true,
+      repair_mode: "adopt_exact_deployment",
+      deployment_id: exactDeploymentId,
+    });
+
+    expect(rollbackDeployment).not.toHaveBeenCalled();
+    expect(purge).toHaveBeenCalledOnce();
+    expect(queries.join("\n")).toContain("record_current_pages_repair_v1");
+  });
+
+  it("rolls production back to the pointer deployment when content drifted", async () => {
+    const { sql, queries } = repairSql();
+    const repairedDeploymentId = "123e4567-e89b-42d3-a456-426614174012";
+    const verify = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("release 166 is still live"))
+      .mockResolvedValueOnce({
+        multi_edge_verified: true,
+        site_release_id: context.site_release_id,
+      });
+    const rollbackDeployment = vi.fn(async () => ({
+      id: repairedDeploymentId,
+      url: "https://repaired-current.pages.dev",
+    }));
+
+    await expect(
+      verifyOrRepairCurrentDeployment(context, sql as never, {} as never, {
+        loadArtifact: vi.fn(async () => ({ kind: "tar", files: [] }) as never),
+        latestDeployment: vi.fn(async () => ({
+          id: "123e4567-e89b-42d3-a456-426614174099",
+          url: "https://stale.pages.dev",
+          commitHash: "b".repeat(40),
+          commitMessage: "content release 166",
+        })),
+        verify,
+        rollbackDeployment,
+        purge: vi.fn(async () => ({ urls: [] })),
+      }),
+    ).resolves.toMatchObject({
+      healthy: true,
+      repaired: true,
+      repair_mode: "rollback_exact_deployment",
+      deployment_id: repairedDeploymentId,
+    });
+
+    expect(rollbackDeployment).toHaveBeenCalledWith(
+      expectedDeploymentId,
+      expect.anything(),
+    );
+    expect(verify).toHaveBeenCalledTimes(2);
+    expect(queries.join("\n")).toContain("record_current_pages_repair_v1");
+  });
+});
 
 describe("promotion commit recovery", () => {
   it("accepts only the target release at the next pointer generation", () => {
@@ -59,6 +413,177 @@ describe("promotion commit recovery", () => {
     ).toBe(false);
   });
 
+  it("repairs committed-pointer drift from the serialized reconciler", async () => {
+    const current = {
+      ...databaseContentContract,
+      site_release_id: "123e4567-e89b-42d3-a456-426614174001",
+      site_release_sequence: 167,
+      manifest_sha256: "a".repeat(64),
+      content_sha256: "b".repeat(64),
+      artifact_object_key: `artifacts/sha256/${"c".repeat(64)}.json`,
+      artifact_byte_length: 1,
+      artifact_sha256: "c".repeat(64),
+      artifact_fingerprint_sha256: "d".repeat(64),
+      artifact_hash_algorithm: "sha256-content-addressed-pages-v1",
+      code_sha: "e".repeat(40),
+      build_environment_version: "node22.17-astro7-hugo0.147.9-v1",
+      pointer_generation: 56,
+      current_site_release_id: "123e4567-e89b-42d3-a456-426614174001",
+    };
+    const expectedDeploymentId = "123e4567-e89b-42d3-a456-426614174010";
+    const repairedDeploymentId = "123e4567-e89b-42d3-a456-426614174011";
+    const queries: string[] = [];
+    const end = vi.fn(async () => undefined);
+    const sql = vi.fn(async (strings: TemplateStringsArray) => {
+      const query = strings.join("?");
+      queries.push(query);
+      if (query.includes("begin_production_reconcile_v1")) {
+        return [{ result: null }];
+      }
+      if (query.includes("get_current_release_v1")) {
+        return [{ result: { site_release_id: current.site_release_id } }];
+      }
+      if (query.includes("get_production_deploy_context_v1")) {
+        return [{ result: current }];
+      }
+      if (query.includes("get_current_pages_deployment_v1")) {
+        return [
+          {
+            result: {
+              pointer_generation: 56,
+              pages_deployment_id: expectedDeploymentId,
+            },
+          },
+        ];
+      }
+      if (query.includes("record_current_pages_repair_v1")) {
+        return [
+          {
+            result: {
+              site_release_id: current.site_release_id,
+              generation: 57,
+            },
+          },
+        ];
+      }
+      throw new Error(`Unexpected SQL: ${query}`);
+    });
+    Object.assign(sql, {
+      json: vi.fn((value: unknown) => value),
+      end,
+    });
+    const verify = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("release 166 is still live"))
+      .mockResolvedValueOnce({
+        multi_edge_verified: true,
+        site_release_id: current.site_release_id,
+      });
+    const rollbackDeployment = vi.fn(async () => ({
+      id: repairedDeploymentId,
+      url: "https://repaired-current.pages.dev",
+    }));
+
+    await expect(
+      reconcileProduction({} as never, {
+        openDatabase: vi.fn(() => sql as never),
+        loadArtifact: vi.fn(async () => ({ kind: "tar", files: [] }) as never),
+        latestDeployment: vi.fn(async () => ({
+          id: "123e4567-e89b-42d3-a456-426614174099",
+          url: "https://stale-current.pages.dev",
+          commitHash: "f".repeat(40),
+          commitMessage: "content release 166",
+        })),
+        verify,
+        rollbackDeployment,
+        purge: vi.fn(async () => ({ urls: [] })),
+      }),
+    ).resolves.toBe("restored");
+
+    expect(rollbackDeployment).toHaveBeenCalledWith(
+      expectedDeploymentId,
+      expect.anything(),
+    );
+    expect(verify).toHaveBeenCalledTimes(2);
+    expect(queries.join("\n")).toContain("record_current_pages_repair_v1");
+    expect(end).toHaveBeenCalledWith({ timeout: 2 });
+  });
+
+  it("does not repair when the committed pointer generation changed", async () => {
+    const current = {
+      ...databaseContentContract,
+      site_release_id: "123e4567-e89b-42d3-a456-426614174001",
+      site_release_sequence: 167,
+      manifest_sha256: "a".repeat(64),
+      content_sha256: "b".repeat(64),
+      artifact_object_key: `artifacts/sha256/${"c".repeat(64)}.json`,
+      artifact_byte_length: 1,
+      artifact_sha256: "c".repeat(64),
+      artifact_fingerprint_sha256: "d".repeat(64),
+      artifact_hash_algorithm: "sha256-content-addressed-pages-v1",
+      code_sha: "e".repeat(40),
+      build_environment_version: "node22.17-astro7-hugo0.147.9-v1",
+      pointer_generation: 56,
+      current_site_release_id: "123e4567-e89b-42d3-a456-426614174001",
+    };
+    let pointerReads = 0;
+    const queries: string[] = [];
+    const sql = vi.fn(async (strings: TemplateStringsArray) => {
+      const query = strings.join("?");
+      queries.push(query);
+      if (query.includes("begin_production_reconcile_v1")) {
+        return [{ result: null }];
+      }
+      if (query.includes("get_current_release_v1")) {
+        return [{ result: { site_release_id: current.site_release_id } }];
+      }
+      if (query.includes("get_production_deploy_context_v1")) {
+        return [{ result: current }];
+      }
+      if (query.includes("get_current_pages_deployment_v1")) {
+        pointerReads += 1;
+        return [
+          {
+            result: {
+              pointer_generation: pointerReads === 1 ? 56 : 57,
+              pages_deployment_id: "123e4567-e89b-42d3-a456-426614174010",
+            },
+          },
+        ];
+      }
+      throw new Error(`Unexpected SQL: ${query}`);
+    });
+    Object.assign(sql, {
+      json: vi.fn((value: unknown) => value),
+      end: vi.fn(async () => undefined),
+    });
+    const rollbackDeployment = vi.fn();
+    const purge = vi.fn();
+
+    await expect(
+      reconcileProduction({} as never, {
+        openDatabase: vi.fn(() => sql as never),
+        loadArtifact: vi.fn(async () => ({ kind: "tar", files: [] }) as never),
+        latestDeployment: vi.fn(async () => ({
+          id: "123e4567-e89b-42d3-a456-426614174099",
+          url: "https://stale-current.pages.dev",
+          commitHash: "f".repeat(40),
+          commitMessage: "content release 166",
+        })),
+        verify: vi.fn(async () => {
+          throw new Error("release 166 is still live");
+        }),
+        rollbackDeployment,
+        purge,
+      }),
+    ).resolves.toBe("superseded");
+
+    expect(pointerReads).toBe(2);
+    expect(rollbackDeployment).not.toHaveBeenCalled();
+    expect(purge).not.toHaveBeenCalled();
+    expect(queries.join("\n")).not.toContain("record_current_pages_repair_v1");
+  });
+
   it("reuses an already restored deployment instead of uploading it again", async () => {
     const target = {
       site_release_id: "123e4567-e89b-42d3-a456-426614174001",
@@ -75,6 +600,21 @@ describe("promotion commit recovery", () => {
       const query = strings.join("?");
       queries.push(query);
       if (query.includes("begin_production_reconcile_v1")) {
+        return [
+          {
+            result: {
+              slot: {
+                operation: "forward",
+                fencing_token: 7,
+                expected_pointer_generation: 49,
+              },
+              target,
+              current,
+            },
+          },
+        ];
+      }
+      if (query.includes("get_promotion_reconcile_context_v1")) {
         return [
           {
             result: {
@@ -134,6 +674,69 @@ describe("promotion commit recovery", () => {
     ).toBe(true);
     expect(end).toHaveBeenCalledWith({ timeout: 2 });
   });
+
+  it("never restores a cached predecessor after a target commit is fenced", async () => {
+    const target = {
+      site_release_id: "123e4567-e89b-42d3-a456-426614174002",
+      site_release_sequence: 167,
+      code_sha: "b".repeat(40),
+      manifest_sha256: "c".repeat(64),
+      artifact_sha256: "d".repeat(64),
+      build_environment_version: "node22.17-astro7-hugo0.147.9-v1",
+    };
+    const current = {
+      site_release_id: "123e4567-e89b-42d3-a456-426614174001",
+      site_release_sequence: 166,
+      code_sha: "a".repeat(40),
+    };
+    const sql = vi.fn(async (strings: TemplateStringsArray) => {
+      const query = strings.join("?");
+      if (query.includes("begin_production_reconcile_v1")) {
+        return [
+          {
+            result: {
+              slot: {
+                operation: "forward",
+                fencing_token: 41,
+                expected_pointer_generation: 56,
+              },
+              target,
+              current,
+            },
+          },
+        ];
+      }
+      if (query.includes("commit_reconciled_production_promotion_v1")) {
+        throw new Error("Stale production fencing token");
+      }
+      throw new Error(`Unexpected SQL: ${query}`);
+    });
+    Object.assign(sql, {
+      json: vi.fn((value: unknown) => value),
+      end: vi.fn(async () => undefined),
+    });
+    const upload = vi.fn();
+    const verify = vi.fn(async () => ({ multi_edge_verified: true }));
+
+    await expect(
+      reconcileProduction({} as never, {
+        openDatabase: vi.fn(() => sql as never),
+        loadArtifact: vi.fn(async () => ({ kind: "tar", files: [] }) as never),
+        upload,
+        verify,
+        latestDeployment: vi.fn(async () => ({
+          id: "123e4567-e89b-42d3-a456-426614174099",
+          url: "https://release-167.pages.dev",
+          commitHash: target.code_sha,
+          commitMessage: "content release 167",
+        })),
+        purge: vi.fn(),
+      }),
+    ).resolves.toBe("superseded");
+
+    expect(upload).not.toHaveBeenCalled();
+    expect(verify).toHaveBeenCalledTimes(1);
+  });
 });
 
 const encoder = new TextEncoder();
@@ -160,6 +763,224 @@ const routeContentContract = {
 
 afterEach(() => {
   vi.unstubAllGlobals();
+});
+
+describe("attempt-fenced production promotion", () => {
+  const releaseId = "123e4567-e89b-42d3-a456-426614174001";
+  const dispatchId = "123e4567-e89b-42d3-a456-426614174002";
+  const attemptToken = "123e4567-e89b-42d3-a456-426614174003";
+  const context = {
+    ...databaseContentContract,
+    site_release_id: releaseId,
+    site_release_sequence: 167,
+    expected_predecessor_id: null,
+    manifest_sha256: "a".repeat(64),
+    content_sha256: "b".repeat(64),
+    artifact_object_key: `artifacts/sha256/${"c".repeat(64)}.json`,
+    artifact_byte_length: 1,
+    artifact_sha256: "c".repeat(64),
+    artifact_fingerprint_sha256: "e".repeat(64),
+    artifact_hash_algorithm: "sha256-content-addressed-pages-v1",
+    code_sha: "d".repeat(40),
+    build_environment_version: "node22.17-astro7-hugo0.147.9-v1",
+    pointer_generation: 56,
+    current_site_release_id: "123e4567-e89b-42d3-a456-426614174000",
+  };
+  const request = {
+    dispatch_id: dispatchId,
+    site_release_id: releaseId,
+    attempt_token: attemptToken,
+    execution_generation: 2,
+    site_release_sequence: 167,
+    expected_predecessor_id: null,
+    artifact_sha256: "c".repeat(64),
+    artifact_object_key: `artifacts/sha256/${"c".repeat(64)}.json`,
+    code_sha: "d".repeat(40),
+    content_sha256: "b".repeat(64),
+    build_environment_version: "node22.17-astro7-hugo0.147.9-v1",
+  };
+
+  function promotionSql(
+    queryHandler: (query: string) => Promise<unknown> | unknown,
+  ) {
+    const queries: string[] = [];
+    const end = vi.fn(async () => undefined);
+    const sql = vi.fn(async (strings: TemplateStringsArray) => {
+      const query = strings.join("?");
+      queries.push(query);
+      return queryHandler(query);
+    });
+    Object.assign(sql, {
+      json: vi.fn((value: unknown) => value),
+      end,
+    });
+    return { sql, queries, end };
+  }
+
+  it("requires the workflow attempt identity in every broker request", () => {
+    expect(() => validatePromotion({ ...request })).not.toThrow();
+    expect(() =>
+      validatePromotion({ ...request, attempt_token: undefined }),
+    ).toThrow("Invalid production promotion request");
+    expect(() =>
+      validatePromotion({ ...request, execution_generation: 0 }),
+    ).toThrow("Invalid production promotion request");
+  });
+
+  it("rejects a stale same-release attempt before any Pages side effect", async () => {
+    const { sql, queries, end } = promotionSql((query) => {
+      if (query.includes("get_production_deploy_context_v1")) {
+        return [{ result: { ...context, current_site_release_id: releaseId } }];
+      }
+      if (query.includes("authorize_attempt_production_promotion_v1")) {
+        throw new Error("Stale production deployment attempt");
+      }
+      throw new Error(`Unexpected SQL: ${query}`);
+    });
+    const loadArtifact = vi.fn();
+    const upload = vi.fn();
+    const verify = vi.fn();
+    const purge = vi.fn();
+
+    const response = await performPromotion(request, {} as never, {
+      openDatabase: vi.fn(() => sql as never),
+      loadArtifact,
+      upload,
+      verify,
+      purge,
+    });
+
+    expect(response.status).toBe(503);
+    await expect(response.json()).resolves.toMatchObject({
+      error: "promotion_failed",
+      stage: "authorize_attempt",
+    });
+    expect(queries.join("\n")).toContain(
+      "authorize_attempt_production_promotion_v1",
+    );
+    expect(loadArtifact).not.toHaveBeenCalled();
+    expect(upload).not.toHaveBeenCalled();
+    expect(verify).not.toHaveBeenCalled();
+    expect(purge).not.toHaveBeenCalled();
+    expect(end).toHaveBeenCalledWith({ timeout: 2 });
+  });
+
+  it("uses attempt-fenced authorize and commit RPCs for a forward write", async () => {
+    const { sql, queries, end } = promotionSql((query) => {
+      if (query.includes("get_production_deploy_context_v1")) {
+        return [{ result: context }];
+      }
+      if (query.includes("authorize_attempt_production_promotion_v1")) {
+        return [
+          {
+            result: {
+              already_committed: false,
+              fencing_token: 19,
+              expected_pointer_generation: 56,
+            },
+          },
+        ];
+      }
+      if (
+        query.includes("mark_promotion_deploying_v1") ||
+        query.includes("mark_promotion_verifying_v1")
+      ) {
+        return [];
+      }
+      if (query.includes("commit_attempt_production_promotion_v1")) {
+        return [
+          {
+            result: {
+              site_release_id: releaseId,
+              generation: 57,
+            },
+          },
+        ];
+      }
+      throw new Error(`Unexpected SQL: ${query}`);
+    });
+    const artifact = { kind: "tar", files: [] } as never;
+    const deployment = {
+      id: "123e4567-e89b-42d3-a456-426614174010",
+      url: "https://release-167.pages.dev",
+    };
+    const upload = vi.fn(async () => deployment);
+
+    const response = await performPromotion(request, {} as never, {
+      openDatabase: vi.fn(() => sql as never),
+      loadArtifact: vi.fn(async () => artifact),
+      upload,
+      verify: vi.fn(async () => ({ multi_edge_verified: true })),
+      purge: vi.fn(async () => ({ urls: [] })),
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      ok: true,
+      site_release_id: releaseId,
+      deployment_id: deployment.id,
+      generation: 57,
+    });
+    expect(upload).toHaveBeenCalledOnce();
+    expect(queries.join("\n")).toContain(
+      "authorize_attempt_production_promotion_v1",
+    );
+    expect(queries.join("\n")).toContain(
+      "commit_attempt_production_promotion_v1",
+    );
+    expect(
+      queries.some((query) =>
+        query.includes("select private.authorize_production_promotion_v1"),
+      ),
+    ).toBe(false);
+    expect(
+      queries.some((query) =>
+        query.includes("select private.commit_production_promotion_v1"),
+      ),
+    ).toBe(false);
+    expect(end).toHaveBeenCalledWith({ timeout: 2 });
+  });
+
+  it("acknowledges an already committed exact attempt without repair", async () => {
+    const { sql, queries } = promotionSql((query) => {
+      if (query.includes("get_production_deploy_context_v1")) {
+        return [{ result: { ...context, current_site_release_id: releaseId } }];
+      }
+      if (query.includes("authorize_attempt_production_promotion_v1")) {
+        return [
+          {
+            result: {
+              already_committed: true,
+              expected_pointer_generation: 57,
+            },
+          },
+        ];
+      }
+      throw new Error(`Unexpected SQL: ${query}`);
+    });
+    const upload = vi.fn();
+    const verify = vi.fn();
+    const purge = vi.fn();
+
+    const response = await performPromotion(request, {} as never, {
+      openDatabase: vi.fn(() => sql as never),
+      upload,
+      verify,
+      purge,
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      ok: true,
+      idempotent: true,
+      site_release_id: releaseId,
+      generation: 57,
+    });
+    expect(queries).toHaveLength(2);
+    expect(upload).not.toHaveBeenCalled();
+    expect(verify).not.toHaveBeenCalled();
+    expect(purge).not.toHaveBeenCalled();
+  });
 });
 
 function octal(value: number, width: number): Uint8Array {
@@ -603,15 +1424,26 @@ describe("production convergence verification", () => {
 
   it("requires exact HTML, daily JSON and search bytes on every origin", async () => {
     const value = setup();
+    const clock = controlledClock();
     await expect(
-      verifyDeployment(context, "https://deploy.pages.dev", value.env, {
-        kind: "tar",
-        files,
-      }),
+      verifyDeployment(
+        context,
+        "https://deploy.pages.dev",
+        value.env,
+        {
+          kind: "tar",
+          files,
+        },
+        clock.startedAt,
+        clock.dependencies,
+      ),
     ).resolves.toMatchObject({
       multi_edge_verified: true,
       maximum_inconsistency_ms: 240000,
       convergence_elapsed_ms: expect.any(Number),
+      stability_elapsed_ms: 120000,
+      stable_verified_at: expect.any(String),
+      stability_offsets: [15000, 45000, 120000],
       site_release_id: context.site_release_id,
       site_release_sequence: context.site_release_sequence,
       manifest_sha256: context.manifest_sha256,
@@ -643,6 +1475,7 @@ describe("production convergence verification", () => {
 
   it("allows declared custom-domain HTML transforms while keeping two exact-byte origins", async () => {
     const value = setup(false, 0, true);
+    const clock = controlledClock();
     await expect(
       verifyDeployment(
         context,
@@ -656,6 +1489,8 @@ describe("production convergence verification", () => {
           VERIFY_MIN_EXACT_ENDPOINTS: "2",
         },
         { kind: "tar", files },
+        clock.startedAt,
+        clock.dependencies,
       ),
     ).resolves.toMatchObject({
       endpoints: expect.arrayContaining([
@@ -703,7 +1538,7 @@ describe("production convergence verification", () => {
         { ...value.env, MAX_PRODUCTION_INCONSISTENCY_MS: "20000" },
         { kind: "tar", files },
         clock.startedAt,
-        clock.dependencies,
+        { ...clock.dependencies, stabilityOffsetsMs: [] },
       ),
     ).resolves.toMatchObject({
       multi_edge_verified: true,
@@ -716,6 +1551,54 @@ describe("production convergence verification", () => {
     });
     expect(value.manifestAttempts.get("https://deploy.pages.dev")).toBe(1);
     expect(value.manifestAttempts.get("https://www.example.test")).toBe(10);
+  });
+
+  it("fails closed when a later stability round drifts after convergence", async () => {
+    const value = setup();
+    const clock = controlledClock();
+    const baseFetch = vi.mocked(fetch);
+    let configuredManifestProbes = 0;
+
+    await expect(
+      verifyDeployment(
+        context,
+        "https://deploy.pages.dev",
+        value.env,
+        { kind: "tar", files },
+        clock.startedAt,
+        {
+          ...clock.dependencies,
+          stabilityOffsetsMs: [15, 45, 120],
+          fetch: async (input, init) => {
+            const url = new URL(String(input));
+            if (
+              url.origin === "https://www.example.test" &&
+              url.pathname.endsWith(
+                "/release-manifests/site-route-manifest.json",
+              )
+            ) {
+              configuredManifestProbes += 1;
+              if (configuredManifestProbes === 3) {
+                return new Response(
+                  JSON.stringify({
+                    build: {
+                      ...routeContentContract,
+                      site_release_id: "123e4567-e89b-42d3-a456-426614174099",
+                    },
+                  }),
+                  {
+                    status: 200,
+                    headers: { "Content-Type": "application/json" },
+                  },
+                );
+              }
+            }
+            return baseFetch(input, init);
+          },
+        },
+      ),
+    ).rejects.toThrow("release-manifests/site-route-manifest.json");
+    expect(configuredManifestProbes).toBe(3);
   });
 
   it("supports one recovery probe so rollback retains the invocation budget", async () => {
@@ -810,7 +1693,7 @@ describe("production convergence verification", () => {
 });
 
 describe("production rollback handler", () => {
-  it("loads the exact fenced context, deploys it, and commits through the rollback RPC", async () => {
+  it("reuses an already exact rollback deployment before committing the fenced RPC", async () => {
     const targetId = "123e4567-e89b-42d3-a456-426614174000";
     const context = {
       ...databaseContentContract,
@@ -872,6 +1755,12 @@ describe("production rollback handler", () => {
         loadArtifact,
         upload,
         verify,
+        latestDeployment: vi.fn(async () => ({
+          id: "123e4567-e89b-42d3-a456-426614174000",
+          url: "https://rollback.pages.dev",
+          commitHash: context.code_sha,
+          commitMessage: "content release 7",
+        })),
         purge,
       },
     );
@@ -883,7 +1772,7 @@ describe("production rollback handler", () => {
       generation: 8,
     });
     expect(loadArtifact).toHaveBeenCalledWith(context, expect.anything());
-    expect(upload).toHaveBeenCalledOnce();
+    expect(upload).not.toHaveBeenCalled();
     expect(verify).toHaveBeenCalledOnce();
     expect(purge).toHaveBeenCalledOnce();
     expect(queries).toHaveLength(2);
@@ -942,6 +1831,9 @@ describe("production rollback handler", () => {
           url: "https://rollback.pages.dev",
         })),
         verify: vi.fn(async () => ({ multi_edge_verified: true })),
+        latestDeployment: vi.fn(async () => {
+          throw new Error("rollback target is not yet current");
+        }),
         purge: vi.fn(async () => {
           throw new Error("purge failed");
         }),

--- a/workers/content/broker/index.ts
+++ b/workers/content/broker/index.ts
@@ -7,6 +7,7 @@ type Env = {
   CONTENT_DB?: { connectionString?: string };
   CONTENT_DATABASE_URL?: string;
   ARTIFACTS: R2Bucket;
+  PRODUCTION_COORDINATOR: DurableObjectNamespace;
   WORKFLOW_HMAC_SECRET: string;
   CONTROL_BROKER_SECRET: string;
   CLOUDFLARE_API_TOKEN: string;
@@ -23,6 +24,23 @@ type Env = {
 };
 
 type JsonRecord = Record<string, unknown>;
+type CoordinatorOperationKind = "promote" | "rollback" | "reconcile";
+type CoordinatorOperation = {
+  id: string;
+  kind: CoordinatorOperationKind;
+  payload: JsonRecord | null;
+  status: "queued" | "running" | "completed";
+  attempts: number;
+  created_at: string;
+  updated_at: string;
+  completed_at?: string;
+  response_status?: number;
+  response_body?: string;
+};
+type CompletedCoordinatorOperation = {
+  id: string;
+  completed_at: string;
+};
 type ArtifactContext = {
   site_release_id: string;
   site_release_sequence: number;
@@ -80,6 +98,7 @@ type VerificationDependencies = {
   now?: () => number;
   sleep?: (milliseconds: number) => Promise<void>;
   maximumAttempts?: number;
+  stabilityOffsetsMs?: number[];
 };
 type VerificationProbeResult =
   | { ok: true; evidence: JsonRecord }
@@ -1043,16 +1062,95 @@ export async function verifyDeployment(
     await sleep(Math.min(delay, remainingAfterProbe));
     round += 1;
   }
-  const elapsedMs = Math.max(0, now() - windowStartedAt);
+  const convergenceElapsedMs = Math.max(0, now() - windowStartedAt);
   if (
     evidenceByOrigin.size !== bases.length ||
-    elapsedMs > maximumInconsistencyMs
+    convergenceElapsedMs > maximumInconsistencyMs
   ) {
     throw new ProductionConvergenceError(
-      elapsedMs,
+      convergenceElapsedMs,
       maximumInconsistencyMs,
       failures,
     );
+  }
+  const stabilityOffsets = dependencies.stabilityOffsetsMs ?? [
+    15_000, 45_000, 120_000,
+  ];
+  if (
+    stabilityOffsets.some(
+      (offset, index) =>
+        !Number.isSafeInteger(offset) ||
+        offset <= 0 ||
+        offset >= maximumInconsistencyMs ||
+        (index > 0 && offset <= stabilityOffsets[index - 1]),
+    )
+  ) {
+    throw new Error("Production stability offsets are invalid");
+  }
+  const firstConvergedAt = now();
+  const stabilityRounds: JsonRecord[] = [];
+  for (const offsetMs of stabilityOffsets) {
+    const targetTime = firstConvergedAt + offsetMs;
+    const delay = targetTime - now();
+    if (delay > 0) {
+      const remaining = remainingWindow();
+      if (delay >= remaining) {
+        throw new ProductionConvergenceError(
+          Math.max(0, now() - windowStartedAt),
+          maximumInconsistencyMs,
+          [],
+        );
+      }
+      await sleep(delay);
+    }
+    const remaining = maximumInconsistencyMs - (now() - windowStartedAt);
+    if (remaining <= 0) {
+      throw new ProductionConvergenceError(
+        Math.max(0, now() - windowStartedAt),
+        maximumInconsistencyMs,
+        [],
+      );
+    }
+    const stableResults = await Promise.all(
+      bases.map(async (base) => {
+        const attempt = (attemptsByOrigin.get(base) || 0) + 1;
+        attemptsByOrigin.set(base, attempt);
+        return {
+          base,
+          result: await probeDeploymentOrigin(
+            base,
+            context,
+            [],
+            transformedHtmlOrigins.has(new URL(base).origin),
+            attempt,
+            remaining,
+            fetcher,
+          ),
+        };
+      }),
+    );
+    const stabilityFailures = stableResults.flatMap(({ result }) =>
+      result.ok ? [] : [result.failure],
+    );
+    if (stabilityFailures.length > 0) {
+      throw new ProductionConvergenceError(
+        Math.max(0, now() - windowStartedAt),
+        maximumInconsistencyMs,
+        stabilityFailures,
+      );
+    }
+    stabilityRounds.push({
+      offset_ms: offsetMs,
+      verified_at: new Date(now()).toISOString(),
+      endpoints: stableResults.map(({ result }) =>
+        result.ok ? result.evidence : null,
+      ),
+    });
+  }
+  const stableVerifiedAt = new Date(now()).toISOString();
+  const elapsedMs = Math.max(0, now() - windowStartedAt);
+  if (elapsedMs > maximumInconsistencyMs) {
+    throw new ProductionConvergenceError(elapsedMs, maximumInconsistencyMs, []);
   }
   return {
     multi_edge_verified: true,
@@ -1064,7 +1162,11 @@ export async function verifyDeployment(
     artifact_fingerprint_sha256: context.artifact_fingerprint_sha256,
     code_sha: context.code_sha,
     build_environment_version: context.build_environment_version,
-    convergence_elapsed_ms: elapsedMs,
+    convergence_elapsed_ms: convergenceElapsedMs,
+    stability_elapsed_ms: elapsedMs,
+    stable_verified_at: stableVerifiedAt,
+    stability_offsets: stabilityOffsets,
+    stability_rounds: stabilityRounds,
     maximum_inconsistency_ms: maximumInconsistencyMs,
     endpoints: bases.map((base) => evidenceByOrigin.get(base)),
   };
@@ -1138,12 +1240,15 @@ async function artifactFiles(
   return { kind: "content-addressed", manifest };
 }
 
-function validatePromotion(
+export function validatePromotion(
   value: JsonRecord,
 ): asserts value is JsonRecord & ArtifactContext {
   if (
     !UUID.test(String(value.dispatch_id)) ||
     !UUID.test(String(value.site_release_id)) ||
+    !UUID.test(String(value.attempt_token)) ||
+    !Number.isSafeInteger(value.execution_generation) ||
+    Number(value.execution_generation) < 1 ||
     !Number.isSafeInteger(value.site_release_sequence) ||
     (value.expected_predecessor_id !== null &&
       value.expected_predecessor_id !== undefined &&
@@ -1219,19 +1324,179 @@ export function isCommittedPromotionContext(
   );
 }
 
-async function promote(request: Request, env: Env): Promise<Response> {
-  let body: JsonRecord;
-  try {
-    body = JSON.parse(
-      new TextDecoder("utf-8", { fatal: true }).decode(
-        await verifyWorkflowRequest(request, env),
-      ),
-    );
-    validatePromotion(body);
-  } catch {
-    return json({ error: "unauthorized_or_invalid" }, 401);
+async function rollbackPagesDeployment(
+  deploymentId: string,
+  env: Env,
+): Promise<{ id: string; url: string }> {
+  if (!UUID.test(deploymentId))
+    throw new Error("Current Pages deployment identity is invalid");
+  const api = "https://api.cloudflare.com/client/v4";
+  const result = await cfApi<JsonRecord>(
+    `${api}/accounts/${encodeURIComponent(env.CLOUDFLARE_ACCOUNT_ID)}/pages/projects/${encodeURIComponent(env.PAGES_PROJECT)}/deployments/${deploymentId}/rollback`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "{}",
+    },
+    env.CLOUDFLARE_API_TOKEN,
+  );
+  const id = String(result.id || "");
+  const url = String(result.url || "");
+  if (!UUID.test(id) || !/^https:\/\//.test(url)) {
+    throw new Error("Pages repair returned an unexpected deployment");
   }
-  const sql = openContentDatabase(env, "content-production-broker");
+  return { id, url };
+}
+
+type CurrentRepairDependencies = {
+  loadArtifact?: typeof artifactFiles;
+  latestDeployment?: typeof latestProductionDeployment;
+  verify?: typeof verifyDeployment;
+  rollbackDeployment?: typeof rollbackPagesDeployment;
+  purge?: typeof purgeContentCaches;
+};
+
+export async function verifyOrRepairCurrentDeployment(
+  context: ArtifactContext,
+  sql: ContentSql,
+  env: Env,
+  dependencies: CurrentRepairDependencies = {},
+): Promise<JsonRecord> {
+  const loadArtifact = dependencies.loadArtifact || artifactFiles;
+  const latestDeployment =
+    dependencies.latestDeployment || latestProductionDeployment;
+  const verify = dependencies.verify || verifyDeployment;
+  const rollbackDeployment =
+    dependencies.rollbackDeployment || rollbackPagesDeployment;
+  const purge = dependencies.purge || purgeContentCaches;
+  const pointer = await rpc(
+    sql,
+    sql<JsonRecord[]>`
+      select private.get_current_pages_deployment_v1(
+        ${context.site_release_id}::uuid
+      ) as result
+    `,
+  );
+  const expectedGeneration = Number(pointer.pointer_generation);
+  const expectedDeploymentId = String(pointer.pages_deployment_id || "");
+  const repairStillCurrent = async (): Promise<boolean> => {
+    const refreshed = await rpc(
+      sql,
+      sql<JsonRecord[]>`
+        select private.get_current_pages_deployment_v1(
+          ${context.site_release_id}::uuid
+        ) as result
+      `,
+    );
+    return (
+      Number(refreshed.pointer_generation) === expectedGeneration &&
+      String(refreshed.pages_deployment_id || "") === expectedDeploymentId
+    );
+  };
+  const superseded = (): JsonRecord => ({
+    healthy: false,
+    repaired: false,
+    superseded: true,
+    site_release_id: context.site_release_id,
+    pointer_generation: expectedGeneration,
+  });
+  const files = await loadArtifact(context, env);
+  const latest = await latestDeployment(env);
+  try {
+    const evidence = await verify(context, latest.url, env, files, undefined, {
+      maximumAttempts: 1,
+    });
+    if (latest.id !== expectedDeploymentId) {
+      if (!(await repairStillCurrent())) return superseded();
+      await purge(env);
+      await rpc(
+        sql,
+        sql<JsonRecord[]>`
+          select private.record_current_pages_repair_v1(
+            ${context.site_release_id}::uuid,
+            ${expectedGeneration},
+            ${latest.id},
+            ${sql.json({
+              ...evidence,
+              repair_mode: "adopt_exact_deployment",
+            })}
+          ) as result
+        `,
+      );
+      return {
+        healthy: true,
+        repaired: true,
+        repair_mode: "adopt_exact_deployment",
+        deployment_id: latest.id,
+        evidence,
+      };
+    }
+    return {
+      healthy: true,
+      repaired: false,
+      deployment_id: latest.id,
+      evidence,
+    };
+  } catch (error) {
+    console.warn(
+      "[ContentBroker] current pointer drifted from Pages; repairing exact deployment",
+      {
+        siteReleaseId: context.site_release_id,
+        expectedDeploymentId,
+        latestDeploymentId: latest.id,
+        ...errorDiagnostics(error),
+      },
+    );
+  }
+
+  if (!(await repairStillCurrent())) return superseded();
+  const repairStartedAt = Date.now();
+  const repaired = await rollbackDeployment(expectedDeploymentId, env);
+  const evidence = await verify(
+    context,
+    repaired.url,
+    env,
+    files,
+    repairStartedAt,
+  );
+  await purge(env);
+  await rpc(
+    sql,
+    sql<JsonRecord[]>`
+      select private.record_current_pages_repair_v1(
+        ${context.site_release_id}::uuid,
+        ${expectedGeneration},
+        ${repaired.id},
+        ${sql.json({ ...evidence, repair_mode: "rollback_exact_deployment" })}
+      ) as result
+    `,
+  );
+  return {
+    healthy: true,
+    repaired: true,
+    repair_mode: "rollback_exact_deployment",
+    deployment_id: repaired.id,
+    evidence,
+  };
+}
+
+type PromotionDependencies = {
+  openDatabase?: typeof openContentDatabase;
+  loadArtifact?: typeof artifactFiles;
+  upload?: typeof uploadPages;
+  verify?: typeof verifyDeployment;
+  purge?: typeof purgeContentCaches;
+};
+
+export async function performPromotion(
+  body: JsonRecord,
+  env: Env,
+  dependencies: PromotionDependencies = {},
+): Promise<Response> {
+  const sql = (dependencies.openDatabase || openContentDatabase)(
+    env,
+    "content-production-broker",
+  );
   let deploymentChanged = false;
   let authorization: JsonRecord | null = null;
   let context: ArtifactContext | null = null;
@@ -1240,39 +1505,53 @@ async function promote(request: Request, env: Env): Promise<Response> {
     context = await deployContext(sql, String(body.site_release_id));
     promotionStage = "compare_request";
     comparePromotion(context, body);
-    if (context.current_site_release_id === context.site_release_id) {
+    promotionStage = "authorize_attempt";
+    authorization = await rpc(
+      sql,
+      sql<JsonRecord[]>`
+      select private.authorize_attempt_production_promotion_v1(
+        ${context.site_release_id}::uuid,
+        ${String(body.dispatch_id)}::uuid,
+        ${String(body.attempt_token)}::uuid,
+        ${Number(body.execution_generation)},
+        ${Number(context.pointer_generation)},
+        ${`broker:${String(body.dispatch_id)}:${String(body.attempt_token)}`},
+        900,
+        600
+      ) as result
+    `,
+    );
+    if (authorization.already_committed === true) {
       return json({
         ok: true,
         idempotent: true,
         site_release_id: context.site_release_id,
+        generation: Number(authorization.expected_pointer_generation),
       });
     }
-    promotionStage = "authorize";
-    authorization = await rpc(
-      sql,
-      sql<JsonRecord[]>`
-      select private.authorize_production_promotion_v1(
-        ${context.site_release_id}::uuid, ${Number(context.pointer_generation)},
-        ${`broker:${String(body.dispatch_id)}`}, 600
-      ) as result
-    `,
-    );
     const token = Number(authorization.fencing_token);
     const generation = Number(authorization.expected_pointer_generation);
     promotionStage = "mark_deploying";
     await sql`select private.mark_promotion_deploying_v1(${context.site_release_id}::uuid, ${token}, ${generation})`;
     promotionStage = "load_artifact";
-    const files = await artifactFiles(context, env);
+    const files = await (dependencies.loadArtifact || artifactFiles)(
+      context,
+      env,
+    );
     const deploymentStartedAt = Date.now();
     promotionStage = "upload_pages";
-    const deployment = await uploadPages(files, context, env);
+    const deployment = await (dependencies.upload || uploadPages)(
+      files,
+      context,
+      env,
+    );
     deploymentChanged = true;
     promotionStage = "mark_verifying";
     await sql`select private.mark_promotion_verifying_v1(
       ${context.site_release_id}::uuid, ${token}, ${generation}, ${deployment.id}
     )`;
     promotionStage = "verify_deployment";
-    const evidence = await verifyDeployment(
+    const evidence = await (dependencies.verify || verifyDeployment)(
       context,
       deployment.url,
       env,
@@ -1280,13 +1559,17 @@ async function promote(request: Request, env: Env): Promise<Response> {
       deploymentStartedAt,
     );
     promotionStage = "purge_caches";
-    await purgeContentCaches(env);
+    await (dependencies.purge || purgeContentCaches)(env);
     promotionStage = "commit_promotion";
     const committed = await rpc(
       sql,
       sql<JsonRecord[]>`
-      select private.commit_production_promotion_v1(
-        ${context.site_release_id}::uuid, ${token}, ${generation}, ${deployment.id},
+      select private.commit_attempt_production_promotion_v1(
+        ${context.site_release_id}::uuid,
+        ${String(body.dispatch_id)}::uuid,
+        ${String(body.attempt_token)}::uuid,
+        ${Number(body.execution_generation)},
+        ${token}, ${generation}, ${deployment.id},
         ${context.manifest_sha256}, ${context.artifact_sha256}, ${context.build_environment_version},
         ${sql.json(evidence)}
       ) as result
@@ -1340,38 +1623,29 @@ async function promote(request: Request, env: Env): Promise<Response> {
     if (authorization && context) {
       const token = Number(authorization.fencing_token);
       const generation = Number(authorization.expected_pointer_generation);
-      try {
-        if (deploymentChanged && context.current_site_release_id) {
-          const previous = await deployContext(
-            sql,
-            context.current_site_release_id,
-          );
-          const previousFiles = await artifactFiles(previous, env);
-          const restored = await uploadPages(previousFiles, previous, env);
-          const recovery = await verifyDeployment(
-            previous,
-            restored.url,
-            env,
-            previousFiles,
-          );
-          await sql`select private.finish_production_recovery_v1(
-            ${context.site_release_id}::uuid, ${token}, ${generation}, true,
-            ${sql.json({ ...recovery, restored_site_release_id: previous.site_release_id, deployment_id: restored.id })}
-          )`;
-        } else if (!deploymentChanged) {
+      if (!deploymentChanged) {
+        try {
           await sql`select private.finish_production_recovery_v1(
             ${context.site_release_id}::uuid, ${token}, ${generation}, true,
             ${sql.json({ production_unchanged: true })}
           )`;
+        } catch {
+          await sql`select private.finish_production_recovery_v1(
+            ${context.site_release_id}::uuid, ${token}, ${generation}, false,
+            ${sql.json({ recovery_failed: true })}
+          )`.catch(() => undefined);
         }
-        // If Pages changed during the first-ever promotion there is no prior
-        // release to restore. Keep the slot in verifying so the scheduled
-        // reconciler can commit after delayed multi-edge convergence.
-      } catch {
-        await sql`select private.finish_production_recovery_v1(
-          ${context.site_release_id}::uuid, ${token}, ${generation}, false,
-          ${sql.json({ recovery_failed: true })}
-        )`.catch(() => undefined);
+      } else {
+        // Once Pages may have changed, this execution never performs a cached
+        // predecessor upload. The durable coordinator will run a fresh,
+        // fenced reconcile after the lease expires.
+        console.warn(
+          "[ContentBroker] promotion requires fresh reconcile; cached compensation suppressed",
+          {
+            siteReleaseId: context.site_release_id,
+            stage: promotionStage,
+          },
+        );
       }
     }
     console.error("[ContentBroker] promotion failed", {
@@ -1396,6 +1670,7 @@ type RollbackDependencies = {
   loadArtifact?: typeof artifactFiles;
   upload?: typeof uploadPages;
   verify?: typeof verifyDeployment;
+  latestDeployment?: typeof latestProductionDeployment;
   purge?: typeof purgeContentCaches;
 };
 
@@ -1444,19 +1719,32 @@ export async function handleRollbackRequest(
       context,
       env,
     );
-    const deploymentStartedAt = Date.now();
-    const deployment = await (dependencies.upload || uploadPages)(
-      artifact,
-      context,
-      env,
-    );
-    const evidence = await (dependencies.verify || verifyDeployment)(
-      context,
-      deployment.url,
-      env,
-      artifact,
-      deploymentStartedAt,
-    );
+    const verify = dependencies.verify || verifyDeployment;
+    let deployment: ProductionDeployment | { id: string; url: string };
+    let evidence: JsonRecord;
+    try {
+      const latest = await (
+        dependencies.latestDeployment || latestProductionDeployment
+      )(env);
+      evidence = await verify(context, latest.url, env, artifact, undefined, {
+        maximumAttempts: 1,
+      });
+      deployment = latest;
+    } catch {
+      const deploymentStartedAt = Date.now();
+      deployment = await (dependencies.upload || uploadPages)(
+        artifact,
+        context,
+        env,
+      );
+      evidence = await verify(
+        context,
+        deployment.url,
+        env,
+        artifact,
+        deploymentStartedAt,
+      );
+    }
     await (dependencies.purge || purgeContentCaches)(env);
     const committed = await rpc(
       sql,
@@ -1528,13 +1816,14 @@ type ReconcileDependencies = {
   upload?: typeof uploadPages;
   verify?: typeof verifyDeployment;
   latestDeployment?: typeof latestProductionDeployment;
+  rollbackDeployment?: typeof rollbackPagesDeployment;
   purge?: typeof purgeContentCaches;
 };
 
 export async function reconcileProduction(
   env: Env,
   dependencies: ReconcileDependencies = {},
-): Promise<"empty" | "committed" | "restored"> {
+): Promise<"empty" | "committed" | "restored" | "superseded"> {
   const sql = (dependencies.openDatabase || openContentDatabase)(
     env,
     "content-production-reconciler",
@@ -1548,19 +1837,43 @@ export async function reconcileProduction(
       JsonRecord[]
     >`select private.begin_production_reconcile_v1() as result`;
     const reconciliation = rows[0]?.result as JsonRecord | null;
-    if (!reconciliation) return "empty";
+    if (!reconciliation) {
+      const currentRows = await sql<
+        JsonRecord[]
+      >`select private.get_current_release_v1() as result`;
+      const currentPointer = currentRows[0]?.result as JsonRecord | null;
+      const currentReleaseId = String(currentPointer?.site_release_id || "");
+      if (!UUID.test(currentReleaseId)) return "empty";
+      const current = await deployContext(sql, currentReleaseId);
+      const currentResult = await verifyOrRepairCurrentDeployment(
+        current,
+        sql,
+        env,
+        {
+          loadArtifact,
+          latestDeployment:
+            dependencies.latestDeployment || latestProductionDeployment,
+          verify,
+          rollbackDeployment:
+            dependencies.rollbackDeployment || rollbackPagesDeployment,
+          purge,
+        },
+      );
+      if (currentResult.superseded === true) return "superseded";
+      return currentResult.repaired === true ? "restored" : "empty";
+    }
     const slot = reconciliation.slot as JsonRecord;
     const target = reconciliation.target as unknown as ArtifactContext;
-    const current = reconciliation.current as unknown as ArtifactContext | null;
     const deployment = await (
       dependencies.latestDeployment || latestProductionDeployment
     )(env);
+    const targetFiles = await loadArtifact(target, env);
+    let targetEvidence: JsonRecord | null = null;
     try {
-      const targetFiles = await loadArtifact(target, env);
       // Recovery runs on the Free-plan 50-subrequest budget. Probe the
       // interrupted target once; if it has not already converged, preserve the
       // rest of this invocation for restoring and verifying last-known-good.
-      const evidence = await verify(
+      targetEvidence = await verify(
         target,
         deployment.url,
         env,
@@ -1568,81 +1881,533 @@ export async function reconcileProduction(
         undefined,
         { maximumAttempts: 1 },
       );
+    } catch (error) {
+      console.warn("[ContentBroker] reconcile target did not verify", {
+        ...errorDiagnostics(error),
+      });
+    }
+
+    if (targetEvidence) {
+      // A stale fence or pointer conflict after successful target verification
+      // means another serialized operation won. It must never fall through to
+      // a compensating upload based on a cached previous pointer.
       await purge(env);
-      if (slot.operation === "forward") {
-        await rpc(
-          sql,
-          sql<JsonRecord[]>`
-          select private.commit_production_promotion_v1(
+      try {
+        if (slot.operation === "forward") {
+          await rpc(
+            sql,
+            sql<JsonRecord[]>`
+          select private.commit_reconciled_production_promotion_v1(
             ${target.site_release_id}::uuid, ${Number(slot.fencing_token)},
             ${Number(slot.expected_pointer_generation)}, ${deployment.id},
             ${target.manifest_sha256}, ${target.artifact_sha256}, ${target.build_environment_version},
-            ${sql.json({ ...evidence, reconciled: true })}
+              ${sql.json({ ...targetEvidence, reconciled: true })}
           ) as result
         `,
-        );
-      } else {
-        await rpc(
-          sql,
-          sql<JsonRecord[]>`
+          );
+        } else {
+          await rpc(
+            sql,
+            sql<JsonRecord[]>`
           select private.commit_production_rollback_v1(
             ${target.site_release_id}::uuid, ${Number(slot.fencing_token)},
             ${Number(slot.expected_pointer_generation)}, ${deployment.id},
-            ${sql.json({ ...evidence, reconciled: true })}
+              ${sql.json({ ...targetEvidence, reconciled: true })}
           ) as result
         `,
+          );
+        }
+        return "committed";
+      } catch (error) {
+        console.warn(
+          "[ContentBroker] reconcile commit was superseded; no compensating Pages write",
+          {
+            ...errorDiagnostics(error),
+          },
         );
+        return "superseded";
       }
-      return "committed";
-    } catch (error) {
-      console.warn("[ContentBroker] reconcile target not committed", {
-        ...errorDiagnostics(error),
-      });
-      if (!current) {
-        // A first-ever promotion can be terminated before Pages changes while
-        // leaving the fenced slot in a deploying state. With no current
-        // pointer there is nothing to restore; release the slot only after the
-        // target failed verification against the latest production deployment.
-        await sql`select private.finish_production_recovery_v1(
+    }
+
+    // Refresh both the operation fence and the desired current pointer after
+    // target verification fails. Never restore the pointer snapshot returned
+    // by the initial reconcile claim.
+    const refreshedRows = await sql<
+      JsonRecord[]
+    >`select private.get_promotion_reconcile_context_v1() as result`;
+    const refreshed = refreshedRows[0]?.result as JsonRecord | null;
+    const refreshedSlot = refreshed?.slot as JsonRecord | undefined;
+    if (
+      !refreshed ||
+      Number(refreshedSlot?.fencing_token) !== Number(slot.fencing_token) ||
+      Number(refreshedSlot?.expected_pointer_generation) !==
+        Number(slot.expected_pointer_generation)
+    ) {
+      console.info(
+        "[ContentBroker] reconcile recovery was superseded before Pages write",
+      );
+      return "superseded";
+    }
+    const current =
+      (refreshed.current as unknown as ArtifactContext | null) || null;
+    if (!current) {
+      // A first-ever promotion can be terminated before Pages changes while
+      // leaving the fenced slot in a deploying state. With no current
+      // pointer there is nothing to restore; release the slot only after the
+      // target failed verification against the latest production deployment.
+      await sql`select private.finish_production_recovery_v1(
           ${target.site_release_id}::uuid, ${Number(slot.fencing_token)},
           ${Number(slot.expected_pointer_generation)}, true,
           ${sql.json({ production_unchanged: true, reconciled: true, no_current_release: true })}
         )`;
-        return "restored";
-      }
-      const currentFiles = await loadArtifact(current, env);
-      const reuseLatest = deploymentMatchesContext(deployment, current);
-      const restorationStartedAt = reuseLatest ? undefined : Date.now();
-      const restored = reuseLatest
-        ? deployment
-        : await upload(currentFiles, current, env);
-      if (reuseLatest) {
-        console.info(
-          "[ContentBroker] reusing latest last-known-good deployment during recovery",
-          {
-            deploymentId: deployment.id,
-            siteReleaseId: current.site_release_id,
-            siteReleaseSequence: current.site_release_sequence,
-          },
-        );
-      }
-      const evidence = await verify(
-        current,
-        restored.url,
-        env,
-        currentFiles,
-        restorationStartedAt,
+      return "restored";
+    }
+    const currentFiles = await loadArtifact(current, env);
+    const reuseLatest = deploymentMatchesContext(deployment, current);
+    const restorationStartedAt = reuseLatest ? undefined : Date.now();
+    const restored = reuseLatest
+      ? deployment
+      : await upload(currentFiles, current, env);
+    if (reuseLatest) {
+      console.info(
+        "[ContentBroker] reusing latest last-known-good deployment during recovery",
+        {
+          deploymentId: deployment.id,
+          siteReleaseId: current.site_release_id,
+          siteReleaseSequence: current.site_release_sequence,
+        },
       );
-      await sql`select private.finish_production_recovery_v1(
+    }
+    const evidence = await verify(
+      current,
+      restored.url,
+      env,
+      currentFiles,
+      restorationStartedAt,
+    );
+    await sql`select private.finish_production_recovery_v1(
         ${target.site_release_id}::uuid, ${Number(slot.fencing_token)},
         ${Number(slot.expected_pointer_generation)}, true,
         ${sql.json({ ...evidence, reconciled: true, restored_site_release_id: current.site_release_id, deployment_id: restored.id })}
       )`;
-      return "restored";
-    }
+    return "restored";
   } finally {
     await sql.end({ timeout: 2 });
   }
+}
+
+const COORDINATOR_POLL_INTERVAL_MS = 1_000;
+const COORDINATOR_WAIT_TIMEOUT_MS = 15 * 60 * 1_000;
+const COORDINATOR_QUEUE_KEY = "production-operation-queue";
+const COORDINATOR_ACTIVE_KEY = "production-operation-active";
+const COORDINATOR_PENDING_RECONCILE_KEY =
+  "production-operation-pending-reconcile";
+const COORDINATOR_COMPLETED_KEY = "production-operation-completed";
+const COORDINATOR_WATCHDOG_MS = 60_000;
+const COORDINATOR_RETENTION_MS = 24 * 60 * 60 * 1_000;
+
+function coordinatorOperationKey(id: string): string {
+  return `production-operation:${id}`;
+}
+
+async function executeCoordinatorOperation(
+  operation: CoordinatorOperation,
+  env: Env,
+): Promise<Response> {
+  if (operation.kind === "promote") {
+    if (!operation.payload)
+      return json({ error: "coordinator_payload_missing" }, 500);
+    return performPromotion(operation.payload, env);
+  }
+  if (operation.kind === "rollback") {
+    if (!operation.payload)
+      return json({ error: "coordinator_payload_missing" }, 500);
+    return handleRollbackRequest(
+      new Request("https://production-coordinator.internal/v1/rollback", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "X-Content-Control-Secret": env.CONTROL_BROKER_SECRET,
+        },
+        body: JSON.stringify(operation.payload),
+      }),
+      env,
+    );
+  }
+  const result = await reconcileProduction(env);
+  return json({ ok: true, result });
+}
+
+/**
+ * The only runtime allowed to call production Pages mutation helpers.
+ *
+ * Fetch handlers only enqueue and inspect durable state. The alarm drains one
+ * operation at a time, so promote, rollback, reconcile and repair work cannot
+ * overlap even when ordinary Worker requests interleave across awaits.
+ */
+export class ProductionCoordinator {
+  private alarmRunning = false;
+
+  constructor(
+    private readonly state: DurableObjectState,
+    private readonly env: Env,
+    private readonly execute: typeof executeCoordinatorOperation = executeCoordinatorOperation,
+  ) {}
+
+  async fetch(request: Request): Promise<Response> {
+    const url = new URL(request.url);
+    if (request.method === "POST" && url.pathname === "/internal/enqueue") {
+      let input: JsonRecord;
+      try {
+        input = (await request.json()) as JsonRecord;
+      } catch {
+        return json({ error: "invalid_request" }, 400);
+      }
+      const kind = String(input.kind || "") as CoordinatorOperationKind;
+      if (!["promote", "rollback", "reconcile"].includes(kind)) {
+        return json({ error: "invalid_operation_kind" }, 400);
+      }
+      const payload =
+        input.payload && typeof input.payload === "object"
+          ? (input.payload as JsonRecord)
+          : null;
+      if (kind !== "reconcile" && !payload) {
+        return json({ error: "operation_payload_required" }, 400);
+      }
+      const id = crypto.randomUUID();
+      const now = new Date().toISOString();
+      const operation: CoordinatorOperation = {
+        id,
+        kind,
+        payload,
+        status: "queued",
+        attempts: 0,
+        created_at: now,
+        updated_at: now,
+      };
+      let acceptedId = id;
+      let deduplicated = false;
+      await this.state.storage.transaction(async (transaction) => {
+        if (kind === "reconcile") {
+          const pendingId = await transaction.get<string>(
+            COORDINATOR_PENDING_RECONCILE_KEY,
+          );
+          if (pendingId) {
+            const pending = await transaction.get<CoordinatorOperation>(
+              coordinatorOperationKey(pendingId),
+            );
+            if (pending && pending.status !== "completed") {
+              acceptedId = pendingId;
+              deduplicated = true;
+              return;
+            }
+            await transaction.delete(COORDINATOR_PENDING_RECONCILE_KEY);
+          }
+        }
+        const queue =
+          (await transaction.get<string[]>(COORDINATOR_QUEUE_KEY)) || [];
+        queue.push(id);
+        await transaction.put(coordinatorOperationKey(id), operation);
+        await transaction.put(COORDINATOR_QUEUE_KEY, queue);
+        if (kind === "reconcile") {
+          await transaction.put(COORDINATOR_PENDING_RECONCILE_KEY, id);
+        }
+      });
+      await this.pruneCompletedOperations();
+      await this.state.storage.setAlarm(Date.now());
+      return json({ ok: true, operation_id: acceptedId, deduplicated }, 202);
+    }
+
+    const match = /^\/internal\/operations\/([0-9a-f-]{36})$/i.exec(
+      url.pathname,
+    );
+    if (request.method === "GET" && match) {
+      const operation = await this.state.storage.get<CoordinatorOperation>(
+        coordinatorOperationKey(match[1]),
+      );
+      return operation
+        ? json({ ok: true, operation })
+        : json({ error: "operation_not_found" }, 404);
+    }
+    return json({ error: "not_found" }, 404);
+  }
+
+  async alarm(): Promise<void> {
+    if (this.alarmRunning) return;
+    this.alarmRunning = true;
+    try {
+      let activeId = await this.state.storage.get<string>(
+        COORDINATOR_ACTIVE_KEY,
+      );
+      const queue =
+        (await this.state.storage.get<string[]>(COORDINATOR_QUEUE_KEY)) || [];
+      if (!activeId) activeId = queue[0];
+      if (!activeId) return;
+
+      const key = coordinatorOperationKey(activeId);
+      const operation = await this.state.storage.get<CoordinatorOperation>(key);
+      if (!operation) {
+        await this.finishMissingOperation(activeId);
+        return;
+      }
+      if (operation.status === "completed") {
+        await this.finishOperation(operation);
+        return;
+      }
+
+      operation.status = "running";
+      operation.attempts = Number(operation.attempts || 0) + 1;
+      operation.updated_at = new Date().toISOString();
+      await this.state.storage.put(COORDINATOR_ACTIVE_KEY, activeId);
+      await this.state.storage.put(key, operation);
+      // An alarm normally retries automatically after an uncaught runtime
+      // failure. Persist an explicit watchdog as well so an isolate reset after
+      // a Pages side effect cannot strand the active operation indefinitely.
+      await this.state.storage.setAlarm(Date.now() + COORDINATOR_WATCHDOG_MS);
+
+      let response: Response;
+      try {
+        response = await this.execute(operation, this.env);
+      } catch (error) {
+        console.error("[ContentBroker] coordinator operation failed", {
+          operationId: operation.id,
+          kind: operation.kind,
+          ...errorDiagnostics(error),
+        });
+        response = json(
+          {
+            error: "coordinator_operation_failed",
+            diagnostics: errorDiagnostics(error),
+          },
+          503,
+        );
+      }
+      operation.status = "completed";
+      operation.response_status = response.status;
+      operation.response_body = await response.text();
+      operation.completed_at = new Date().toISOString();
+      operation.updated_at = operation.completed_at;
+      await this.state.storage.put(key, operation);
+      await this.finishOperation(operation);
+    } finally {
+      this.alarmRunning = false;
+    }
+  }
+
+  private async finishOperation(
+    operation: CoordinatorOperation,
+  ): Promise<void> {
+    let hasMore = false;
+    await this.state.storage.transaction(async (transaction) => {
+      const queue =
+        (await transaction.get<string[]>(COORDINATOR_QUEUE_KEY)) || [];
+      const remaining = queue.filter((candidate) => candidate !== operation.id);
+      hasMore = remaining.length > 0;
+      await transaction.put(COORDINATOR_QUEUE_KEY, remaining);
+      await transaction.delete(COORDINATOR_ACTIVE_KEY);
+      if (operation.kind === "reconcile") {
+        const pending = await transaction.get<string>(
+          COORDINATOR_PENDING_RECONCILE_KEY,
+        );
+        if (pending === operation.id) {
+          await transaction.delete(COORDINATOR_PENDING_RECONCILE_KEY);
+        }
+      }
+      const completed =
+        (await transaction.get<CompletedCoordinatorOperation[]>(
+          COORDINATOR_COMPLETED_KEY,
+        )) || [];
+      completed.push({
+        id: operation.id,
+        completed_at: operation.completed_at || new Date().toISOString(),
+      });
+      await transaction.put(COORDINATOR_COMPLETED_KEY, completed);
+    });
+    await this.pruneCompletedOperations();
+    if (hasMore) {
+      await this.state.storage.setAlarm(Date.now());
+    }
+  }
+
+  private async finishMissingOperation(id: string): Promise<void> {
+    let hasMore = false;
+    await this.state.storage.transaction(async (transaction) => {
+      const queue =
+        (await transaction.get<string[]>(COORDINATOR_QUEUE_KEY)) || [];
+      const remaining = queue.filter((candidate) => candidate !== id);
+      hasMore = remaining.length > 0;
+      await transaction.put(COORDINATOR_QUEUE_KEY, remaining);
+      await transaction.delete(COORDINATOR_ACTIVE_KEY);
+      const pending = await transaction.get<string>(
+        COORDINATOR_PENDING_RECONCILE_KEY,
+      );
+      if (pending === id) {
+        await transaction.delete(COORDINATOR_PENDING_RECONCILE_KEY);
+      }
+    });
+    if (hasMore) {
+      await this.state.storage.setAlarm(Date.now());
+    }
+  }
+
+  private async pruneCompletedOperations(): Promise<void> {
+    const cutoff = Date.now() - COORDINATOR_RETENTION_MS;
+    await this.state.storage.transaction(async (transaction) => {
+      const completed =
+        (await transaction.get<CompletedCoordinatorOperation[]>(
+          COORDINATOR_COMPLETED_KEY,
+        )) || [];
+      const retained: CompletedCoordinatorOperation[] = [];
+      for (const item of completed) {
+        if (Date.parse(item.completed_at) >= cutoff) {
+          retained.push(item);
+        } else {
+          await transaction.delete(coordinatorOperationKey(item.id));
+        }
+      }
+      await transaction.put(COORDINATOR_COMPLETED_KEY, retained);
+    });
+  }
+}
+
+async function enqueueCoordinatorOperation(
+  env: Env,
+  kind: CoordinatorOperationKind,
+  payload: JsonRecord | null = null,
+) {
+  if (!env.PRODUCTION_COORDINATOR) {
+    return {
+      response: json({ error: "production_coordinator_unavailable" }, 503),
+      stub: null,
+      operationId: null,
+    };
+  }
+  const id = env.PRODUCTION_COORDINATOR.idFromName(
+    `pages-project:${env.PAGES_PROJECT}`,
+  );
+  const stub = env.PRODUCTION_COORDINATOR.get(id);
+  const enqueued = await stub.fetch(
+    new Request("https://production-coordinator.internal/internal/enqueue", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ kind, payload }),
+    }),
+  );
+  if (!enqueued.ok) {
+    return { response: enqueued, stub: null, operationId: null };
+  }
+  const accepted = (await enqueued.json()) as JsonRecord;
+  const operationId = String(accepted.operation_id || "");
+  if (!UUID.test(operationId)) {
+    return {
+      response: json({ error: "invalid_coordinator_response" }, 503),
+      stub: null,
+      operationId: null,
+    };
+  }
+  return {
+    response: json(accepted, enqueued.status),
+    stub,
+    operationId,
+  };
+}
+
+async function submitCoordinatorOperation(
+  env: Env,
+  kind: CoordinatorOperationKind,
+  payload: JsonRecord | null = null,
+): Promise<Response> {
+  const enqueued = await enqueueCoordinatorOperation(env, kind, payload);
+  if (!enqueued.stub || !enqueued.operationId) return enqueued.response;
+  const { stub, operationId } = enqueued;
+
+  const deadline = Date.now() + COORDINATOR_WAIT_TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    const status = await stub.fetch(
+      new Request(
+        `https://production-coordinator.internal/internal/operations/${operationId}`,
+      ),
+    );
+    if (!status.ok) return status;
+    const result = (await status.json()) as {
+      operation?: CoordinatorOperation;
+    };
+    if (result.operation?.status === "completed") {
+      return new Response(result.operation.response_body || "", {
+        status: result.operation.response_status || 500,
+        headers: {
+          "Content-Type": "application/json; charset=utf-8",
+          "Cache-Control": "no-store",
+        },
+      });
+    }
+    await new Promise((resolve) =>
+      setTimeout(resolve, COORDINATOR_POLL_INTERVAL_MS),
+    );
+  }
+  return json(
+    { error: "coordinator_wait_timeout", operation_id: operationId },
+    504,
+  );
+}
+
+async function handlePromotionRequest(
+  request: Request,
+  env: Env,
+): Promise<Response> {
+  let body: JsonRecord;
+  try {
+    body = JSON.parse(
+      new TextDecoder("utf-8", { fatal: true }).decode(
+        await verifyWorkflowRequest(request, env),
+      ),
+    ) as JsonRecord;
+    validatePromotion(body);
+  } catch {
+    return json({ error: "unauthorized_or_invalid" }, 401);
+  }
+  return submitCoordinatorOperation(env, "promote", body);
+}
+
+async function handleCoordinatedRollbackRequest(
+  request: Request,
+  env: Env,
+): Promise<Response> {
+  if (
+    !bytesEqual(
+      request.headers.get("X-Content-Control-Secret") || "",
+      env.CONTROL_BROKER_SECRET,
+    )
+  ) {
+    return json({ error: "unauthorized" }, 401);
+  }
+  const bytes = new Uint8Array(await request.arrayBuffer());
+  if (bytes.byteLength > MAX_REQUEST_BYTES)
+    return json({ error: "payload_too_large" }, 413);
+  let payload: JsonRecord;
+  try {
+    payload = JSON.parse(
+      new TextDecoder("utf-8", { fatal: true }).decode(bytes),
+    ) as JsonRecord;
+  } catch {
+    return json({ error: "invalid_request" }, 400);
+  }
+  return submitCoordinatorOperation(env, "rollback", payload);
+}
+
+async function handleCoordinatedReconcileRequest(
+  request: Request,
+  env: Env,
+): Promise<Response> {
+  if (
+    !bytesEqual(
+      request.headers.get("X-Content-Control-Secret") || "",
+      env.CONTROL_BROKER_SECRET,
+    )
+  ) {
+    return json({ error: "unauthorized" }, 401);
+  }
+  return submitCoordinatorOperation(env, "reconcile");
 }
 
 export default {
@@ -1650,21 +2415,11 @@ export default {
     const path = new URL(request.url).pathname;
     if (request.method !== "POST")
       return Promise.resolve(json({ error: "method_not_allowed" }, 405));
-    if (path === "/v1/promote") return promote(request, env);
-    if (path === "/v1/rollback") return handleRollbackRequest(request, env);
-    if (path === "/v1/reconcile") {
-      if (
-        !bytesEqual(
-          request.headers.get("X-Content-Control-Secret") || "",
-          env.CONTROL_BROKER_SECRET,
-        )
-      ) {
-        return Promise.resolve(json({ error: "unauthorized" }, 401));
-      }
-      return reconcileProduction(env)
-        .then((result) => json({ ok: true, result }))
-        .catch(() => json({ error: "reconcile_failed" }, 503));
-    }
+    if (path === "/v1/promote") return handlePromotionRequest(request, env);
+    if (path === "/v1/rollback")
+      return handleCoordinatedRollbackRequest(request, env);
+    if (path === "/v1/reconcile")
+      return handleCoordinatedReconcileRequest(request, env);
     return Promise.resolve(json({ error: "not_found" }, 404));
   },
   scheduled(
@@ -1673,11 +2428,19 @@ export default {
     context: ExecutionContext,
   ): void {
     context.waitUntil(
-      reconcileProduction(env).catch((error) => {
-        console.error("[ContentBroker] reconcile failed", {
-          ...errorDiagnostics(error),
-        });
-      }),
+      enqueueCoordinatorOperation(env, "reconcile")
+        .then(({ response }) => {
+          if (!response.ok) {
+            throw new Error(
+              `Production reconcile enqueue failed with ${response.status}`,
+            );
+          }
+        })
+        .catch((error) => {
+          console.error("[ContentBroker] reconcile enqueue failed", {
+            ...errorDiagnostics(error),
+          });
+        }),
     );
   },
 };

--- a/workers/content/deployer/index.test.ts
+++ b/workers/content/deployer/index.test.ts
@@ -5,12 +5,41 @@ import {
   diffGitHubTrees,
   handleBuildContentRequest,
   handleCodeReleaseRequest,
+  handleDeploymentCallback,
+  handleDeploymentPlanRequest,
   handleRecoveryHealthCallback,
   outboxAlertReasons,
   runRetentionMaintenance,
   validateCodeReleaseChangeSet,
   validateDispatchPayload,
 } from "./index";
+
+async function signedDeploymentCallback(
+  secret: string,
+  payload: Record<string, unknown>,
+): Promise<Request> {
+  const body = JSON.stringify(payload);
+  const key = await crypto.subtle.importKey(
+    "raw",
+    new TextEncoder().encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  const signature = await crypto.subtle.sign(
+    "HMAC",
+    key,
+    new TextEncoder().encode(body),
+  );
+  const hex = Array.from(new Uint8Array(signature), (value) =>
+    value.toString(16).padStart(2, "0"),
+  ).join("");
+  return new Request("https://deployer.test/internal/deployment-callback", {
+    method: "POST",
+    headers: { "X-Content-Signature": hex },
+    body,
+  });
+}
 
 async function signedRecoveryRequest(
   secret: string,
@@ -147,6 +176,197 @@ describe("content release dispatch recovery", () => {
     });
     expect(events).toEqual(["failed", "building"]);
     expect(end).toHaveBeenCalledTimes(2);
+  });
+
+  it("dispatches only the fenced identity and never a caller plan", async () => {
+    const attemptToken = "44444444-4444-4444-8444-444444444444";
+    const claimed = {
+      site_release_id: valid.site_release_id,
+      dispatch_id: valid.dispatch_id,
+      payload: valid,
+      attempt_token: attemptToken,
+      execution_generation: 3,
+    };
+    const end = vi.fn(async () => undefined);
+    const sql = vi.fn(async (strings: TemplateStringsArray) => {
+      const query = strings.join("?");
+      if (query.includes("claim_content_outbox_v1"))
+        return [{ result: claimed }];
+      if (query.includes("record_deployment_event_v1")) return [];
+      throw new Error(`Unexpected SQL: ${query}`);
+    });
+    Object.assign(sql, { json: vi.fn((value: unknown) => value), end });
+    const dispatch = vi.fn(async () => undefined);
+
+    await expect(
+      dispatchOne({} as never, {
+        openDatabase: vi.fn(() => sql as never),
+        dispatch,
+        randomUUID: () => "33333333-3333-4333-8333-333333333333",
+      }),
+    ).resolves.toBe("dispatched");
+
+    expect(dispatch.mock.calls[0][2]).toMatchObject({
+      attempt_token: attemptToken,
+      execution_generation: "3",
+    });
+    expect(dispatch.mock.calls[0][2]).not.toHaveProperty("resume_plan");
+  });
+});
+
+describe("server-computed deployment plan", () => {
+  it("returns the database plan only for the active fenced attempt", async () => {
+    const plan = {
+      resume_stage: "promote",
+      artifact: { artifact_sha256: "a".repeat(64) },
+      trusted_baseline: { artifact_sha256: "b".repeat(64) },
+      preview_checkpoint: { preview_url: "https://preview.example" },
+    };
+    const end = vi.fn(async () => undefined);
+    const sql = vi.fn(async (strings: TemplateStringsArray) => {
+      const query = strings.join("?");
+      if (query.includes("accept_deployment_callback_v2"))
+        return [{ result: true }];
+      if (query.includes("get_content_release_resume_plan_v1"))
+        return [{ result: plan }];
+      throw new Error(`Unexpected SQL: ${query}`);
+    });
+    Object.assign(sql, { json: vi.fn((value: unknown) => value), end });
+    const response = await handleDeploymentPlanRequest(
+      await signedDeploymentCallback("callback-secret", {
+        site_release_id: valid.site_release_id,
+        dispatch_id: valid.dispatch_id,
+        attempt_token: "44444444-4444-4444-8444-444444444444",
+        execution_generation: 2,
+      }),
+      {
+        DEPLOY_CALLBACK_SECRET: "callback-secret",
+        CONTENT_RELEASE_RESUME_ENABLED: "true",
+        CONTENT_RELEASE_INCREMENTAL_REUSE_ENABLED: "true",
+      } as never,
+      { openDatabase: vi.fn(() => sql as never) },
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual(plan);
+    expect(sql).toHaveBeenCalledTimes(2);
+    expect(end).toHaveBeenCalledWith({ timeout: 2 });
+  });
+});
+
+describe("fenced deployment callbacks", () => {
+  it("rejects an unfenced content callback before opening the database", async () => {
+    const openDatabase = vi.fn();
+    const response = await handleDeploymentCallback(
+      await signedDeploymentCallback("callback-secret", {
+        site_release_id: valid.site_release_id,
+        dispatch_id: valid.dispatch_id,
+        event_type: "failed",
+        evidence: { error: "workflow_failed" },
+      }),
+      {
+        DEPLOY_CALLBACK_SECRET: "callback-secret",
+        CONTENT_RELEASE_REQUIRE_FENCED_CALLBACKS: "true",
+      } as never,
+      { openDatabase },
+    );
+
+    expect(response.status).toBe(409);
+    expect(await response.json()).toEqual({
+      error: "fenced_callback_required",
+    });
+    expect(openDatabase).not.toHaveBeenCalled();
+  });
+
+  it("keeps the unfenced callback path available only when the rollout gate is off", async () => {
+    const end = vi.fn(async () => undefined);
+    const sql = vi.fn(async (strings: TemplateStringsArray) => {
+      const query = strings.join("?");
+      if (query.includes("record_deployment_event_v1")) return [];
+      throw new Error(`Unexpected SQL: ${query}`);
+    });
+    Object.assign(sql, { json: vi.fn((value: unknown) => value), end });
+    const response = await handleDeploymentCallback(
+      await signedDeploymentCallback("callback-secret", {
+        site_release_id: valid.site_release_id,
+        dispatch_id: valid.dispatch_id,
+        event_type: "failed",
+        evidence: { error: "workflow_failed" },
+      }),
+      {
+        DEPLOY_CALLBACK_SECRET: "callback-secret",
+        CONTENT_RELEASE_REQUIRE_FENCED_CALLBACKS: "false",
+      } as never,
+      { openDatabase: vi.fn(() => sql as never) },
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ ok: true });
+    expect(sql).toHaveBeenCalledTimes(1);
+    expect(end).toHaveBeenCalledWith({ timeout: 2 });
+  });
+
+  it("audits a stale callback without mutating release state", async () => {
+    const end = vi.fn(async () => undefined);
+    const sql = vi.fn(async (strings: TemplateStringsArray) => {
+      const query = strings.join("?");
+      if (query.includes("accept_deployment_callback_v2"))
+        return [{ result: false }];
+      throw new Error(`Unexpected SQL after stale callback: ${query}`);
+    });
+    Object.assign(sql, { json: vi.fn((value: unknown) => value), end });
+    const response = await handleDeploymentCallback(
+      await signedDeploymentCallback("callback-secret", {
+        site_release_id: valid.site_release_id,
+        dispatch_id: valid.dispatch_id,
+        attempt_token: "44444444-4444-4444-8444-444444444444",
+        execution_generation: 2,
+        event_type: "preview_verified",
+        evidence: {
+          artifact_sha256: "a".repeat(64),
+          content_sha256: "b".repeat(64),
+          code_sha: "c".repeat(40),
+        },
+      }),
+      {
+        DEPLOY_CALLBACK_SECRET: "callback-secret",
+      } as never,
+      { openDatabase: vi.fn(() => sql as never) },
+    );
+
+    expect(response.status).toBe(202);
+    expect(await response.json()).toEqual({ ok: true, stale: true });
+    expect(sql).toHaveBeenCalledTimes(1);
+    expect(end).toHaveBeenCalledWith({ timeout: 2 });
+  });
+
+  it("extends a fenced attempt lease on heartbeat", async () => {
+    const end = vi.fn(async () => undefined);
+    const sql = vi.fn(async (strings: TemplateStringsArray) => {
+      const query = strings.join("?");
+      if (query.includes("accept_deployment_callback_v2"))
+        return [{ result: true }];
+      throw new Error(`Unexpected SQL: ${query}`);
+    });
+    Object.assign(sql, { json: vi.fn((value: unknown) => value), end });
+    const response = await handleDeploymentCallback(
+      await signedDeploymentCallback("callback-secret", {
+        site_release_id: valid.site_release_id,
+        dispatch_id: valid.dispatch_id,
+        attempt_token: "44444444-4444-4444-8444-444444444444",
+        execution_generation: 2,
+        event_type: "heartbeat",
+        evidence: { github_run_id: 123, stage: "checkout_verified" },
+      }),
+      {
+        DEPLOY_CALLBACK_SECRET: "callback-secret",
+      } as never,
+      { openDatabase: vi.fn(() => sql as never) },
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ ok: true, lease_extended: true });
+    expect(sql).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/workers/content/deployer/index.ts
+++ b/workers/content/deployer/index.ts
@@ -8,6 +8,9 @@ type Env = {
   GITHUB_TOKEN: string;
   GITHUB_REPOSITORY: string;
   GITHUB_WORKFLOW_REF?: string;
+  CONTENT_RELEASE_RESUME_ENABLED?: string;
+  CONTENT_RELEASE_INCREMENTAL_REUSE_ENABLED?: string;
+  CONTENT_RELEASE_REQUIRE_FENCED_CALLBACKS?: string;
   DEPLOY_CALLBACK_SECRET: string;
   PREVIEW_DISPATCH_SECRET: string;
   CONTENT_BUILD_API_SECRET: string;
@@ -34,6 +37,7 @@ const UUID =
 const DATE = /^\d{4}-\d{2}-\d{2}$/;
 const SHA1 = /^[a-f0-9]{40}$/;
 const CALLBACK_EVENTS = new Set([
+  "heartbeat",
   "building",
   "artifact_registered",
   "preview_verified",
@@ -603,22 +607,32 @@ export async function dispatchOne(
       ? dependencies.randomUUID()
       : crypto.randomUUID();
     const rows = await sql<Record<string, unknown>[]>`
-			select private.claim_content_outbox_v1(${workerId}, 600) as result
+				select private.claim_content_outbox_v1(${workerId}, 1800) as result
     `;
     claimed = rows[0]?.result as Record<string, unknown> | null;
     if (!claimed) return "empty";
     const payload = claimed.payload;
     validateDispatchPayload(payload);
     const dispatchPayload = payload as Record<string, unknown>;
+    const attemptToken = String(claimed.attempt_token || "");
+    const executionGeneration = Number(claimed.execution_generation);
     await (dependencies.dispatch || githubDispatch)(
       env,
       "content-release.yml",
-      Object.fromEntries(
-        Object.entries(dispatchPayload).map(([key, value]) => [
-          key,
-          value === null ? "" : value,
-        ]),
-      ),
+      {
+        ...Object.fromEntries(
+          Object.entries(dispatchPayload).map(([key, value]) => [
+            key,
+            value === null ? "" : value,
+          ]),
+        ),
+        ...(UUID.test(attemptToken)
+          ? {
+              attempt_token: attemptToken,
+              execution_generation: String(executionGeneration),
+            }
+          : {}),
+      },
     );
     await recordEvent(
       sql,
@@ -639,6 +653,83 @@ export async function dispatchOne(
       );
     }
     throw error;
+  } finally {
+    await sql.end({ timeout: 2 });
+  }
+}
+
+export async function handleDeploymentPlanRequest(
+  request: Request,
+  env: Env,
+  dependencies: { openDatabase?: typeof openContentDatabase } = {},
+): Promise<Response> {
+  if (request.method !== "POST")
+    return json({ error: "method_not_allowed" }, 405);
+  const bytes = new Uint8Array(await request.arrayBuffer());
+  if (bytes.byteLength === 0 || bytes.byteLength > 8 * 1024)
+    return json({ error: "invalid_request" }, 400);
+  const supplied = request.headers.get("X-Content-Signature") || "";
+  const expected = await hmacHex(env.DEPLOY_CALLBACK_SECRET, bytes);
+  if (!timingSafeHex(supplied, expected))
+    return json({ error: "unauthorized" }, 401);
+  let payload: Record<string, unknown>;
+  try {
+    payload = JSON.parse(
+      new TextDecoder("utf-8", { fatal: true }).decode(bytes),
+    );
+  } catch {
+    return json({ error: "invalid_request" }, 400);
+  }
+  const releaseId = String(payload.site_release_id || "");
+  const dispatchId = String(payload.dispatch_id || "");
+  const attemptToken = String(payload.attempt_token || "");
+  const executionGeneration = Number(payload.execution_generation);
+  if (
+    !UUID.test(releaseId) ||
+    !UUID.test(dispatchId) ||
+    !UUID.test(attemptToken) ||
+    !Number.isSafeInteger(executionGeneration) ||
+    executionGeneration < 1
+  ) {
+    return json({ error: "invalid_request" }, 400);
+  }
+  const sql = (dependencies.openDatabase || openContentDatabase)(
+    env,
+    "content-deployer-plan",
+  );
+  try {
+    const evidence = {
+      stage: "resume_plan",
+      requested_at: new Date().toISOString(),
+    };
+    const accepted = await sql<Record<string, unknown>[]>`
+      select private.accept_deployment_callback_v2(
+        ${releaseId}::uuid, ${dispatchId}::uuid, ${attemptToken}::uuid,
+        ${executionGeneration}, 'heartbeat', ${sql.json(evidence)}
+      ) as result
+    `;
+    if (accepted[0]?.result !== true)
+      return json({ error: "stale_attempt" }, 409);
+    const rows = await sql<Record<string, unknown>[]>`
+      select private.get_content_release_resume_plan_v1(
+        ${releaseId}::uuid, ${dispatchId}::uuid, ${attemptToken}::uuid
+      ) as result
+    `;
+    const plan = rows[0]?.result as Record<string, unknown> | null;
+    if (!plan) throw new Error("Resume plan is unavailable");
+    return json({
+      ...plan,
+      resume_stage:
+        env.CONTENT_RELEASE_RESUME_ENABLED === "true"
+          ? plan.resume_stage
+          : "build",
+      trusted_baseline:
+        env.CONTENT_RELEASE_INCREMENTAL_REUSE_ENABLED === "true"
+          ? plan.trusted_baseline
+          : null,
+    });
+  } catch {
+    return json({ error: "service_unavailable" }, 503);
   } finally {
     await sql.end({ timeout: 2 });
   }
@@ -704,6 +795,7 @@ export async function runRetentionMaintenance(
 export async function handleDeploymentCallback(
   request: Request,
   env: Env,
+  dependencies: { openDatabase?: typeof openContentDatabase } = {},
 ): Promise<Response> {
   if (request.method !== "POST")
     return json({ error: "method_not_allowed" }, 405);
@@ -727,6 +819,8 @@ export async function handleDeploymentCallback(
   const releaseId = String(payload.site_release_id || "");
   const dispatchId = String(payload.dispatch_id || "");
   const eventType = String(payload.event_type || "");
+  const attemptToken = String(payload.attempt_token || "");
+  const executionGeneration = Number(payload.execution_generation);
   if (
     !UUID.test(releaseId) ||
     !UUID.test(dispatchId) ||
@@ -737,7 +831,24 @@ export async function handleDeploymentCallback(
   ) {
     return json({ error: "invalid_request" }, 400);
   }
-  const sql = openContentDatabase(env, "content-deployer-callback");
+  const editorialCallback =
+    eventType === "editorial_preview_verified" ||
+    eventType === "editorial_preview_failed";
+  const fencedCallback =
+    UUID.test(attemptToken) &&
+    Number.isSafeInteger(executionGeneration) &&
+    executionGeneration > 0;
+  if (
+    !editorialCallback &&
+    env.CONTENT_RELEASE_REQUIRE_FENCED_CALLBACKS === "true" &&
+    !fencedCallback
+  ) {
+    return json({ error: "fenced_callback_required" }, 409);
+  }
+  const sql = (dependencies.openDatabase || openContentDatabase)(
+    env,
+    "content-deployer-callback",
+  );
   try {
     if (eventType === "editorial_preview_verified") {
       const evidence = payload.evidence as Record<string, unknown>;
@@ -759,6 +870,23 @@ export async function handleDeploymentCallback(
       `;
       return json({ ok: true });
     }
+    if (fencedCallback) {
+      const acceptedRows = await sql<Record<string, unknown>[]>`
+        select private.accept_deployment_callback_v2(
+          ${releaseId}::uuid, ${dispatchId}::uuid, ${attemptToken}::uuid,
+          ${executionGeneration}, ${eventType},
+          ${sql.json(payload.evidence as Record<string, unknown>)}
+        ) as result
+      `;
+      if (acceptedRows[0]?.result !== true) {
+        return json({ ok: true, stale: true }, 202);
+      }
+      if (eventType === "heartbeat") {
+        return json({ ok: true, lease_extended: true });
+      }
+    } else if (eventType === "heartbeat") {
+      return json({ error: "attempt_token_required" }, 400);
+    }
     if (eventType === "artifact_registered") {
       const evidence = payload.evidence as Record<string, unknown>;
       await sql`
@@ -769,14 +897,34 @@ export async function handleDeploymentCallback(
           ${String(evidence.code_sha)}, ${String(evidence.build_environment_version)}
         )
       `;
+      if (fencedCallback) {
+        await sql`
+          select private.attest_release_artifact_v1(
+            ${releaseId}::uuid, ${String(evidence.artifact_sha256)},
+            ${String(evidence.verification_profile)},
+            ${String(evidence.r2_verified_at)}::timestamptz,
+            ${String(evidence.lock_evidence_sha256)}
+          )
+        `;
+      }
     }
-    await recordEvent(
-      sql,
-      releaseId,
-      dispatchId,
-      eventType,
-      payload.evidence as Record<string, unknown>,
-    );
+    if (fencedCallback) {
+      await sql`
+        select private.record_deployment_checkpoint_v2(
+          ${releaseId}::uuid, ${dispatchId}::uuid, ${attemptToken}::uuid,
+          ${executionGeneration}, ${eventType},
+          ${sql.json(payload.evidence as Record<string, unknown>)}
+        )
+      `;
+    } else {
+      await recordEvent(
+        sql,
+        releaseId,
+        dispatchId,
+        eventType,
+        payload.evidence as Record<string, unknown>,
+      );
+    }
     return json({ ok: true });
   } catch {
     return json({ error: "service_unavailable" }, 503);
@@ -1285,6 +1433,8 @@ export default {
     const url = new URL(request.url);
     if (url.pathname === "/callbacks/github")
       return handleDeploymentCallback(request, env);
+    if (url.pathname === "/internal/deployment-plan")
+      return handleDeploymentPlanRequest(request, env);
     if (url.pathname === "/internal/recovery-health")
       return handleRecoveryHealthCallback(request, env);
     if (url.pathname === "/internal/code-release") {

--- a/workers/content/ingestion/mirror.ts
+++ b/workers/content/ingestion/mirror.ts
@@ -8,6 +8,7 @@ import {
   isRetryableReleaseContention,
   openContentDatabase,
   prepareIngestionPublicationSlot,
+  recordScheduledRunTrace as persistScheduledRunTrace,
   reserveIngestionSiteRelease,
   type ContentSql,
 } from "../shared/db";
@@ -43,9 +44,37 @@ export type MirrorResult = {
   reportSnapshotId?: string;
   siteReleaseId?: string;
   siteReleaseSequence?: number;
+  dispatchId?: string;
   contentSha256?: string;
   manifestSha256?: string;
 };
+
+export async function recordScheduledRunTrace(
+  env: MirrorEnv,
+  input: {
+    runId: string;
+    scheduledAt: string;
+    eventType: "started" | "succeeded" | "failed";
+    evidence: Record<string, unknown>;
+  },
+  dependencies: {
+    openDatabase?: typeof openContentDatabase;
+  } = {},
+): Promise<boolean> {
+  if (String(env.CONTENT_DATABASE_MIRROR_ENABLED).toLowerCase() !== "true") {
+    return false;
+  }
+  const sql = (dependencies.openDatabase || openContentDatabase)(
+    env,
+    "content-ingestor-run-trace",
+  );
+  try {
+    await persistScheduledRunTrace(sql, input);
+    return true;
+  } finally {
+    await (sql as ContentSql).end({ timeout: 2 });
+  }
+}
 
 const MAX_CONTENTION_ATTEMPTS = 3;
 const CONTENTION_RETRY_BASE_MS = 100;
@@ -299,6 +328,7 @@ export async function mirrorStructuredReport(
       reportSnapshotId: String(snapshot.report_snapshot_id),
       siteReleaseId: String(release.site_release_id),
       siteReleaseSequence: Number(release.site_release_sequence),
+      dispatchId: release.dispatch_id ? String(release.dispatch_id) : undefined,
       contentSha256: reportObject.sha256,
       manifestSha256: manifestObject.sha256,
     };

--- a/workers/content/shared/db.ts
+++ b/workers/content/shared/db.ts
@@ -167,3 +167,21 @@ export async function finalizeSiteRelease(
   `;
   return oneJson(rows, "result");
 }
+
+export async function recordScheduledRunTrace(
+  sql: ContentSql,
+  input: {
+    runId: string;
+    scheduledAt: string;
+    eventType: "started" | "succeeded" | "failed";
+    evidence: Record<string, unknown>;
+  },
+): Promise<Record<string, unknown>> {
+  const rows = await sql<Record<string, unknown>[]>`
+    select private.record_scheduled_run_trace_v1(
+      ${input.runId}, ${input.scheduledAt}::timestamptz,
+      ${input.eventType}, ${sql.json(input.evidence)}
+    ) as result
+  `;
+  return oneJson(rows, "result");
+}

--- a/wrangler.content-broker.toml
+++ b/wrangler.content-broker.toml
@@ -37,6 +37,14 @@ bucket_name = "bubble-content-artifacts"
 binding = "CONTENT_DB"
 id = "136110d1dbf246d8b655e047cb4a8f0d"
 
+[[durable_objects.bindings]]
+name = "PRODUCTION_COORDINATOR"
+class_name = "ProductionCoordinator"
+
+[[migrations]]
+tag = "production-coordinator-v1"
+new_sqlite_classes = ["ProductionCoordinator"]
+
 [observability]
 enabled = true
 head_sampling_rate = 1

--- a/wrangler.content-deployer.toml
+++ b/wrangler.content-deployer.toml
@@ -14,6 +14,11 @@ crons = ["* * * * *"]
 [vars]
 GITHUB_REPOSITORY = "DylanDDeng/ai-bubblebrain-daily-news"
 GITHUB_WORKFLOW_REF = "main"
+CONTENT_RELEASE_RESUME_ENABLED = "false"
+CONTENT_RELEASE_INCREMENTAL_REUSE_ENABLED = "false"
+# Keep legacy callbacks compatible during the drain phase. Set this to "true"
+# only after all workflows dispatched before the fenced rollout have finished.
+CONTENT_RELEASE_REQUIRE_FENCED_CALLBACKS = "false"
 
 [[hyperdrive]]
 binding = "CONTENT_DB"


### PR DESCRIPTION
## Summary

- serialize all production Pages writes through the ProductionCoordinator Durable Object and restore same-release drift from the reconciler
- add attempt-token fencing, immutable checkpoints, server-owned resume plans, and verified R2 incremental reuse
- add a shared 16-slot schedule contract plus KV/DB/release observability and a two-day rollout gate
- keep incremental reuse, resume, and strict fenced callbacks disabled for staged rollout

## Safety and rollout

This PR uses an expand -> switch -> contract sequence:

1. Apply migrations 002-004.
2. Deploy the new Broker, Deployer, main Worker, and workflow while all three release feature flags remain false.
3. Drain workflows and outbox attempts created by the previous release path.
4. Confirm the Broker only calls attempt-fenced and reconciler-specific RPCs.
5. Apply `supabase/post_deploy/20260724_revoke_legacy_production_promotion.sql`.
6. Enable incremental R2 reuse, then resume, then strict fenced callbacks one at a time.
7. Verify both current APIs, Pages/custom-domain manifests, and t+15/45/120 stability evidence.

## Validation

- `npm test`: 43 files, 641 tests
- clean Supabase reset: passed
- all migrations applied a second time: passed
- pgTAP: 323 tests on both passes
- content failure matrix: passed
- Broker, Deployer, and main Worker Wrangler dry-runs: passed
- `git diff --check`: passed

## Important default state

- `CONTENT_RELEASE_INCREMENTAL_REUSE_ENABLED=false`
- `CONTENT_RELEASE_RESUME_ENABLED=false`
- `CONTENT_RELEASE_REQUIRE_FENCED_CALLBACKS=false`

Production deployment is intentionally gated until old runs are drained and the staged fault-injection and convergence checks have passed.