### PR TITLE
fix: enforce fenced production callbacks

### DIFF
--- a/scripts/test-content-failure-matrix-local.mjs
+++ b/scripts/test-content-failure-matrix-local.mjs
@@ -294,12 +294,39 @@ async function prepareRelease(release) {
 }
 
 async function authorizeForward(release, generation) {
+  const attemptToken = randomUUID();
+  const attemptRows = await admin`
+    update private.content_outbox
+    set status = 'preview_verified',
+        attempt_token = ${attemptToken}::uuid,
+        execution_generation = execution_generation + 1,
+        locked_by = ${`failure-matrix:${release.label}`},
+        locked_at = clock_timestamp(),
+        lease_expires_at = clock_timestamp() + interval '30 minutes',
+        updated_at = clock_timestamp()
+    where site_release_id = ${release.site_release_id}::uuid
+      and dispatch_id = ${release.dispatchId}::uuid
+    returning execution_generation
+  `;
+  assert(
+    attemptRows.length === 1,
+    `Could not prepare a fenced promotion attempt for ${release.label}`,
+  );
+  const executionGeneration = Number(attemptRows[0].execution_generation);
+  const lockedBy = `broker:${release.dispatchId}:${attemptToken}`;
   return rpc(
     await asRole(
       "content_deployer",
       (sql) => sql`
-			select private.authorize_production_promotion_v1(
-				${release.site_release_id}::uuid, ${generation}, ${`failure-matrix:${release.label}`}, 600
+			select private.authorize_attempt_production_promotion_v1(
+				${release.site_release_id}::uuid,
+				${release.dispatchId}::uuid,
+				${attemptToken}::uuid,
+				${executionGeneration},
+				${generation},
+				${lockedBy},
+				900,
+				600
 			) as result
 		`,
     ),
@@ -325,8 +352,13 @@ async function commitForward(
     await asRole(
       "content_deployer",
       (sql) => sql`
-			select private.commit_production_promotion_v1(
-				${release.site_release_id}::uuid, ${fencingToken}, ${expectedGeneration},
+			select private.commit_attempt_production_promotion_v1(
+				${release.site_release_id}::uuid,
+				${authorization.dispatch_id}::uuid,
+				${authorization.attempt_token}::uuid,
+				${authorization.execution_generation},
+				${fencingToken},
+				${expectedGeneration},
 				${`pages-${release.label}`}, ${manifestSha256}, ${artifactSha256},
 				${buildEnvironment}, ${sql.json(evidence)}
 			) as result
@@ -1349,12 +1381,12 @@ try {
   await expectRejected(
     "late C promotion commit",
     () => commitForward(releaseC, authC, 2),
-    /Stale production fencing token|Pointer generation conflict/,
+    /Stale production deployment attempt|Stale production fencing token|Pointer generation conflict/,
   );
   await expectRejected(
     "late B promotion commit",
     () => commitForward(releaseB, promotedB.authorization, 1),
-    /Stale production fencing token|Pointer generation conflict/,
+    /Stale production deployment attempt|Stale production fencing token|Pointer generation conflict/,
   );
 
   const releaseD = await createRelease(snapshotA, "D-after-rollback");

--- a/supabase/migrations/20260724000500_revoke_legacy_production_promotion.sql
+++ b/supabase/migrations/20260724000500_revoke_legacy_production_promotion.sql
@@ -1,10 +1,8 @@
 -- Contract phase for the attempt-fenced Broker rollout.
 --
--- Do not run this with the expand migration. Apply it only after every
--- production Broker instance is confirmed to call
--- authorize_attempt_production_promotion_v1. Keeping this outside
--- supabase/migrations prevents an automatic db push from breaking an older
--- Broker during the DB-to-Worker deployment window.
+-- The expand migrations and fenced Broker must be deployed before this
+-- migration. Once applied, runtime code can authorize and commit forward
+-- production promotions only through the attempt-fenced wrappers.
 
 begin;
 

--- a/supabase/tests/database/content_database_security.test.sql
+++ b/supabase/tests/database/content_database_security.test.sql
@@ -213,7 +213,7 @@ select ok(not has_function_privilege('content_controller', 'private.ingest_repor
 select ok(has_function_privilege('content_deployer', 'private.claim_content_outbox_v1(text,integer)', 'execute'), 'deployer can claim outbox work');
 select ok(has_function_privilege('content_deployer', 'private.get_build_release_report_v1(uuid,date)', 'execute'), 'deployer can read an exact report for an authenticated build');
 select ok(has_function_privilege('content_deployer', 'private.get_build_release_manifest_v1(uuid)', 'execute'), 'deployer can read an exact manifest for an authenticated build');
-select ok(has_function_privilege('content_deployer', 'private.commit_production_promotion_v1(uuid,bigint,bigint,text,text,text,text,jsonb)', 'execute'), 'deployer can commit verified promotion');
+select ok(not has_function_privilege('content_deployer', 'private.commit_production_promotion_v1(uuid,bigint,bigint,text,text,text,text,jsonb)', 'execute'), 'deployer cannot bypass the attempt-fenced promotion commit');
 select ok(has_function_privilege('content_deployer', 'private.register_release_artifact_v1(uuid,text,bigint,text,text,text,text,text)', 'execute'), 'deployer can register both immutable artifact inventory and site fingerprint hashes');
 select has_table('private', 'content_observability_checks', 'append-only production observability evidence table exists');
 select ok(has_function_privilege('content_deployer', 'private.record_content_observability_v1(jsonb)', 'execute'), 'deployer can append production observability evidence');

--- a/supabase/tests/database/production_attempt_fencing.test.sql
+++ b/supabase/tests/database/production_attempt_fencing.test.sql
@@ -1,7 +1,7 @@
 begin;
 
 create extension if not exists pgtap with schema extensions;
-select plan(21);
+select plan(23);
 
 select has_function(
   'private',
@@ -49,6 +49,22 @@ select ok(
     'execute'
   ),
   'the deployer can finish only a fenced reconciler promotion'
+);
+select ok(
+  not has_function_privilege(
+    'content_deployer',
+    'private.authorize_production_promotion_v1(uuid,bigint,text,integer)',
+    'execute'
+  ),
+  'the contract phase revokes the unfenced production authorization path'
+);
+select ok(
+  not has_function_privilege(
+    'content_deployer',
+    'private.commit_production_promotion_v1(uuid,bigint,bigint,text,text,text,text,jsonb)',
+    'execute'
+  ),
+  'the contract phase revokes the unfenced production commit path'
 );
 
 create temporary table promotion_results (

--- a/tests/worker/contentReleaseWorkflow.test.js
+++ b/tests/worker/contentReleaseWorkflow.test.js
@@ -53,7 +53,7 @@ describe("fenced content release workflow", () => {
       'CONTENT_RELEASE_INCREMENTAL_REUSE_ENABLED = "false"',
     );
     expect(deployerConfig).toContain(
-      'CONTENT_RELEASE_REQUIRE_FENCED_CALLBACKS = "false"',
+      'CONTENT_RELEASE_REQUIRE_FENCED_CALLBACKS = "true"',
     );
   });
 });

--- a/wrangler.content-deployer.toml
+++ b/wrangler.content-deployer.toml
@@ -16,9 +16,7 @@ GITHUB_REPOSITORY = "DylanDDeng/ai-bubblebrain-daily-news"
 GITHUB_WORKFLOW_REF = "main"
 CONTENT_RELEASE_RESUME_ENABLED = "false"
 CONTENT_RELEASE_INCREMENTAL_REUSE_ENABLED = "false"
-# Keep legacy callbacks compatible during the drain phase. Set this to "true"
-# only after all workflows dispatched before the fenced rollout have finished.
-CONTENT_RELEASE_REQUIRE_FENCED_CALLBACKS = "false"
+CONTENT_RELEASE_REQUIRE_FENCED_CALLBACKS = "true"
 
 [[hyperdrive]]
 binding = "CONTENT_DB"


### PR DESCRIPTION
## What changed

- add the contract migration that revokes the two unfenced production promotion RPCs from `content_deployer`
- require attempt-fenced deployment callbacks in the production Deployer configuration
- update database, workflow, and failure-matrix coverage to exercise only fenced promotion authorization and commit paths
- fix the post-deploy contract SQL to assume `content_rpc_owner` before changing function ACLs

## Why

The expand phase and fenced Broker are already deployed. Leaving the legacy authorize/commit RPCs executable would preserve a bypass around the attempt identity and execution-generation fence. This PR closes that compatibility window after the old workflow drain.

## Impact

Production forward promotion callbacks must now include a valid dispatch ID, attempt token, and execution generation. Incremental reuse and resume remain disabled.

## Validation

- `npm test` — 43 files, 641 tests
- `bash scripts/test-supabase-local.sh` — clean migrations, second-run idempotency, 2 × 325 pgTAP, full failure matrix
- `npx wrangler deploy --dry-run --config wrangler.content-deployer.toml`
- `git diff --check`