### PR TITLE
fix: reconcile legacy GitHub Trending source IDs

### DIFF
--- a/supabase/migrations/20260724000600_github_trending_source_id_reconciliation.sql
+++ b/supabase/migrations/20260724000600_github_trending_source_id_reconciliation.sql
@@ -1,0 +1,184 @@
+begin;
+
+set local role content_rpc_owner;
+
+create or replace function private.reconcile_legacy_github_trending_source_id_v1()
+returns trigger
+language plpgsql
+volatile
+security definer
+set search_path = ''
+as $$
+declare
+  v_identity_digest text;
+begin
+  if new.source_type <> 'github_trending'
+    or new.content_type <> 'project'
+    or new.source_id is distinct from new.canonical_url
+    or new.url is distinct from new.canonical_url
+    or new.canonical_url !~ '^https://github[.]com/[^/?#]+/[^/?#]+$' then
+    return new;
+  end if;
+
+  v_identity_digest := encode(
+    extensions.digest(
+      convert_to('url:' || new.canonical_url, 'utf8'),
+      'sha256'
+    ),
+    'hex'
+  );
+  if new.id <> ('n_' || v_identity_digest)
+    or new.event_id <> ('e_' || v_identity_digest) then
+    return new;
+  end if;
+
+  update private.content_items
+  set source_id = new.source_id
+  where id = new.id
+    and event_id = new.event_id
+    and identity_version = new.identity_version
+    and source_type = new.source_type
+    and content_type = new.content_type
+    and source_id ~ '^[0-9]+$'
+    and url = new.url
+    and canonical_url = new.canonical_url;
+
+  return new;
+end;
+$$;
+
+create or replace function private.reconcile_all_legacy_github_trending_source_ids_v1()
+returns integer
+language plpgsql
+volatile
+security definer
+set search_path = ''
+as $$
+declare
+  v_updated integer;
+begin
+  lock table private.content_items in share row exclusive mode;
+  lock table private.content_identity_claims in share row exclusive mode;
+
+  if exists (
+    select 1
+    from private.content_items item
+    where item.source_type = 'github_trending'
+      and item.source_id ~ '^[0-9]+$'
+      and not (
+        item.content_type = 'project'
+        and item.url is not distinct from item.canonical_url
+        and item.canonical_url ~ '^https://github[.]com/[^/?#]+/[^/?#]+$'
+        and item.id = 'n_' || encode(
+          extensions.digest(
+            convert_to('url:' || item.canonical_url, 'utf8'),
+            'sha256'
+          ),
+          'hex'
+        )
+        and item.event_id = 'e_' || substr(item.id, 3)
+      )
+  ) then
+    raise exception
+      'Legacy GitHub Trending source IDs failed canonical identity preflight';
+  end if;
+
+  if exists (
+    select 1
+    from private.content_items item
+    join private.content_identity_claims claim
+      on claim.claim_id = 'c_' || encode(
+        extensions.digest(
+          convert_to(
+            'source:github_trending:' || item.canonical_url,
+            'utf8'
+          ),
+          'sha256'
+        ),
+        'hex'
+      )
+    where item.source_type = 'github_trending'
+      and item.source_id ~ '^[0-9]+$'
+      and claim.item_id <> item.id
+  ) then
+    raise exception
+      'Legacy GitHub Trending canonical source claim belongs to another item';
+  end if;
+
+  insert into private.content_identity_claims(
+    claim_id,
+    item_id,
+    identity_version,
+    strategy
+  )
+  select
+    'c_' || encode(
+      extensions.digest(
+        convert_to(
+          'source:github_trending:' || item.canonical_url,
+          'utf8'
+        ),
+        'sha256'
+      ),
+      'hex'
+    ),
+    item.id,
+    item.identity_version,
+    'canonical_url'
+  from private.content_items item
+  where item.source_type = 'github_trending'
+    and item.source_id ~ '^[0-9]+$'
+  on conflict on constraint content_identity_claims_pkey do nothing;
+
+  update private.content_items item
+  set source_id = item.canonical_url
+  where item.source_type = 'github_trending'
+    and item.source_id ~ '^[0-9]+$';
+  get diagnostics v_updated = row_count;
+  return v_updated;
+end;
+$$;
+
+do $$
+begin
+  execute format(
+    'grant execute on function private.reconcile_legacy_github_trending_source_id_v1() to %I',
+    session_user
+  );
+end;
+$$;
+
+reset role;
+
+drop trigger if exists reconcile_legacy_github_trending_source_id
+  on private.content_items;
+create trigger reconcile_legacy_github_trending_source_id
+before insert on private.content_items
+for each row
+execute function private.reconcile_legacy_github_trending_source_id_v1();
+
+set local role content_rpc_owner;
+
+select private.reconcile_all_legacy_github_trending_source_ids_v1();
+
+revoke all on function private.reconcile_legacy_github_trending_source_id_v1()
+  from public, anon, authenticated, service_role,
+       content_ingestor, content_editor, content_controller,
+       content_reader, content_deployer, content_backup;
+revoke all on function private.reconcile_all_legacy_github_trending_source_ids_v1()
+  from public, anon, authenticated, service_role,
+       content_ingestor, content_editor, content_controller,
+       content_reader, content_deployer, content_backup;
+
+do $$
+begin
+  execute format(
+    'revoke execute on function private.reconcile_legacy_github_trending_source_id_v1() from %I',
+    session_user
+  );
+end;
+$$;
+
+reset role;
+
+commit;

--- a/supabase/tests/database/github_trending_identity_reconciliation.test.sql
+++ b/supabase/tests/database/github_trending_identity_reconciliation.test.sql
@@ -1,0 +1,273 @@
+begin;
+
+create extension if not exists pgtap with schema extensions;
+select plan(13);
+
+set local role content_rpc_owner;
+
+insert into private.content_items(
+  id,
+  event_id,
+  identity_version,
+  source_type,
+  content_type,
+  source_id,
+  source_name,
+  url,
+  canonical_url,
+  published_date,
+  time_precision,
+  provenance_kind
+)
+values (
+  'n_2955677f0d2801c015fafe447b356e88c7eca8077b5aa6416e239376b7accb37',
+  'e_2955677f0d2801c015fafe447b356e88c7eca8077b5aa6416e239376b7accb37',
+  1,
+  'github_trending',
+  'project',
+  '3',
+  'GitHub Trending',
+  'https://github.com/example/repository',
+  'https://github.com/example/repository',
+  '2026-07-16',
+  'date_only',
+  'legacy_structured_import'
+);
+
+insert into private.content_items(
+  id,
+  event_id,
+  identity_version,
+  source_type,
+  content_type,
+  source_id,
+  source_name,
+  url,
+  canonical_url,
+  published_date,
+  time_precision,
+  provenance_kind
+)
+values (
+  'n_2955677f0d2801c015fafe447b356e88c7eca8077b5aa6416e239376b7accb37',
+  'e_2955677f0d2801c015fafe447b356e88c7eca8077b5aa6416e239376b7accb37',
+  1,
+  'github_trending',
+  'project',
+  'https://github.com/example/repository',
+  'GitHub Trending',
+  'https://github.com/example/repository',
+  'https://github.com/example/repository',
+  '2026-07-24',
+  'date_only',
+  'live_ingestion'
+)
+on conflict on constraint content_items_pkey do nothing;
+
+select is(
+  (
+    select source_id
+    from private.content_items
+    where id = 'n_2955677f0d2801c015fafe447b356e88c7eca8077b5aa6416e239376b7accb37'
+  ),
+  'https://github.com/example/repository',
+  'a canonical GitHub source ID safely replaces its historical ranking index'
+);
+
+select is(
+  (
+    select count(*)
+    from private.content_items
+    where id = 'n_2955677f0d2801c015fafe447b356e88c7eca8077b5aa6416e239376b7accb37'
+  ),
+  1::bigint,
+  'source ID reconciliation preserves the canonical content item'
+);
+
+insert into private.content_items(
+  id,
+  event_id,
+  identity_version,
+  source_type,
+  content_type,
+  source_id,
+  source_name,
+  url,
+  canonical_url,
+  time_precision,
+  provenance_kind
+)
+values (
+  'n_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+  'e_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+  1,
+  'github_trending',
+  'project',
+  '9',
+  'GitHub Trending',
+  'https://github.com/example/not-the-hashed-item',
+  'https://github.com/example/not-the-hashed-item',
+  'inferred',
+  'legacy_structured_import'
+);
+
+insert into private.content_items(
+  id,
+  event_id,
+  identity_version,
+  source_type,
+  content_type,
+  source_id,
+  source_name,
+  url,
+  canonical_url,
+  time_precision,
+  provenance_kind
+)
+values (
+  'n_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+  'e_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+  1,
+  'github_trending',
+  'project',
+  'https://github.com/example/not-the-hashed-item',
+  'GitHub Trending',
+  'https://github.com/example/not-the-hashed-item',
+  'https://github.com/example/not-the-hashed-item',
+  'inferred',
+  'live_ingestion'
+)
+on conflict on constraint content_items_pkey do nothing;
+
+select is(
+  (
+    select source_id
+    from private.content_items
+    where id = 'n_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+  ),
+  '9',
+  'an item whose ID does not derive from the canonical URL remains immutable'
+);
+
+select throws_ok(
+  'select private.reconcile_all_legacy_github_trending_source_ids_v1()',
+  'P0001',
+  'Legacy GitHub Trending source IDs failed canonical identity preflight',
+  'bulk reconciliation fails closed when any historical identity is invalid'
+);
+
+delete from private.content_items
+where id = 'n_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+
+insert into private.content_items(
+  id,
+  event_id,
+  identity_version,
+  source_type,
+  content_type,
+  source_id,
+  source_name,
+  url,
+  canonical_url,
+  published_date,
+  time_precision,
+  provenance_kind
+)
+values (
+  'n_d5e00c05855bb932d0f93d26da1395ab8724f9f26319d630cd6a819e8e86f0a5',
+  'e_d5e00c05855bb932d0f93d26da1395ab8724f9f26319d630cd6a819e8e86f0a5',
+  1,
+  'github_trending',
+  'project',
+  '12',
+  'GitHub Trending',
+  'https://github.com/example/bulk-repository',
+  'https://github.com/example/bulk-repository',
+  '2026-07-16',
+  'date_only',
+  'legacy_structured_import'
+);
+
+select is(
+  private.reconcile_all_legacy_github_trending_source_ids_v1(),
+  1,
+  'the bounded bulk reconciler upgrades one validated historical row'
+);
+
+select is(
+  (
+    select source_id
+    from private.content_items
+    where id = 'n_d5e00c05855bb932d0f93d26da1395ab8724f9f26319d630cd6a819e8e86f0a5'
+  ),
+  'https://github.com/example/bulk-repository',
+  'the bulk reconciler stores the canonical repository URL'
+);
+
+select ok(
+  exists (
+    select 1
+    from private.content_identity_claims
+    where claim_id = 'c_2639127531a50fd6e135090004e789e69436e707fdc898ce967484632ac4bd2c'
+      and item_id = 'n_d5e00c05855bb932d0f93d26da1395ab8724f9f26319d630cd6a819e8e86f0a5'
+  ),
+  'the bulk reconciler records the canonical source claim'
+);
+
+select is(
+  private.reconcile_all_legacy_github_trending_source_ids_v1(),
+  0,
+  'the bulk reconciler is idempotent'
+);
+
+select ok(
+  (
+    select p.prosecdef
+    from pg_proc p
+    join pg_namespace n on n.oid = p.pronamespace
+    where n.nspname = 'private'
+      and p.proname = 'reconcile_legacy_github_trending_source_id_v1'
+  ),
+  'the reconciliation trigger uses the private security boundary'
+);
+
+select ok(
+  (
+    select coalesce(p.proconfig, '{}') @> array['search_path=""']
+    from pg_proc p
+    join pg_namespace n on n.oid = p.pronamespace
+    where n.nspname = 'private'
+      and p.proname = 'reconcile_legacy_github_trending_source_id_v1'
+  ),
+  'the reconciliation trigger has an empty search path'
+);
+
+select ok(
+  not has_function_privilege(
+    'content_ingestor',
+    'private.reconcile_legacy_github_trending_source_id_v1()',
+    'execute'
+  ),
+  'the ingestor cannot invoke the reconciliation trigger directly'
+);
+
+select ok(
+  not has_function_privilege(
+    'service_role',
+    'private.reconcile_legacy_github_trending_source_id_v1()',
+    'execute'
+  ),
+  'the service role cannot invoke the reconciliation trigger directly'
+);
+
+select ok(
+  not has_function_privilege(
+    'content_ingestor',
+    'private.reconcile_all_legacy_github_trending_source_ids_v1()',
+    'execute'
+  ),
+  'the ingestor cannot invoke bulk reconciliation'
+);
+
+select * from finish();
+rollback;


### PR DESCRIPTION
## What changed

- migrate validated historical GitHub Trending numeric source IDs to canonical repository URLs
- add a narrowly scoped insert reconciliation trigger for the same identity transition
- keep all unrelated identity drift fail-closed
- add database regression and permission coverage

## Root cause

Historical GitHub Trending rows stored ranking positions as source IDs, while current ingestion uses stable GitHub URLs. The insert-only identity guard correctly rejected that drift, which blocked the 20:00 and 22:00 content snapshots from reaching production.

## Validation

- npm test: 43 files, 641 tests passed
- local Supabase migration matrix: 338 pgTAP assertions passed twice, including idempotency
- real 113-item report ingested successfully against historical production-shaped data
- final database concurrency and security review: GO, no P0/P1 findings