### PR TITLE
fix: preserve migration role for trigger installation

### DIFF
--- a/supabase/migrations/20260724000600_github_trending_source_id_reconciliation.sql
+++ b/supabase/migrations/20260724000600_github_trending_source_id_reconciliation.sql
@@ -139,16 +139,10 @@ begin
 end;
 $$;
 
-do $$
-begin
-  execute format(
-    'grant execute on function private.reconcile_legacy_github_trending_source_id_v1() to %I',
-    session_user
-  );
-end;
-$$;
+grant execute on function private.reconcile_legacy_github_trending_source_id_v1()
+  to postgres;
 
-reset role;
+set local role postgres;
 
 drop trigger if exists reconcile_legacy_github_trending_source_id
   on private.content_items;
@@ -162,23 +156,12 @@ set local role content_rpc_owner;
 select private.reconcile_all_legacy_github_trending_source_ids_v1();
 
 revoke all on function private.reconcile_legacy_github_trending_source_id_v1()
-  from public, anon, authenticated, service_role,
+  from public, postgres, anon, authenticated, service_role,
        content_ingestor, content_editor, content_controller,
        content_reader, content_deployer, content_backup;
 revoke all on function private.reconcile_all_legacy_github_trending_source_ids_v1()
   from public, anon, authenticated, service_role,
        content_ingestor, content_editor, content_controller,
        content_reader, content_deployer, content_backup;
-
-do $$
-begin
-  execute format(
-    'revoke execute on function private.reconcile_legacy_github_trending_source_id_v1() from %I',
-    session_user
-  );
-end;
-$$;
-
-reset role;
 
 commit;


### PR DESCRIPTION
## What changed

- create and retain reconciliation functions under content_rpc_owner
- grant postgres execute only while installing the table trigger
- revoke that temporary privilege before the migration commits

## Why

The production Supabase CLI uses an ephemeral session login with postgres as its active migration role. RESET ROLE returned to the restricted session login before trigger installation, so the first production attempt failed and rolled back atomically.

## Validation

- local migration first run passed
- 338 pgTAP assertions passed
- second migration run passed idempotently
- 338 pgTAP assertions passed again
- full database failure matrix passed