### PR TITLE
fix: make production promotion asynchronously recoverable

### DIFF
--- a/scripts/request-production-promotion.mjs
+++ b/scripts/request-production-promotion.mjs
@@ -1,34 +1,231 @@
 import { createHmac } from "node:crypto";
+import { pathToFileURL } from "node:url";
 
-const brokerUrl = process.env.PRODUCTION_BROKER_URL;
-const secret = process.env.PRODUCTION_BROKER_HMAC_SECRET;
-if (!brokerUrl || !secret)
-  throw new Error("Production Broker environment is incomplete");
+const UUID =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const DEFAULT_POLL_INTERVAL_MS = 5_000;
+const DEFAULT_WAIT_TIMEOUT_MS = 45 * 60 * 1_000;
+const DEFAULT_SUBMIT_TIMEOUT_MS = 16 * 60 * 1_000;
+const DEFAULT_REQUEST_TIMEOUT_MS = 15_000;
+const MAX_CONSECUTIVE_STATUS_FAILURES = 6;
 
-const chunks = [];
-for await (const chunk of process.stdin) chunks.push(chunk);
-const body = Buffer.concat(chunks).toString("utf8");
-JSON.parse(body);
-const timestamp = String(Math.floor(Date.now() / 1000));
-const signature = createHmac("sha256", secret)
-  .update(`${timestamp}\n${body}`)
-  .digest("hex");
-const response = await fetch(new URL("/v1/promote", brokerUrl), {
-  method: "POST",
-  headers: {
-    "Content-Type": "application/json",
-    "X-Content-Timestamp": timestamp,
-    "X-Content-Signature": signature,
-  },
-  body,
-});
-const responseBody = await response.text();
-if (!response.ok) {
+function positiveInteger(value, fallback) {
+  const number = Number(value);
+  return Number.isSafeInteger(number) && number > 0 ? number : fallback;
+}
+
+function brokerError(prefix, response, responseBody) {
   const diagnosticBody = responseBody.trim().slice(0, 4096);
-  throw new Error(
-    `Production Broker rejected promotion with ${response.status}${
+  return new Error(
+    `${prefix} with ${response.status}${
       diagnosticBody ? `: ${diagnosticBody}` : ""
     }`,
   );
 }
-process.stdout.write(responseBody);
+
+function signedHeaders(secret, body, now) {
+  const timestamp = String(Math.floor(now() / 1000));
+  const signature = createHmac("sha256", secret)
+    .update(`${timestamp}\n${body}`)
+    .digest("hex");
+  return {
+    "Content-Type": "application/json",
+    "X-Content-Timestamp": timestamp,
+    "X-Content-Signature": signature,
+  };
+}
+
+async function signedPost({
+  brokerUrl,
+  path,
+  secret,
+  body,
+  fetchImpl,
+  now,
+  requestTimeoutMs,
+}) {
+  return fetchImpl(new URL(path, brokerUrl), {
+    method: "POST",
+    headers: signedHeaders(secret, body, now),
+    body,
+    signal: AbortSignal.timeout(
+      positiveInteger(requestTimeoutMs, DEFAULT_REQUEST_TIMEOUT_MS),
+    ),
+  });
+}
+
+export async function requestProductionPromotion({
+  brokerUrl,
+  secret,
+  body,
+  fetchImpl = fetch,
+  now = Date.now,
+  sleep = (milliseconds) =>
+    new Promise((resolve) => setTimeout(resolve, milliseconds)),
+  pollIntervalMs = DEFAULT_POLL_INTERVAL_MS,
+  waitTimeoutMs = DEFAULT_WAIT_TIMEOUT_MS,
+  submitTimeoutMs = DEFAULT_SUBMIT_TIMEOUT_MS,
+  requestTimeoutMs = DEFAULT_REQUEST_TIMEOUT_MS,
+}) {
+  const promotion = JSON.parse(body);
+  const siteReleaseId = String(promotion.site_release_id || "");
+  if (!UUID.test(siteReleaseId)) {
+    throw new Error("Production promotion site_release_id is invalid");
+  }
+  const submitted = await signedPost({
+    brokerUrl,
+    path: "/v1/promote",
+    secret,
+    body,
+    fetchImpl,
+    now,
+    // During the compatibility rollout the old Broker may hold this request
+    // for its full 15-minute synchronous wait. Keep a bounded but larger
+    // submit timeout until every Broker speaks the asynchronous protocol.
+    requestTimeoutMs: submitTimeoutMs,
+  });
+  const submittedBody = await submitted.text();
+  if (!submitted.ok) {
+    throw brokerError(
+      "Production Broker rejected promotion",
+      submitted,
+      submittedBody,
+    );
+  }
+  // Backward compatibility: the old Broker waits for the Durable Object and
+  // returns the final 200 response directly.
+  if (submitted.status !== 202) return submittedBody;
+
+  let accepted;
+  try {
+    accepted = JSON.parse(submittedBody);
+  } catch {
+    throw new Error("Production Broker returned an invalid operation response");
+  }
+  const operationId = String(accepted.operation_id || "");
+  if (
+    !UUID.test(operationId) ||
+    String(accepted.site_release_id || "") !== siteReleaseId
+  ) {
+    throw new Error("Production Broker returned an invalid operation identity");
+  }
+
+  const deadline =
+    now() + positiveInteger(waitTimeoutMs, DEFAULT_WAIT_TIMEOUT_MS);
+  const pollDelay = positiveInteger(pollIntervalMs, DEFAULT_POLL_INTERVAL_MS);
+  let consecutiveFailures = 0;
+  while (now() < deadline) {
+    await sleep(Math.min(pollDelay, Math.max(1, deadline - now())));
+    const statusBody = JSON.stringify({
+      operation_id: operationId,
+      site_release_id: siteReleaseId,
+    });
+    let statusResponse;
+    try {
+      statusResponse = await signedPost({
+        brokerUrl,
+        path: `/v1/operations/${operationId}`,
+        secret,
+        body: statusBody,
+        fetchImpl,
+        now,
+        requestTimeoutMs: Math.min(
+          positiveInteger(requestTimeoutMs, DEFAULT_REQUEST_TIMEOUT_MS),
+          Math.max(1, deadline - now()),
+        ),
+      });
+    } catch (error) {
+      consecutiveFailures += 1;
+      if (consecutiveFailures >= MAX_CONSECUTIVE_STATUS_FAILURES) throw error;
+      continue;
+    }
+    const responseBody = await statusResponse.text();
+    if (statusResponse.status === 202) {
+      consecutiveFailures = 0;
+      let pending;
+      try {
+        pending = JSON.parse(responseBody);
+      } catch {
+        throw new Error(
+          "Production Broker returned an invalid pending operation response",
+        );
+      }
+      if (
+        String(pending.operation_id || "") !== operationId ||
+        String(pending.site_release_id || "") !== siteReleaseId ||
+        !["queued", "running"].includes(String(pending.status || ""))
+      ) {
+        throw new Error(
+          "Production Broker returned a mismatched operation status",
+        );
+      }
+      continue;
+    }
+    if (
+      statusResponse.headers.get("X-Content-Operation-Status") === "completed"
+    ) {
+      if (!statusResponse.ok) {
+        throw brokerError(
+          `Production Broker operation ${operationId} failed`,
+          statusResponse,
+          responseBody,
+        );
+      }
+      return responseBody;
+    }
+    if (statusResponse.status === 429 || statusResponse.status >= 500) {
+      consecutiveFailures += 1;
+      if (consecutiveFailures < MAX_CONSECUTIVE_STATUS_FAILURES) continue;
+    }
+    throw brokerError(
+      "Production Broker status request failed",
+      statusResponse,
+      responseBody,
+    );
+  }
+  throw new Error(
+    `Production Broker operation ${operationId} did not complete within ${Math.ceil(
+      positiveInteger(waitTimeoutMs, DEFAULT_WAIT_TIMEOUT_MS) / 60_000,
+    )} minutes`,
+  );
+}
+
+async function main() {
+  const brokerUrl = process.env.PRODUCTION_BROKER_URL;
+  const secret = process.env.PRODUCTION_BROKER_HMAC_SECRET;
+  if (!brokerUrl || !secret)
+    throw new Error("Production Broker environment is incomplete");
+
+  const chunks = [];
+  for await (const chunk of process.stdin) chunks.push(chunk);
+  const body = Buffer.concat(chunks).toString("utf8");
+  const result = await requestProductionPromotion({
+    brokerUrl,
+    secret,
+    body,
+    pollIntervalMs: positiveInteger(
+      process.env.PRODUCTION_BROKER_POLL_INTERVAL_MS,
+      DEFAULT_POLL_INTERVAL_MS,
+    ),
+    waitTimeoutMs: positiveInteger(
+      process.env.PRODUCTION_BROKER_WAIT_TIMEOUT_MS,
+      DEFAULT_WAIT_TIMEOUT_MS,
+    ),
+    submitTimeoutMs: positiveInteger(
+      process.env.PRODUCTION_BROKER_SUBMIT_TIMEOUT_MS,
+      DEFAULT_SUBMIT_TIMEOUT_MS,
+    ),
+    requestTimeoutMs: positiveInteger(
+      process.env.PRODUCTION_BROKER_REQUEST_TIMEOUT_MS,
+      DEFAULT_REQUEST_TIMEOUT_MS,
+    ),
+  });
+  process.stdout.write(result);
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  await main();
+}

--- a/tests/worker/contentReleaseWorkflow.test.js
+++ b/tests/worker/contentReleaseWorkflow.test.js
@@ -46,18 +46,20 @@ describe("fenced content release workflow", () => {
     expect(workflow).toContain(
       'node scripts/verify-preview.mjs "$PREVIEW_URL" "$EXACT_CODE_SHA"',
     );
-    expect(deployerConfig).toContain(
-      'CONTENT_RELEASE_RESUME_ENABLED = "true"',
+    expect(workflow).toContain(
+      "node scripts/request-production-promotion.mjs > broker-result.json",
     );
+    expect(workflow).toContain(
+      "jq -e '.ok == true and (.site_release_id == env.SITE_RELEASE_ID)' broker-result.json",
+    );
+    expect(deployerConfig).toContain('CONTENT_RELEASE_RESUME_ENABLED = "true"');
     expect(deployerConfig).toContain(
       'CONTENT_RELEASE_INCREMENTAL_REUSE_ENABLED = "false"',
     );
     expect(deployerConfig).toContain(
       'CONTENT_RELEASE_REQUIRE_FENCED_CALLBACKS = "true"',
     );
-    expect(deployerConfig).toContain(
-      'CONTENT_BACKLOG_REPLAY_ENABLED = "true"',
-    );
+    expect(deployerConfig).toContain('CONTENT_BACKLOG_REPLAY_ENABLED = "true"');
     expect(deployerConfig).toContain('binding = "CONTENT_INGESTOR"');
     expect(deployerConfig).toContain('service = "ai-daily"');
     expect(deployerConfig).toContain("CONTENT_BACKLOG_REPLAY_SECRET");

--- a/tests/worker/productionPromotionClient.test.js
+++ b/tests/worker/productionPromotionClient.test.js
@@ -1,0 +1,207 @@
+import { describe, expect, it, vi } from "vitest";
+import { requestProductionPromotion } from "../../scripts/request-production-promotion.mjs";
+
+const operationId = "123e4567-e89b-42d3-a456-426614174000";
+const siteReleaseId = "123e4567-e89b-42d3-a456-426614174001";
+const body = JSON.stringify({
+  site_release_id: siteReleaseId,
+});
+
+function completedResponse(payload, status = 200) {
+  return new Response(JSON.stringify(payload), {
+    status,
+    headers: {
+      "Content-Type": "application/json",
+      "X-Content-Operation-Status": "completed",
+    },
+  });
+}
+
+describe("production promotion client", () => {
+  it("remains compatible with the old synchronous Broker response", async () => {
+    const fetchImpl = vi.fn(
+      async (_url, init) =>
+        new Promise((resolve, reject) => {
+          const timer = setTimeout(
+            () =>
+              resolve(
+                Response.json({ ok: true, site_release_id: siteReleaseId }),
+              ),
+            20,
+          );
+          init.signal.addEventListener(
+            "abort",
+            () => {
+              clearTimeout(timer);
+              reject(init.signal.reason);
+            },
+            { once: true },
+          );
+        }),
+    );
+
+    const result = await requestProductionPromotion({
+      brokerUrl: "https://broker.test",
+      secret: "secret",
+      body,
+      fetchImpl,
+      submitTimeoutMs: 50,
+      requestTimeoutMs: 5,
+    });
+
+    expect(JSON.parse(result)).toEqual({
+      ok: true,
+      site_release_id: siteReleaseId,
+    });
+    expect(fetchImpl).toHaveBeenCalledOnce();
+    expect(new URL(fetchImpl.mock.calls[0][0]).pathname).toBe("/v1/promote");
+  });
+
+  it("polls independent signed requests until an asynchronous operation completes", async () => {
+    const responses = [
+      new Response(
+        JSON.stringify({
+          ok: true,
+          operation_id: operationId,
+          site_release_id: siteReleaseId,
+          status: "queued",
+        }),
+        { status: 202 },
+      ),
+      new Response(
+        JSON.stringify({
+          ok: true,
+          operation_id: operationId,
+          site_release_id: siteReleaseId,
+          status: "running",
+          attempts: 1,
+        }),
+        { status: 202 },
+      ),
+      new Response(JSON.stringify({ error: "temporary_unavailable" }), {
+        status: 503,
+      }),
+      completedResponse({ ok: true, site_release_id: siteReleaseId }),
+    ];
+    const fetchImpl = vi.fn(async () => responses.shift());
+    let clock = 1_000;
+    const sleep = vi.fn(async (milliseconds) => {
+      clock += milliseconds;
+    });
+
+    const result = await requestProductionPromotion({
+      brokerUrl: "https://broker.test",
+      secret: "secret",
+      body,
+      fetchImpl,
+      now: () => clock,
+      sleep,
+      pollIntervalMs: 5,
+      waitTimeoutMs: 1_000,
+    });
+
+    expect(JSON.parse(result)).toEqual({
+      ok: true,
+      site_release_id: siteReleaseId,
+    });
+    expect(fetchImpl).toHaveBeenCalledTimes(4);
+    for (const [url, init] of fetchImpl.mock.calls.slice(1)) {
+      expect(new URL(url).pathname).toBe(`/v1/operations/${operationId}`);
+      expect(init.headers["X-Content-Signature"]).toMatch(/^[a-f0-9]{64}$/);
+      expect(init.signal).toBeInstanceOf(AbortSignal);
+      expect(JSON.parse(init.body)).toEqual({
+        operation_id: operationId,
+        site_release_id: siteReleaseId,
+      });
+    }
+  });
+
+  it("surfaces a completed operation failure instead of retrying it", async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            ok: true,
+            operation_id: operationId,
+            site_release_id: siteReleaseId,
+            status: "queued",
+          }),
+          { status: 202 },
+        ),
+      )
+      .mockResolvedValueOnce(
+        completedResponse({ error: "production_convergence_timeout" }, 503),
+      );
+    let clock = 1_000;
+
+    await expect(
+      requestProductionPromotion({
+        brokerUrl: "https://broker.test",
+        secret: "secret",
+        body,
+        fetchImpl,
+        now: () => clock,
+        sleep: async (milliseconds) => {
+          clock += milliseconds;
+        },
+        pollIntervalMs: 5,
+        waitTimeoutMs: 1_000,
+      }),
+    ).rejects.toThrow(
+      `Production Broker operation ${operationId} failed with 503`,
+    );
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+
+  it("rejects a mismatched operation identity before polling", async () => {
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            ok: true,
+            operation_id: operationId,
+            site_release_id: "123e4567-e89b-42d3-a456-426614174099",
+            status: "queued",
+          }),
+          { status: 202 },
+        ),
+    );
+
+    await expect(
+      requestProductionPromotion({
+        brokerUrl: "https://broker.test",
+        secret: "secret",
+        body,
+        fetchImpl,
+      }),
+    ).rejects.toThrow(
+      "Production Broker returned an invalid operation identity",
+    );
+    expect(fetchImpl).toHaveBeenCalledOnce();
+  });
+
+  it("bounds each Broker request independently", async () => {
+    const fetchImpl = vi.fn(
+      async (_url, init) =>
+        new Promise((_resolve, reject) => {
+          init.signal.addEventListener(
+            "abort",
+            () => reject(init.signal.reason),
+            { once: true },
+          );
+        }),
+    );
+
+    await expect(
+      requestProductionPromotion({
+        brokerUrl: "https://broker.test",
+        secret: "secret",
+        body,
+        fetchImpl,
+        submitTimeoutMs: 5,
+      }),
+    ).rejects.toMatchObject({ name: "TimeoutError" });
+    expect(fetchImpl).toHaveBeenCalledOnce();
+  });
+});

--- a/workers/content/broker/index.test.ts
+++ b/workers/content/broker/index.test.ts
@@ -40,6 +40,39 @@ function fakeCoordinatorState() {
   return { state: { storage } as never, values, alarms };
 }
 
+async function signedWorkflowRequest(
+  path: string,
+  secret: string,
+  payload: Record<string, unknown>,
+): Promise<Request> {
+  const body = JSON.stringify(payload);
+  const timestamp = String(Math.floor(Date.now() / 1000));
+  const key = await crypto.subtle.importKey(
+    "raw",
+    new TextEncoder().encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  const signature = await crypto.subtle.sign(
+    "HMAC",
+    key,
+    new TextEncoder().encode(`${timestamp}\n${body}`),
+  );
+  const hex = Array.from(new Uint8Array(signature), (value) =>
+    value.toString(16).padStart(2, "0"),
+  ).join("");
+  return new Request(`https://broker.test${path}`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "X-Content-Timestamp": timestamp,
+      "X-Content-Signature": hex,
+    },
+    body,
+  });
+}
+
 describe("production coordinator", () => {
   it("enqueues scheduled reconcile once without polling operation status", async () => {
     const operationId = "123e4567-e89b-42d3-a456-426614174000";
@@ -246,6 +279,343 @@ describe("production coordinator", () => {
       deduplicated: true,
     });
     expect(values.has(`production-operation:${expiredId}`)).toBe(false);
+  });
+
+  it("deduplicates replayed promotion attempts and rejects identity reuse", async () => {
+    const { state, values } = fakeCoordinatorState();
+    const attemptToken = "123e4567-e89b-42d3-a456-426614174088";
+    const coordinator = new ProductionCoordinator(
+      state,
+      {} as never,
+      vi.fn() as never,
+    );
+    const enqueue = (payload: Record<string, unknown>) =>
+      coordinator.fetch(
+        new Request("https://coordinator.internal/internal/enqueue", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ kind: "promote", payload }),
+        }),
+      );
+
+    const first = await enqueue({
+      attempt_token: attemptToken,
+      execution_generation: 3,
+      site_release_id: "123e4567-e89b-42d3-a456-426614174001",
+    });
+    const replay = await enqueue({
+      site_release_id: "123e4567-e89b-42d3-a456-426614174001",
+      execution_generation: 3,
+      attempt_token: attemptToken,
+    });
+    const conflict = await enqueue({
+      attempt_token: attemptToken,
+      execution_generation: 4,
+      site_release_id: "123e4567-e89b-42d3-a456-426614174001",
+    });
+
+    expect(first.status).toBe(202);
+    await expect(replay.json()).resolves.toMatchObject({
+      operation_id: attemptToken,
+      deduplicated: true,
+    });
+    expect(conflict.status).toBe(409);
+    await expect(conflict.json()).resolves.toEqual({
+      error: "coordinator_idempotency_conflict",
+    });
+    expect(values.get("production-operation-queue")).toEqual([attemptToken]);
+  });
+
+  it("re-enqueues an expired completed promotion without pruning the replacement", async () => {
+    const { state, values } = fakeCoordinatorState();
+    const attemptToken = "123e4567-e89b-42d3-a456-426614174088";
+    const payload = {
+      attempt_token: attemptToken,
+      execution_generation: 3,
+      site_release_id: "123e4567-e89b-42d3-a456-426614174001",
+    };
+    values.set(`production-operation:${attemptToken}`, {
+      id: attemptToken,
+      kind: "promote",
+      payload,
+      status: "completed",
+      attempts: 1,
+      created_at: "2026-01-01T00:00:00.000Z",
+      updated_at: "2026-01-01T00:01:00.000Z",
+      completed_at: "2026-01-01T00:01:00.000Z",
+      response_status: 200,
+      response_body: JSON.stringify({ ok: true }),
+    });
+    values.set("production-operation-completed", [
+      {
+        id: attemptToken,
+        completed_at: "2026-01-01T00:01:00.000Z",
+      },
+    ]);
+    const coordinator = new ProductionCoordinator(
+      state,
+      {} as never,
+      vi.fn() as never,
+    );
+
+    const response = await coordinator.fetch(
+      new Request("https://coordinator.internal/internal/enqueue", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ kind: "promote", payload }),
+      }),
+    );
+
+    expect(response.status).toBe(202);
+    await expect(response.json()).resolves.toMatchObject({
+      operation_id: attemptToken,
+      deduplicated: false,
+    });
+    expect(values.get("production-operation-queue")).toEqual([attemptToken]);
+    expect(values.get("production-operation-completed")).toEqual([]);
+    expect(values.get(`production-operation:${attemptToken}`)).toMatchObject({
+      id: attemptToken,
+      status: "queued",
+      attempts: 0,
+    });
+  });
+});
+
+describe("asynchronous production promotion protocol", () => {
+  const secret = "workflow-secret";
+  const operationId = "123e4567-e89b-42d3-a456-426614174000";
+  const siteReleaseId = "123e4567-e89b-42d3-a456-426614174001";
+  const promotion = {
+    dispatch_id: "123e4567-e89b-42d3-a456-426614174002",
+    site_release_id: siteReleaseId,
+    attempt_token: "123e4567-e89b-42d3-a456-426614174003",
+    execution_generation: 2,
+    site_release_sequence: 176,
+    expected_predecessor_id: "123e4567-e89b-42d3-a456-426614174004",
+    artifact_sha256: "a".repeat(64),
+    artifact_object_key: `artifacts/sha256/${"a".repeat(64)}.json`,
+    code_sha: "b".repeat(40),
+    content_sha256: "c".repeat(64),
+    build_environment_version: "node22-astro7-v1",
+  };
+
+  function envFor(fetch: ReturnType<typeof vi.fn>) {
+    return {
+      WORKFLOW_HMAC_SECRET: secret,
+      PAGES_PROJECT: "content-pages",
+      PRODUCTION_COORDINATOR: {
+        idFromName: vi.fn(() => ({ name: "coordinator" })),
+        get: vi.fn(() => ({ fetch })),
+      },
+    } as never;
+  }
+
+  it("returns 202 immediately after enqueueing without polling in the request", async () => {
+    const coordinatorFetch = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ ok: true, operation_id: operationId }), {
+          status: 202,
+          headers: { "Content-Type": "application/json" },
+        }),
+    );
+    const response = await contentBroker.fetch(
+      await signedWorkflowRequest("/v1/promote", secret, promotion),
+      envFor(coordinatorFetch),
+    );
+
+    expect(response.status).toBe(202);
+    await expect(response.json()).resolves.toEqual({
+      ok: true,
+      operation_id: operationId,
+      site_release_id: siteReleaseId,
+      status: "queued",
+    });
+    expect(coordinatorFetch).toHaveBeenCalledOnce();
+    expect(
+      new URL((coordinatorFetch.mock.calls[0][0] as Request).url).pathname,
+    ).toBe("/internal/enqueue");
+  });
+
+  it("returns only sanitized queued operation status", async () => {
+    const coordinatorFetch = vi.fn(async () =>
+      Response.json({
+        ok: true,
+        operation: {
+          id: operationId,
+          kind: "promote",
+          payload: promotion,
+          status: "running",
+          attempts: 1,
+          created_at: "2026-07-25T09:00:00.000Z",
+          updated_at: "2026-07-25T09:00:01.000Z",
+        },
+      }),
+    );
+    const response = await contentBroker.fetch(
+      await signedWorkflowRequest(`/v1/operations/${operationId}`, secret, {
+        operation_id: operationId,
+        site_release_id: siteReleaseId,
+      }),
+      envFor(coordinatorFetch),
+    );
+
+    expect(response.status).toBe(202);
+    const result = await response.json();
+    expect(result).toEqual({
+      ok: true,
+      operation_id: operationId,
+      site_release_id: siteReleaseId,
+      status: "running",
+      attempts: 1,
+    });
+    expect(JSON.stringify(result)).not.toContain("attempt_token");
+    expect(JSON.stringify(result)).not.toContain("payload");
+  });
+
+  it("returns the completed operation result with an explicit completion header", async () => {
+    const coordinatorFetch = vi.fn(async () =>
+      Response.json({
+        ok: true,
+        operation: {
+          id: operationId,
+          kind: "promote",
+          payload: promotion,
+          status: "completed",
+          attempts: 1,
+          created_at: "2026-07-25T09:00:00.000Z",
+          updated_at: "2026-07-25T09:05:00.000Z",
+          completed_at: "2026-07-25T09:05:00.000Z",
+          response_status: 200,
+          response_body: JSON.stringify({
+            ok: true,
+            site_release_id: siteReleaseId,
+          }),
+        },
+      }),
+    );
+    const response = await contentBroker.fetch(
+      await signedWorkflowRequest(`/v1/operations/${operationId}`, secret, {
+        operation_id: operationId,
+        site_release_id: siteReleaseId,
+      }),
+      envFor(coordinatorFetch),
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("X-Content-Operation-Status")).toBe(
+      "completed",
+    );
+    await expect(response.json()).resolves.toEqual({
+      ok: true,
+      site_release_id: siteReleaseId,
+    });
+  });
+
+  it("preserves a completed operation failure status and body", async () => {
+    const coordinatorFetch = vi.fn(async () =>
+      Response.json({
+        ok: true,
+        operation: {
+          id: operationId,
+          kind: "promote",
+          payload: promotion,
+          status: "completed",
+          attempts: 2,
+          created_at: "2026-07-25T09:00:00.000Z",
+          updated_at: "2026-07-25T09:05:00.000Z",
+          completed_at: "2026-07-25T09:05:00.000Z",
+          response_status: 503,
+          response_body: JSON.stringify({
+            error: "production_stability_failed",
+          }),
+        },
+      }),
+    );
+    const response = await contentBroker.fetch(
+      await signedWorkflowRequest(`/v1/operations/${operationId}`, secret, {
+        operation_id: operationId,
+        site_release_id: siteReleaseId,
+      }),
+      envFor(coordinatorFetch),
+    );
+
+    expect(response.status).toBe(503);
+    expect(response.headers.get("X-Content-Operation-Status")).toBe(
+      "completed",
+    );
+    await expect(response.json()).resolves.toEqual({
+      error: "production_stability_failed",
+    });
+  });
+
+  it("does not disclose an operation for a mismatched release identity", async () => {
+    const coordinatorFetch = vi.fn(async () =>
+      Response.json({
+        ok: true,
+        operation: {
+          id: operationId,
+          kind: "promote",
+          payload: promotion,
+          status: "running",
+          attempts: 1,
+          created_at: "2026-07-25T09:00:00.000Z",
+          updated_at: "2026-07-25T09:00:01.000Z",
+        },
+      }),
+    );
+    const response = await contentBroker.fetch(
+      await signedWorkflowRequest(`/v1/operations/${operationId}`, secret, {
+        operation_id: operationId,
+        site_release_id: "123e4567-e89b-42d3-a456-426614174099",
+      }),
+      envFor(coordinatorFetch),
+    );
+
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toEqual({
+      error: "operation_not_found",
+    });
+  });
+
+  it("fails closed for invalid workflow authentication and pruned operations", async () => {
+    const coordinatorFetch = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ error: "operation_not_found" }), {
+          status: 404,
+        }),
+    );
+    const invalid = new Request(
+      `https://broker.test/v1/operations/${operationId}`,
+      {
+        method: "POST",
+        headers: {
+          "X-Content-Timestamp": String(Math.floor(Date.now() / 1000)),
+          "X-Content-Signature": "0".repeat(64),
+        },
+        body: JSON.stringify({
+          operation_id: operationId,
+          site_release_id: siteReleaseId,
+        }),
+      },
+    );
+    const unauthorized = await contentBroker.fetch(
+      invalid,
+      envFor(coordinatorFetch),
+    );
+    expect(unauthorized.status).toBe(401);
+    expect(coordinatorFetch).not.toHaveBeenCalled();
+
+    const missing = await contentBroker.fetch(
+      await signedWorkflowRequest(`/v1/operations/${operationId}`, secret, {
+        operation_id: operationId,
+        site_release_id: siteReleaseId,
+      }),
+      envFor(coordinatorFetch),
+    );
+    expect(missing.status).toBe(404);
+    await expect(missing.json()).resolves.toEqual({
+      error: "operation_not_found",
+    });
   });
 });
 
@@ -1551,6 +1921,44 @@ describe("production convergence verification", () => {
     });
     expect(value.manifestAttempts.get("https://deploy.pages.dev")).toBe(1);
     expect(value.manifestAttempts.get("https://www.example.test")).toBe(10);
+  });
+
+  it("gives stability probes their own budget after slow initial convergence", async () => {
+    const value = setup();
+    const clock = controlledClock();
+    const baseFetch = vi.mocked(fetch);
+    let advanced = false;
+
+    await expect(
+      verifyDeployment(
+        context,
+        "https://deploy.pages.dev",
+        {
+          ...value.env,
+          MAX_PRODUCTION_INCONSISTENCY_MS: "300000",
+        },
+        { kind: "tar", files },
+        clock.startedAt,
+        {
+          ...clock.dependencies,
+          fetch: async (input, init) => {
+            const response = await baseFetch(input, init);
+            if (!advanced) {
+              advanced = true;
+              clock.advance(216_000);
+            }
+            return response;
+          },
+        },
+      ),
+    ).resolves.toMatchObject({
+      multi_edge_verified: true,
+      convergence_elapsed_ms: 216_000,
+      stability_elapsed_ms: 120_000,
+      operation_elapsed_ms: 336_000,
+      maximum_inconsistency_ms: 300_000,
+      maximum_operation_ms: 450_000,
+    });
   });
 
   it("fails closed when a later stability round drifts after convergence", async () => {

--- a/workers/content/broker/index.ts
+++ b/workers/content/broker/index.ts
@@ -134,6 +134,23 @@ function json(body: unknown, status = 200): Response {
   });
 }
 
+function coordinatorPayloadIdentity(value: unknown): string {
+  if (value === null || typeof value !== "object") {
+    return JSON.stringify(value) ?? "null";
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map(coordinatorPayloadIdentity).join(",")}]`;
+  }
+  const record = value as JsonRecord;
+  return `{${Object.keys(record)
+    .sort()
+    .map(
+      (key) =>
+        `${JSON.stringify(key)}:${coordinatorPayloadIdentity(record[key])}`,
+    )
+    .join(",")}}`;
+}
+
 function bytesEqual(left: string, right: string): boolean {
   if (left.length !== right.length) return false;
   let difference = 0;
@@ -796,6 +813,42 @@ class ProductionConvergenceError extends Error {
   }
 }
 
+class ProductionStabilityError extends Error {
+  readonly code = "production_stability_failed";
+  readonly offsetMs: number;
+  readonly failures: VerificationFailure[];
+
+  constructor(offsetMs: number, failures: VerificationFailure[]) {
+    const summary = failures
+      .map(
+        (failure) =>
+          `${failure.origin}${failure.path} (${failure.phase}, status ${failure.status ?? "request_error"})`,
+      )
+      .join(", ");
+    super(
+      `Production deployment drifted during the ${offsetMs}ms stability probe: ${summary || "verification failed"}`,
+    );
+    this.name = "ProductionStabilityError";
+    this.offsetMs = offsetMs;
+    this.failures = failures;
+  }
+}
+
+class ProductionVerificationTimeoutError extends Error {
+  readonly code = "production_verification_timeout";
+  readonly elapsedMs: number;
+  readonly maximumOperationMs: number;
+
+  constructor(elapsedMs: number, maximumOperationMs: number) {
+    super(
+      `Production verification exceeded its ${maximumOperationMs}ms operation budget`,
+    );
+    this.name = "ProductionVerificationTimeoutError";
+    this.elapsedMs = elapsedMs;
+    this.maximumOperationMs = maximumOperationMs;
+  }
+}
+
 function errorDiagnostics(error: unknown): JsonRecord {
   if (error instanceof ProductionConvergenceError) {
     return {
@@ -804,6 +857,22 @@ function errorDiagnostics(error: unknown): JsonRecord {
       elapsedMs: error.elapsedMs,
       maximumInconsistencyMs: error.maximumInconsistencyMs,
       failures: error.failures,
+    };
+  }
+  if (error instanceof ProductionStabilityError) {
+    return {
+      errorType: error.name,
+      errorCode: error.code,
+      offsetMs: error.offsetMs,
+      failures: error.failures,
+    };
+  }
+  if (error instanceof ProductionVerificationTimeoutError) {
+    return {
+      errorType: error.name,
+      errorCode: error.code,
+      elapsedMs: error.elapsedMs,
+      maximumOperationMs: error.maximumOperationMs,
     };
   }
   return {
@@ -1081,36 +1150,44 @@ export async function verifyDeployment(
       (offset, index) =>
         !Number.isSafeInteger(offset) ||
         offset <= 0 ||
-        offset >= maximumInconsistencyMs ||
         (index > 0 && offset <= stabilityOffsets[index - 1]),
     )
   ) {
     throw new Error("Production stability offsets are invalid");
   }
   const firstConvergedAt = now();
+  // The inconsistency deadline governs how long a new release may take to
+  // converge for the first time. Stability probes intentionally run after
+  // that point and therefore need a separate bounded operation budget.
+  const finalStabilityOffset = stabilityOffsets.at(-1) || 0;
+  const maximumOperationMs =
+    maximumInconsistencyMs + finalStabilityOffset + 30_000;
+  const remainingOperation = (): number => {
+    const elapsed = now() - windowStartedAt;
+    const remaining = maximumOperationMs - elapsed;
+    if (remaining <= 0) {
+      throw new ProductionVerificationTimeoutError(
+        Math.max(0, elapsed),
+        maximumOperationMs,
+      );
+    }
+    return remaining;
+  };
   const stabilityRounds: JsonRecord[] = [];
   for (const offsetMs of stabilityOffsets) {
     const targetTime = firstConvergedAt + offsetMs;
     const delay = targetTime - now();
     if (delay > 0) {
-      const remaining = remainingWindow();
+      const remaining = remainingOperation();
       if (delay >= remaining) {
-        throw new ProductionConvergenceError(
+        throw new ProductionVerificationTimeoutError(
           Math.max(0, now() - windowStartedAt),
-          maximumInconsistencyMs,
-          [],
+          maximumOperationMs,
         );
       }
       await sleep(delay);
     }
-    const remaining = maximumInconsistencyMs - (now() - windowStartedAt);
-    if (remaining <= 0) {
-      throw new ProductionConvergenceError(
-        Math.max(0, now() - windowStartedAt),
-        maximumInconsistencyMs,
-        [],
-      );
-    }
+    const remaining = remainingOperation();
     const stableResults = await Promise.all(
       bases.map(async (base) => {
         const attempt = (attemptsByOrigin.get(base) || 0) + 1;
@@ -1133,11 +1210,7 @@ export async function verifyDeployment(
       result.ok ? [] : [result.failure],
     );
     if (stabilityFailures.length > 0) {
-      throw new ProductionConvergenceError(
-        Math.max(0, now() - windowStartedAt),
-        maximumInconsistencyMs,
-        stabilityFailures,
-      );
+      throw new ProductionStabilityError(offsetMs, stabilityFailures);
     }
     stabilityRounds.push({
       offset_ms: offsetMs,
@@ -1148,10 +1221,9 @@ export async function verifyDeployment(
     });
   }
   const stableVerifiedAt = new Date(now()).toISOString();
-  const elapsedMs = Math.max(0, now() - windowStartedAt);
-  if (elapsedMs > maximumInconsistencyMs) {
-    throw new ProductionConvergenceError(elapsedMs, maximumInconsistencyMs, []);
-  }
+  const stabilityElapsedMs = Math.max(0, now() - firstConvergedAt);
+  const operationElapsedMs = Math.max(0, now() - windowStartedAt);
+  remainingOperation();
   return {
     multi_edge_verified: true,
     site_release_id: context.site_release_id,
@@ -1163,7 +1235,9 @@ export async function verifyDeployment(
     code_sha: context.code_sha,
     build_environment_version: context.build_environment_version,
     convergence_elapsed_ms: convergenceElapsedMs,
-    stability_elapsed_ms: elapsedMs,
+    stability_elapsed_ms: stabilityElapsedMs,
+    operation_elapsed_ms: operationElapsedMs,
+    maximum_operation_ms: maximumOperationMs,
     stable_verified_at: stableVerifiedAt,
     stability_offsets: stabilityOffsets,
     stability_rounds: stabilityRounds,
@@ -2074,7 +2148,14 @@ export class ProductionCoordinator {
       if (kind !== "reconcile" && !payload) {
         return json({ error: "operation_payload_required" }, 400);
       }
-      const id = crypto.randomUUID();
+      // A deployment attempt is already a fenced UUID. Reuse it as the
+      // promotion operation identity so a replayed signed request cannot
+      // enqueue duplicate work if the original 202 response was lost.
+      const promotionAttemptId =
+        kind === "promote" && UUID.test(String(payload?.attempt_token || ""))
+          ? String(payload?.attempt_token)
+          : null;
+      const id = promotionAttemptId || crypto.randomUUID();
       const now = new Date().toISOString();
       const operation: CoordinatorOperation = {
         id,
@@ -2087,7 +2168,43 @@ export class ProductionCoordinator {
       };
       let acceptedId = id;
       let deduplicated = false;
+      let idempotencyConflict = false;
+      const retentionCutoff = Date.now() - COORDINATOR_RETENTION_MS;
       await this.state.storage.transaction(async (transaction) => {
+        if (promotionAttemptId) {
+          let existing = await transaction.get<CoordinatorOperation>(
+            coordinatorOperationKey(id),
+          );
+          if (
+            existing?.status === "completed" &&
+            existing.completed_at &&
+            Date.parse(existing.completed_at) < retentionCutoff
+          ) {
+            await transaction.delete(coordinatorOperationKey(id));
+            const completed =
+              (await transaction.get<CompletedCoordinatorOperation[]>(
+                COORDINATOR_COMPLETED_KEY,
+              )) || [];
+            await transaction.put(
+              COORDINATOR_COMPLETED_KEY,
+              completed.filter((item) => item.id !== id),
+            );
+            existing = undefined;
+          }
+          if (existing) {
+            if (
+              existing.kind !== kind ||
+              coordinatorPayloadIdentity(existing.payload) !==
+                coordinatorPayloadIdentity(payload)
+            ) {
+              idempotencyConflict = true;
+              return;
+            }
+            acceptedId = existing.id;
+            deduplicated = true;
+            return;
+          }
+        }
         if (kind === "reconcile") {
           const pendingId = await transaction.get<string>(
             COORDINATOR_PENDING_RECONCILE_KEY,
@@ -2113,6 +2230,9 @@ export class ProductionCoordinator {
           await transaction.put(COORDINATOR_PENDING_RECONCILE_KEY, id);
         }
       });
+      if (idempotencyConflict) {
+        return json({ error: "coordinator_idempotency_conflict" }, 409);
+      }
       await this.pruneCompletedOperations();
       await this.state.storage.setAlarm(Date.now());
       return json({ ok: true, operation_id: acceptedId, deduplicated }, 202);
@@ -2351,6 +2471,84 @@ async function submitCoordinatorOperation(
   );
 }
 
+async function handleCoordinatorOperationStatusRequest(
+  request: Request,
+  env: Env,
+  operationId: string,
+): Promise<Response> {
+  let body: JsonRecord;
+  try {
+    body = JSON.parse(
+      new TextDecoder("utf-8", { fatal: true }).decode(
+        await verifyWorkflowRequest(request, env),
+      ),
+    ) as JsonRecord;
+  } catch {
+    return json({ error: "unauthorized_or_invalid" }, 401);
+  }
+  const requestedOperationId = String(body.operation_id || "");
+  const siteReleaseId = String(body.site_release_id || "");
+  if (
+    !UUID.test(operationId) ||
+    requestedOperationId !== operationId ||
+    !UUID.test(siteReleaseId)
+  ) {
+    return json({ error: "invalid_request" }, 400);
+  }
+  if (!env.PRODUCTION_COORDINATOR) {
+    return json({ error: "production_coordinator_unavailable" }, 503);
+  }
+  const id = env.PRODUCTION_COORDINATOR.idFromName(
+    `pages-project:${env.PAGES_PROJECT}`,
+  );
+  const stub = env.PRODUCTION_COORDINATOR.get(id);
+  const status = await stub.fetch(
+    new Request(
+      `https://production-coordinator.internal/internal/operations/${operationId}`,
+    ),
+  );
+  if (!status.ok) {
+    return status.status === 404
+      ? json({ error: "operation_not_found" }, 404)
+      : json({ error: "coordinator_status_unavailable" }, 503);
+  }
+  const result = (await status.json()) as {
+    operation?: CoordinatorOperation;
+  };
+  const operation = result.operation;
+  if (
+    !operation ||
+    operation.id !== operationId ||
+    operation.kind !== "promote" ||
+    String(operation.payload?.site_release_id || "") !== siteReleaseId
+  ) {
+    // Do not disclose whether an operation exists when the caller cannot
+    // prove the release identity that was present in the signed promotion.
+    return json({ error: "operation_not_found" }, 404);
+  }
+  if (operation.status !== "completed") {
+    return json(
+      {
+        ok: true,
+        operation_id: operation.id,
+        site_release_id: siteReleaseId,
+        status: operation.status,
+        attempts: operation.attempts,
+      },
+      202,
+    );
+  }
+  return new Response(operation.response_body || "", {
+    status: operation.response_status || 500,
+    headers: {
+      "Content-Type": "application/json; charset=utf-8",
+      "Cache-Control": "no-store",
+      "X-Content-Operation-Status": "completed",
+      "X-Content-Operation-Id": operation.id,
+    },
+  });
+}
+
 async function handlePromotionRequest(
   request: Request,
   env: Env,
@@ -2366,7 +2564,17 @@ async function handlePromotionRequest(
   } catch {
     return json({ error: "unauthorized_or_invalid" }, 401);
   }
-  return submitCoordinatorOperation(env, "promote", body);
+  const enqueued = await enqueueCoordinatorOperation(env, "promote", body);
+  if (!enqueued.stub || !enqueued.operationId) return enqueued.response;
+  return json(
+    {
+      ok: true,
+      operation_id: enqueued.operationId,
+      site_release_id: String(body.site_release_id),
+      status: "queued",
+    },
+    202,
+  );
 }
 
 async function handleCoordinatedRollbackRequest(
@@ -2416,6 +2624,14 @@ export default {
     if (request.method !== "POST")
       return Promise.resolve(json({ error: "method_not_allowed" }, 405));
     if (path === "/v1/promote") return handlePromotionRequest(request, env);
+    const operationMatch = /^\/v1\/operations\/([0-9a-f-]{36})$/i.exec(path);
+    if (operationMatch) {
+      return handleCoordinatorOperationStatusRequest(
+        request,
+        env,
+        operationMatch[1],
+      );
+    }
     if (path === "/v1/rollback")
       return handleCoordinatedRollbackRequest(request, env);
     if (path === "/v1/reconcile")

--- a/workers/content/deployer/index.test.ts
+++ b/workers/content/deployer/index.test.ts
@@ -132,23 +132,30 @@ describe("content backlog replay trigger", () => {
   it("is a no-op unless the feature, binding, and secret are all configured", async () => {
     const fetch = vi.fn();
     await expect(replayContentBacklog({} as never)).resolves.toBeUndefined();
-    await expect(replayContentBacklog({
-      CONTENT_BACKLOG_REPLAY_ENABLED: "true",
-      CONTENT_INGESTOR: { fetch },
-    } as never)).resolves.toBeUndefined();
+    await expect(
+      replayContentBacklog({
+        CONTENT_BACKLOG_REPLAY_ENABLED: "true",
+        CONTENT_INGESTOR: { fetch },
+      } as never),
+    ).resolves.toBeUndefined();
     expect(fetch).not.toHaveBeenCalled();
   });
 
   it("calls the ingestion service binding with the dedicated secret", async () => {
-    const fetch = vi.fn(async () => new Response(
-      JSON.stringify({ success: true, status: "empty" }),
-      { status: 200 },
-    ));
-    await replayContentBacklog({
-      CONTENT_BACKLOG_REPLAY_ENABLED: "true",
-      CONTENT_BACKLOG_REPLAY_SECRET: "backlog-secret",
-      CONTENT_INGESTOR: { fetch },
-    } as never, new Date("2026-07-14T02:30:00.000Z"));
+    const fetch = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ success: true, status: "empty" }), {
+          status: 200,
+        }),
+    );
+    await replayContentBacklog(
+      {
+        CONTENT_BACKLOG_REPLAY_ENABLED: "true",
+        CONTENT_BACKLOG_REPLAY_SECRET: "backlog-secret",
+        CONTENT_INGESTOR: { fetch },
+      } as never,
+      new Date("2026-07-14T02:30:00.000Z"),
+    );
 
     expect(fetch).toHaveBeenCalledOnce();
     const [url, init] = fetch.mock.calls[0];
@@ -160,13 +167,20 @@ describe("content backlog replay trigger", () => {
   });
 
   it("surfaces non-success responses for the cron isolation boundary to catch", async () => {
-    await expect(replayContentBacklog({
-      CONTENT_BACKLOG_REPLAY_ENABLED: "true",
-      CONTENT_BACKLOG_REPLAY_SECRET: "backlog-secret",
-      CONTENT_INGESTOR: {
-        fetch: vi.fn(async () => new Response("unavailable", { status: 503 })),
-      },
-    } as never, new Date("2026-07-14T02:30:00.000Z"))).rejects.toThrow(/503/);
+    await expect(
+      replayContentBacklog(
+        {
+          CONTENT_BACKLOG_REPLAY_ENABLED: "true",
+          CONTENT_BACKLOG_REPLAY_SECRET: "backlog-secret",
+          CONTENT_INGESTOR: {
+            fetch: vi.fn(
+              async () => new Response("unavailable", { status: 503 }),
+            ),
+          },
+        } as never,
+        new Date("2026-07-14T02:30:00.000Z"),
+      ),
+    ).rejects.toThrow(/503/);
   });
 
   it("does not replay around the top of hour reserved for fresh ingestion", async () => {
@@ -426,6 +440,163 @@ describe("fenced deployment callbacks", () => {
     expect(response.status).toBe(200);
     expect(await response.json()).toEqual({ ok: true, lease_extended: true });
     expect(sql).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns a stable retryable stage when opening the callback database fails", async () => {
+    const log = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const response = await handleDeploymentCallback(
+      await signedDeploymentCallback("callback-secret", {
+        site_release_id: valid.site_release_id,
+        dispatch_id: valid.dispatch_id,
+        attempt_token: "44444444-4444-4444-8444-444444444444",
+        execution_generation: 2,
+        event_type: "preview_verified",
+        evidence: { secret_value: "must-not-leak" },
+      }),
+      {
+        DEPLOY_CALLBACK_SECRET: "callback-secret",
+      } as never,
+      {
+        openDatabase: vi.fn(() => {
+          throw new Error("database password must-not-leak");
+        }),
+      },
+    );
+
+    expect(response.status).toBe(503);
+    expect(await response.json()).toEqual({
+      ok: false,
+      error: "deployment_callback_failed",
+      stage: "database_open",
+      code: "database_unavailable",
+      retryable: true,
+    });
+    expect(JSON.stringify(log.mock.calls)).not.toContain("must-not-leak");
+    log.mockRestore();
+  });
+
+  it("classifies nested database contention at the fenced accept stage", async () => {
+    const end = vi.fn(async () => undefined);
+    const contention = Object.assign(new Error("locked"), {
+      cause: { code: "55P03" },
+    });
+    const sql = vi.fn(async () => {
+      throw contention;
+    });
+    Object.assign(sql, { json: vi.fn((value: unknown) => value), end });
+    const response = await handleDeploymentCallback(
+      await signedDeploymentCallback("callback-secret", {
+        site_release_id: valid.site_release_id,
+        dispatch_id: valid.dispatch_id,
+        attempt_token: "44444444-4444-4444-8444-444444444444",
+        execution_generation: 2,
+        event_type: "preview_verified",
+        evidence: {},
+      }),
+      {
+        DEPLOY_CALLBACK_SECRET: "callback-secret",
+      } as never,
+      { openDatabase: vi.fn(() => sql as never) },
+    );
+
+    expect(response.status).toBe(409);
+    expect(await response.json()).toEqual({
+      ok: false,
+      error: "deployment_callback_failed",
+      stage: "accept",
+      code: "database_contention",
+      retryable: true,
+    });
+    expect(end).toHaveBeenCalledWith({ timeout: 2 });
+  });
+
+  it("classifies malformed artifact evidence without exposing database details", async () => {
+    const end = vi.fn(async () => undefined);
+    const sql = vi.fn(async (strings: TemplateStringsArray) => {
+      const query = strings.join("?");
+      if (query.includes("accept_deployment_callback_v2"))
+        return [{ result: true }];
+      if (query.includes("register_release_artifact_v1")) {
+        throw Object.assign(new Error("invalid byte_length secret"), {
+          code: "P0001",
+        });
+      }
+      throw new Error(`Unexpected SQL: ${query}`);
+    });
+    Object.assign(sql, { json: vi.fn((value: unknown) => value), end });
+    const response = await handleDeploymentCallback(
+      await signedDeploymentCallback("callback-secret", {
+        site_release_id: valid.site_release_id,
+        dispatch_id: valid.dispatch_id,
+        attempt_token: "44444444-4444-4444-8444-444444444444",
+        execution_generation: 2,
+        event_type: "artifact_registered",
+        evidence: {
+          object_key: "artifact",
+          byte_length: -1,
+          artifact_sha256: "a".repeat(64),
+          artifact_fingerprint_sha256: "b".repeat(64),
+          hash_algorithm: "sha256",
+          code_sha: "c".repeat(40),
+          build_environment_version: "test",
+        },
+      }),
+      {
+        DEPLOY_CALLBACK_SECRET: "callback-secret",
+      } as never,
+      { openDatabase: vi.fn(() => sql as never) },
+    );
+
+    expect(response.status).toBe(422);
+    expect(await response.json()).toEqual({
+      ok: false,
+      error: "deployment_callback_failed",
+      stage: "artifact_register",
+      code: "invalid_evidence",
+      retryable: false,
+    });
+    expect(end).toHaveBeenCalledWith({ timeout: 2 });
+  });
+
+  it("does not replace a successful callback when database close fails", async () => {
+    const log = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const end = vi.fn(async () => {
+      throw new Error("close failed");
+    });
+    const sql = vi.fn(async (strings: TemplateStringsArray) => {
+      const query = strings.join("?");
+      if (query.includes("accept_deployment_callback_v2"))
+        return [{ result: true }];
+      throw new Error(`Unexpected SQL: ${query}`);
+    });
+    Object.assign(sql, { json: vi.fn((value: unknown) => value), end });
+    const response = await handleDeploymentCallback(
+      await signedDeploymentCallback("callback-secret", {
+        site_release_id: valid.site_release_id,
+        dispatch_id: valid.dispatch_id,
+        attempt_token: "44444444-4444-4444-8444-444444444444",
+        execution_generation: 2,
+        event_type: "heartbeat",
+        evidence: {},
+      }),
+      {
+        DEPLOY_CALLBACK_SECRET: "callback-secret",
+      } as never,
+      { openDatabase: vi.fn(() => sql as never) },
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      ok: true,
+      lease_extended: true,
+    });
+    expect(log).toHaveBeenCalledWith(
+      "[ContentDeployer] callback database close failed",
+      expect.objectContaining({
+        event: "deployment_callback_database_close_failed",
+      }),
+    );
+    log.mockRestore();
   });
 });
 

--- a/workers/content/deployer/index.ts
+++ b/workers/content/deployer/index.ts
@@ -1,5 +1,9 @@
 import { canonicalJsonBytes, sha256Hex } from "../shared/canonical";
-import { openContentDatabase, type ContentSql } from "../shared/db";
+import {
+  databaseErrorCode,
+  openContentDatabase,
+  type ContentSql,
+} from "../shared/db";
 import { putVerifiedImmutable } from "../shared/r2";
 
 type Env = {
@@ -888,24 +892,38 @@ export async function handleDeploymentCallback(
   ) {
     return json({ error: "fenced_callback_required" }, 409);
   }
-  const sql = (dependencies.openDatabase || openContentDatabase)(
-    env,
-    "content-deployer-callback",
-  );
+  type CallbackStage =
+    | "database_open"
+    | "editorial_register"
+    | "editorial_fail"
+    | "accept"
+    | "artifact_register"
+    | "artifact_attest"
+    | "checkpoint"
+    | "event_record";
+  let callbackStage: CallbackStage = "database_open";
+  let sql: ContentSql | null = null;
   try {
+    const callbackSql = (dependencies.openDatabase || openContentDatabase)(
+      env,
+      "content-deployer-callback",
+    );
+    sql = callbackSql;
     if (eventType === "editorial_preview_verified") {
       const evidence = payload.evidence as Record<string, unknown>;
-      await sql`
+      callbackStage = "editorial_register";
+      await callbackSql`
         select private.register_preview_build_v1(
           ${String(evidence.draft_id)}::uuid, ${String(evidence.preview_sha256)},
-          ${String(evidence.artifact_sha256)}, ${String(evidence.pages_preview_url)}, ${sql.json(evidence)}
+          ${String(evidence.artifact_sha256)}, ${String(evidence.pages_preview_url)}, ${callbackSql.json(evidence)}
         )
       `;
       return json({ ok: true });
     }
     if (eventType === "editorial_preview_failed") {
       const evidence = payload.evidence as Record<string, unknown>;
-      await sql`
+      callbackStage = "editorial_fail";
+      await callbackSql`
         select private.fail_preview_build_v1(
           ${String(evidence.draft_id)}::uuid, ${String(evidence.preview_sha256)},
           ${String(evidence.error_code || "workflow_failed")}
@@ -914,11 +932,12 @@ export async function handleDeploymentCallback(
       return json({ ok: true });
     }
     if (fencedCallback) {
-      const acceptedRows = await sql<Record<string, unknown>[]>`
+      callbackStage = "accept";
+      const acceptedRows = await callbackSql<Record<string, unknown>[]>`
         select private.accept_deployment_callback_v2(
           ${releaseId}::uuid, ${dispatchId}::uuid, ${attemptToken}::uuid,
           ${executionGeneration}, ${eventType},
-          ${sql.json(payload.evidence as Record<string, unknown>)}
+          ${callbackSql.json(payload.evidence as Record<string, unknown>)}
         ) as result
       `;
       if (acceptedRows[0]?.result !== true) {
@@ -932,7 +951,8 @@ export async function handleDeploymentCallback(
     }
     if (eventType === "artifact_registered") {
       const evidence = payload.evidence as Record<string, unknown>;
-      await sql`
+      callbackStage = "artifact_register";
+      await callbackSql`
         select private.register_release_artifact_v1(
           ${releaseId}::uuid, ${String(evidence.object_key)}, ${Number(evidence.byte_length)},
           ${String(evidence.artifact_sha256)}, ${String(evidence.artifact_fingerprint_sha256)},
@@ -941,7 +961,8 @@ export async function handleDeploymentCallback(
         )
       `;
       if (fencedCallback) {
-        await sql`
+        callbackStage = "artifact_attest";
+        await callbackSql`
           select private.attest_release_artifact_v1(
             ${releaseId}::uuid, ${String(evidence.artifact_sha256)},
             ${String(evidence.verification_profile)},
@@ -952,16 +973,18 @@ export async function handleDeploymentCallback(
       }
     }
     if (fencedCallback) {
-      await sql`
+      callbackStage = "checkpoint";
+      await callbackSql`
         select private.record_deployment_checkpoint_v2(
           ${releaseId}::uuid, ${dispatchId}::uuid, ${attemptToken}::uuid,
           ${executionGeneration}, ${eventType},
-          ${sql.json(payload.evidence as Record<string, unknown>)}
+          ${callbackSql.json(payload.evidence as Record<string, unknown>)}
         )
       `;
     } else {
+      callbackStage = "event_record";
       await recordEvent(
-        sql,
+        callbackSql,
         releaseId,
         dispatchId,
         eventType,
@@ -969,10 +992,68 @@ export async function handleDeploymentCallback(
       );
     }
     return json({ ok: true });
-  } catch {
-    return json({ error: "service_unavailable" }, 503);
+  } catch (error) {
+    const databaseCode = databaseErrorCode(error);
+    let code = "internal_error";
+    let status = 503;
+    let retryable = true;
+    if (["55P03", "40001", "40P01"].includes(databaseCode || "")) {
+      code = "database_contention";
+      status = 409;
+    } else if (databaseCode?.startsWith("22")) {
+      code = "invalid_evidence";
+      status = 422;
+      retryable = false;
+    } else if (
+      databaseCode === "P0001" &&
+      ["artifact_register", "artifact_attest"].includes(callbackStage)
+    ) {
+      code = "invalid_evidence";
+      status = 422;
+      retryable = false;
+    } else if (databaseCode?.startsWith("23") || databaseCode === "P0001") {
+      code = "callback_conflict";
+      status = 409;
+      retryable = false;
+    } else if (
+      databaseCode?.startsWith("08") ||
+      databaseCode?.startsWith("53") ||
+      databaseCode === "57P01"
+    ) {
+      code = "database_unavailable";
+    } else if (callbackStage === "database_open") {
+      code = "database_unavailable";
+    }
+    console.error("[ContentDeployer] deployment callback failed", {
+      component: "content-deployer",
+      event: "deployment_callback_failed",
+      eventType,
+      callbackStage,
+      code,
+      errorType: error instanceof Error ? error.name : typeof error,
+    });
+    return json(
+      {
+        ok: false,
+        error: "deployment_callback_failed",
+        stage: callbackStage,
+        code,
+        retryable,
+      },
+      status,
+    );
   } finally {
-    await sql.end({ timeout: 2 });
+    if (sql) {
+      try {
+        await sql.end({ timeout: 2 });
+      } catch (error) {
+        console.error("[ContentDeployer] callback database close failed", {
+          component: "content-deployer",
+          event: "deployment_callback_database_close_failed",
+          errorType: error instanceof Error ? error.name : typeof error,
+        });
+      }
+    }
   }
 }
 


### PR DESCRIPTION
## What changed

- return production promotion operations immediately and poll them with independent signed requests
- preserve compatibility with the old synchronous Broker during the rollout
- separate initial CDN convergence from the post-convergence stability budget
- deduplicate fenced promotion attempts and recover cleanly across retention boundaries
- add structured, redacted Deployer callback error stages and retryability

## Root cause

The Broker queued work in a Durable Object but then kept the original Worker request open while Pages deployment, multi-origin convergence, and stability checks ran. Cloudflare could terminate that long request with 1101 even while the Durable Object continued, causing false workflow failures. The old convergence deadline also included the later stability window, so a slow but valid first convergence could never finish all required probes.

## Validation

- npm test: 45 files, 691 tests
- npm run content:production:preflight
- npm run content:broker:check
- npm run content:deployer:check
- targeted async promotion and callback tests: 94 tests
- two independent agent reviews: no remaining P0/P1