### PR TITLE
fix: order daily content by source publication time

### DIFF
--- a/astro/src/components/DailyArchive.astro
+++ b/astro/src/components/DailyArchive.astro
@@ -17,7 +17,7 @@ import {
 	isDatabaseOwnedDailyDate,
 	type StructuredDailyReport,
 } from '../lib/structuredDaily';
-import { loadStructuredDailyReport } from '../lib/structuredDailyLocal';
+import { loadPublishedDailyReport } from '../lib/structuredDailyLocal';
 
 interface Props {
 	entries: CollectionEntry<'daily'>[];
@@ -46,7 +46,7 @@ await Promise.all(
 	rows
 		.filter(({ identity }) => isDatabaseOwnedDailyDate(identity.dateKey))
 		.map(async ({ identity }) => {
-			reportByDate.set(identity.dateKey, await loadStructuredDailyReport(identity.dateKey));
+			reportByDate.set(identity.dateKey, await loadPublishedDailyReport(identity.dateKey));
 		}),
 );
 

--- a/astro/src/components/DailyTimeline.astro
+++ b/astro/src/components/DailyTimeline.astro
@@ -4,11 +4,12 @@ import {
 	cleanTimelineSummary,
 	displayContentType,
 	formatTimelineTime,
-	orderTimelineBatches,
+	timelineItemsBySourcePublishedAt,
 	timelineDisplayText,
 	timelineSourceDisplay,
 	type DailyContentType,
 	type DailyDisplayContentType,
+	type StructuredDailyBatch,
 	type StructuredDailyReport,
 } from '../lib/structuredDaily';
 import { entitiesById, taxonomyLabel, topicsById } from '../lib/knowledge';
@@ -40,7 +41,16 @@ for (const item of report.items) {
 	typeCounts.set(displayType, (typeCounts.get(displayType) ?? 0) + 1);
 }
 
-const orderedBatches = orderTimelineBatches(report.batches);
+const orderedItems = timelineItemsBySourcePublishedAt(report.items);
+const orderedBatches: StructuredDailyBatch[] = [
+	{
+		id: 'night',
+		label: isEnglish ? 'Source publication time' : '按消息源发布时间',
+		status: 'completed',
+		generated_at: report.generated_at,
+		item_ids: orderedItems.map((item) => item.id),
+	},
+];
 const reportDate = dailyDateFromKey(report.date);
 const dateTitle = new Intl.DateTimeFormat(locale, {
 	year: 'numeric',
@@ -155,12 +165,9 @@ const olderKey = hrefDateKey(olderHref);
 	<div class="batches">
 		{
 			orderedBatches.map((batch) => {
-				// The producer stores each batch in ascending chronology for deterministic artifacts.
-				// The reading UI keeps that source untouched while showing each batch's newest item first.
 				const items = batch.item_ids
 					.map((id) => itemById.get(id))
-					.filter((item) => item !== undefined)
-					.reverse();
+					.filter((item) => item !== undefined);
 				const batchLabel = cleanTimelineSummary(batch.label);
 				const pending = batch.status !== 'completed';
 				return (

--- a/astro/src/components/QuietIndexHome.astro
+++ b/astro/src/components/QuietIndexHome.astro
@@ -19,7 +19,7 @@ import {
 	type DailyContentType,
 	type StructuredDailyReport,
 } from '../lib/structuredDaily';
-import { loadStructuredDailyReport } from '../lib/structuredDailyLocal';
+import { loadPublishedDailyReport } from '../lib/structuredDailyLocal';
 import '../styles/quiet-index.css';
 
 interface Props {
@@ -35,7 +35,7 @@ const latest = entries[0];
 const latestIdentity = latest ? parseDailyEntryId(latest.id) : null;
 const dateKey = latestIdentity?.dateKey ?? null;
 const report: StructuredDailyReport | null = dateKey
-	? await loadStructuredDailyReport(dateKey)
+	? await loadPublishedDailyReport(dateKey)
 	: null;
 const latestHref = latest ? dailyPermalink(latest.id) : isEnglish ? '/en/daily/' : '/daily/';
 

--- a/astro/src/lib/searchIndex.test.ts
+++ b/astro/src/lib/searchIndex.test.ts
@@ -4,6 +4,7 @@ import { join, resolve } from 'node:path';
 
 import { afterEach, describe, expect, it } from 'vitest';
 
+import { buildDailyArtifacts } from '../../../src/daily/buildArtifacts.js';
 import { buildKnowledgeSearchIndex } from './searchIndex';
 
 const fixturePath = resolve(import.meta.dirname, '../../tests/fixtures/daily-report.valid.json');
@@ -19,6 +20,31 @@ async function dailyDirectory(): Promise<string> {
 	const directory = join(root, 'data', 'daily');
 	await mkdir(directory, { recursive: true });
 	return directory;
+}
+
+async function reportForDate(date: string): Promise<Record<string, unknown>> {
+	const build = buildDailyArtifacts as unknown as (
+		input: Record<string, unknown>,
+	) => Promise<{ report: Record<string, unknown> }>;
+	const result = await build({
+		rawItems: [
+			{
+				provider: 'aibase',
+				id: `source-${date}`,
+				title: `AI news for ${date}`,
+				url: `https://example.com/ai-news/${date}`,
+				source: 'Example News',
+				published_date: `${date}T14:20:00+08:00`,
+				description: 'A concise summary.',
+			},
+		],
+		reportDate: date,
+		structuredStartDate: date,
+		batch: 'morning',
+		runAt: `${date}T07:00:00.000Z`,
+		producer: { version: 'search-index-test', commitSha: 'a'.repeat(40) },
+	});
+	return result.report;
 }
 
 afterEach(async () => {
@@ -55,9 +81,8 @@ describe('knowledge search index', () => {
 
 	it('indexes individual news items across reports with stable daily anchors', async () => {
 		const directory = await dailyDirectory();
-		const first = await fixture();
-		const second = structuredClone(first);
-		second.date = '2026-07-15';
+		const first = await reportForDate('2026-07-14');
+		const second = await reportForDate('2026-07-15');
 		await writeFile(join(directory, '2026-07-14.json'), JSON.stringify(first));
 		await writeFile(join(directory, '2026-07-15.json'), JSON.stringify(second));
 
@@ -76,10 +101,9 @@ describe('knowledge search index', () => {
 
 	it('never includes more than the seven newest report days', async () => {
 		const directory = await dailyDirectory();
-		const report = await fixture();
 		for (let day = 1; day <= 8; day += 1) {
 			const date = `2026-07-${String(day).padStart(2, '0')}`;
-			await writeFile(join(directory, `${date}.json`), JSON.stringify({ ...report, date }));
+			await writeFile(join(directory, `${date}.json`), JSON.stringify(await reportForDate(date)));
 		}
 		const index = await buildKnowledgeSearchIndex({ directory });
 		expect(index.report_dates).toHaveLength(7);

--- a/astro/src/lib/searchIndex.ts
+++ b/astro/src/lib/searchIndex.ts
@@ -12,7 +12,7 @@ import {
 } from './knowledge';
 import {
 	dailyDataDirectory,
-	loadStructuredDailyReport,
+	loadPublishedDailyReport,
 } from './structuredDailyLocal';
 import type { StructuredDailyItem } from './structuredDaily';
 
@@ -133,7 +133,7 @@ export async function buildKnowledgeSearchIndex(
 	const reportDates = availableReportDates.slice(0, STATIC_SEARCH_MAX_REPORT_DAYS);
 	const items: KnowledgeSearchItem[] = [];
 	for (const date of reportDates) {
-		const report = await loadStructuredDailyReport(date, { directory });
+		const report = await loadPublishedDailyReport(date, { directory });
 		if (!report) throw new Error(`Structured daily report disappeared: ${date}`);
 		items.push(
 			...report.items.map((item) => ({

--- a/astro/src/lib/structuredDaily.test.ts
+++ b/astro/src/lib/structuredDaily.test.ts
@@ -11,6 +11,7 @@ import {
 	isDatabaseOwnedDailyDate,
 	orderTimelineBatches,
 	structuredCutoverDate,
+	timelineItemsBySourcePublishedAt,
 	timelineDisplayText,
 	timelineSourceDisplay,
 	type StructuredDailyBatch,
@@ -187,6 +188,30 @@ describe('timeline batch order', () => {
 			'night-newer-source',
 			'late-night-newer-source',
 			'late-night-older-source',
+		]);
+	});
+
+	it('orders the full timeline globally by source publication time across fetch batches', () => {
+		const items = [
+			{
+				id: 'morning-newer',
+				batch: 'morning',
+				published_at: '2026-07-25T12:00:00.000Z',
+				published_date: '2026-07-25',
+				ingested_at: '2026-07-25T12:05:00.000Z',
+			},
+			{
+				id: 'night-older',
+				batch: 'night',
+				published_at: '2026-07-25T02:00:00.000Z',
+				published_date: '2026-07-25',
+				ingested_at: '2026-07-25T16:00:00.000Z',
+			},
+		] as StructuredDailyItem[];
+
+		expect(timelineItemsBySourcePublishedAt(items).map(({ id }) => id)).toEqual([
+			'morning-newer',
+			'night-older',
 		]);
 	});
 

--- a/astro/src/lib/structuredDaily.ts
+++ b/astro/src/lib/structuredDaily.ts
@@ -95,6 +95,14 @@ export function homepageFeedItems(
 		.slice(0, Math.max(0, Math.trunc(limit)));
 }
 
+export function timelineItemsBySourcePublishedAt(
+	items: readonly StructuredDailyItem[],
+): StructuredDailyItem[] {
+	return [...items].sort(
+		(a, b) => itemPublishedTimestamp(b) - itemPublishedTimestamp(a) || a.id.localeCompare(b.id),
+	);
+}
+
 const homepageBatchLabels: Record<StructuredDailyBatch['id'], Record<'zh-CN' | 'en', string>> = {
 	morning: { 'zh-CN': '早间累计', en: 'Morning total' },
 	afternoon: { 'zh-CN': '午后累计', en: 'Afternoon total' },

--- a/astro/src/lib/structuredDailyLocal.ts
+++ b/astro/src/lib/structuredDailyLocal.ts
@@ -1,4 +1,4 @@
-import { readFile } from 'node:fs/promises';
+import { readdir, readFile } from 'node:fs/promises';
 import { resolve } from 'node:path';
 
 import {
@@ -6,11 +6,13 @@ import {
 	validateDailyReportSemantics,
 	validateReportFilename,
 } from '../../../src/daily/semanticValidate.js';
+import { projectPublishedCalendarReport } from '../../../src/daily/calendarView.js';
 import { validateDailyReportSchemaForAstro } from './dailySchema';
 import type { StructuredDailyReport } from './structuredDaily';
 
 const dateKeyPattern = /^\d{4}-\d{2}-\d{2}$/;
 const reportCache = new Map<string, Promise<StructuredDailyReport | null>>();
+const publishedReportCache = new Map<string, Promise<StructuredDailyReport | null>>();
 
 export function dailyDataDirectory(directory?: string): string {
 	if (directory) return resolve(directory);
@@ -50,4 +52,37 @@ export function loadStructuredDailyReport(
 		reportCache.set(cacheKey, readStructuredReport(dateKey, directory));
 	}
 	return reportCache.get(cacheKey)!;
+}
+
+async function readPublishedCalendarReport(
+	dateKey: string,
+	directory: string,
+): Promise<StructuredDailyReport | null> {
+	if (!dateKeyPattern.test(dateKey)) throw new Error(`Invalid structured daily date: ${dateKey}`);
+	let names: string[];
+	try {
+		names = await readdir(directory);
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code === 'ENOENT') return null;
+		throw error;
+	}
+	const dates = names
+		.map((name) => name.match(/^(\d{4}-\d{2}-\d{2})\.json$/)?.[1])
+		.filter((date): date is string => Boolean(date));
+	const reports = (await Promise.all(
+		dates.map((date) => loadStructuredDailyReport(date, { directory })),
+	)).filter((report): report is StructuredDailyReport => report !== null);
+	return projectPublishedCalendarReport(dateKey, reports) as StructuredDailyReport | null;
+}
+
+export function loadPublishedDailyReport(
+	dateKey: string,
+	options: { directory?: string } = {},
+): Promise<StructuredDailyReport | null> {
+	const directory = dailyDataDirectory(options.directory);
+	const cacheKey = `${directory}\0${dateKey}`;
+	if (!publishedReportCache.has(cacheKey)) {
+		publishedReportCache.set(cacheKey, readPublishedCalendarReport(dateKey, directory));
+	}
+	return publishedReportCache.get(cacheKey)!;
 }

--- a/astro/src/pages/daily/[year]/[month]/[slug].astro
+++ b/astro/src/pages/daily/[year]/[month]/[slug].astro
@@ -7,7 +7,7 @@ import {
 	isDatabaseOwnedDailyDate,
 	type StructuredDailyReport,
 } from '../../../../lib/structuredDaily';
-import { loadStructuredDailyReport } from '../../../../lib/structuredDailyLocal';
+import { loadPublishedDailyReport } from '../../../../lib/structuredDailyLocal';
 
 export async function getStaticPaths() {
 	const allEntries = await getCollection('daily');
@@ -53,7 +53,7 @@ interface Props {
 
 const { entry, dateKey, newerHref, olderHref, alternateHref } = Astro.props;
 const report: StructuredDailyReport | null = isDatabaseOwnedDailyDate(dateKey)
-	? await loadStructuredDailyReport(dateKey)
+	? await loadPublishedDailyReport(dateKey)
 	: null;
 ---
 

--- a/astro/src/pages/en/daily/[year]/[month]/[slug].astro
+++ b/astro/src/pages/en/daily/[year]/[month]/[slug].astro
@@ -7,7 +7,7 @@ import {
 	isDatabaseOwnedDailyDate,
 	type StructuredDailyReport,
 } from '../../../../../lib/structuredDaily';
-import { loadStructuredDailyReport } from '../../../../../lib/structuredDailyLocal';
+import { loadPublishedDailyReport } from '../../../../../lib/structuredDailyLocal';
 
 export async function getStaticPaths() {
 	const entries = filterDailyEntries(await getCollection('daily'), 'en');
@@ -45,7 +45,7 @@ interface Props {
 
 const { entry, dateKey, newerHref, olderHref, alternateHref } = Astro.props;
 const report: StructuredDailyReport | null = isDatabaseOwnedDailyDate(dateKey)
-	? await loadStructuredDailyReport(dateKey)
+	? await loadPublishedDailyReport(dateKey)
 	: null;
 ---
 

--- a/scripts/verify-site.mjs
+++ b/scripts/verify-site.mjs
@@ -4,6 +4,7 @@ import { dirname, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { XMLParser } from "fast-xml-parser";
+import { projectPublishedCalendarReport } from "../src/daily/calendarView.js";
 import { assertRouteBuildContract } from "./content-route-build-contract.mjs";
 
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
@@ -322,6 +323,20 @@ const dailyDataDirectory = pinnedContentBuild
 const dailyDataNames = (await readdir(dailyDataDirectory))
   .filter((name) => /^\d{4}-\d{2}-\d{2}\.json$/.test(name))
   .sort();
+const canonicalReports = await Promise.all(
+  dailyDataNames.map(async (name) =>
+    JSON.parse(await readFile(resolve(dailyDataDirectory, name), "utf8")),
+  ),
+);
+const canonicalReportByDate = new Map(
+  canonicalReports.map((report) => [report.date, report]),
+);
+const publishedReportByDate = new Map(
+  canonicalReports.map((report) => [
+    report.date,
+    projectPublishedCalendarReport(report.date, canonicalReports),
+  ]),
+);
 const publishedDailyRecords = contract.records.filter(
   (record) =>
     record.status === 200 &&
@@ -362,10 +377,15 @@ const expectedSearchDates = dailyDataNames.map((name) =>
 // this value in sync). Search coverage invariants below apply to that window;
 // JSON route and rendered-HTML checks still cover every published day.
 const STATIC_SEARCH_MAX_REPORT_DAYS = 7;
-const expectedSearchWindow = new Set(
+const searchSourceWindow = new Set(
   [...expectedSearchDates]
     .sort((left, right) => right.localeCompare(left))
     .slice(0, STATIC_SEARCH_MAX_REPORT_DAYS),
+);
+const expectedSearchWindow = new Set(
+  [...searchSourceWindow].filter(
+    (date) => (publishedReportByDate.get(date)?.items.length || 0) > 0,
+  ),
 );
 const pinnedEnglishDailyRssIdentities = new Set(
   pinnedContentBuild
@@ -392,8 +412,10 @@ for (const name of dailyDataNames) {
     source.equals(output),
     `Published structured daily JSON differs from its canonical source: ${route}`,
   );
-  const report = JSON.parse(source.toString("utf8"));
   const date = name.slice(0, -".json".length);
+  const report = canonicalReportByDate.get(date);
+  const publishedReport = publishedReportByDate.get(date);
+  invariant(report && publishedReport, `Structured daily report projection is missing: ${date}`);
   const year = date.slice(0, 4);
   const month = date.slice(5, 7);
   const chinesePageRoute = `/daily/${year}/${month}/${date}/`;
@@ -417,26 +439,26 @@ for (const name of dailyDataNames) {
       ),
       "utf8",
     );
-    for (const item of report.items) {
+    for (const item of publishedReport.items) {
       invariant(
         html.includes(`id="news-${item.id}"`),
         `Structured daily item is missing from HTML: ${pageRoute}#news-${item.id}`,
       );
     }
   }
-  if (expectedSearchWindow.has(date)) {
-    expectedSearchItemCount += report.items.length;
+  if (searchSourceWindow.has(date)) {
+    expectedSearchItemCount += publishedReport.items.length;
     const searchItems = searchIndex.items.filter((item) => item.date === date);
     const expectedSearchItems = new Map(
-      report.items.map((item) => [
+      publishedReport.items.map((item) => [
         `${date}:${item.id}`,
         `/daily/${date.slice(0, 4)}/${date.slice(5, 7)}/${date}/#news-${item.id}`,
       ]),
     );
     invariant(
-      searchIndex.report_dates.includes(date) &&
-        searchItems.length === report.items.length &&
-        expectedSearchItems.size === report.items.length,
+      searchIndex.report_dates.includes(date) === (publishedReport.items.length > 0) &&
+        searchItems.length === publishedReport.items.length &&
+        expectedSearchItems.size === publishedReport.items.length,
       `Structured daily search coverage drifted: ${date}`,
     );
     const seenSearchKeys = new Set();

--- a/src/daily/calendarView.js
+++ b/src/daily/calendarView.js
@@ -1,0 +1,77 @@
+import { deduplicateSameDay } from './dedupe.js';
+import { isRealDate } from './time.js';
+
+function sourcePublishedTimestamp(item) {
+    if (!item?.published_at) return null;
+    const value = Date.parse(item.published_at);
+    return Number.isFinite(value) ? value : null;
+}
+
+function comparePublishedItems(left, right) {
+    const leftTimestamp = sourcePublishedTimestamp(left);
+    const rightTimestamp = sourcePublishedTimestamp(right);
+    if (leftTimestamp !== null && rightTimestamp !== null && leftTimestamp !== rightTimestamp) {
+        return rightTimestamp - leftTimestamp;
+    }
+    if (leftTimestamp !== null) return -1;
+    if (rightTimestamp !== null) return 1;
+    const dateDifference = String(right.published_date || '')
+        .localeCompare(String(left.published_date || ''));
+    if (dateDifference !== 0) return dateDifference;
+    return String(left.id).localeCompare(String(right.id));
+}
+
+export function sortItemsBySourcePublishedAt(items) {
+    return [...(items || [])].sort(comparePublishedItems);
+}
+
+function itemDisplayDate(item, owningReportDate) {
+    return isRealDate(item?.published_date) ? item.published_date : owningReportDate;
+}
+
+function sourcePublishedBatch(item) {
+    const timestamp = sourcePublishedTimestamp(item);
+    if (timestamp === null) return item.batch;
+    const beijingHour = (new Date(timestamp).getUTCHours() + 8) % 24;
+    if (beijingHour < 5) return 'lateNight';
+    if (beijingHour < 14) return 'morning';
+    if (beijingHour < 22) return 'afternoon';
+    return 'night';
+}
+
+export function projectPublishedCalendarReport(dateKey, reports) {
+    if (!isRealDate(dateKey)) throw new Error('Invalid published calendar date');
+    if (!Array.isArray(reports)) throw new Error('Published calendar reports must be an array');
+
+    const baseReport = reports.find(report => report?.date === dateKey) || null;
+    if (!baseReport) return null;
+
+    const candidates = reports.flatMap(report => (
+        (report?.items || [])
+            .filter(item => itemDisplayDate(item, report.date) === dateKey)
+            .map(item => ({ ...item, batch: sourcePublishedBatch(item) }))
+    ));
+    const deduplicated = deduplicateSameDay([], candidates).items;
+    const items = sortItemsBySourcePublishedAt(deduplicated);
+    const itemIds = new Set(items.map(item => item.id));
+    const contributingGeneratedAt = reports
+        .filter(report => report?.items?.some(item => itemIds.has(item.id)))
+        .map(report => report.generated_at)
+        .filter(Boolean)
+        .sort()
+        .at(-1);
+
+    return {
+        ...baseReport,
+        generated_at: contributingGeneratedAt || baseReport.generated_at,
+        batches: baseReport.batches.map(batch => {
+            const batchItems = items.filter(item => item.batch === batch.id);
+            return {
+                ...batch,
+                status: batchItems.length > 0 ? 'completed' : batch.status,
+                item_ids: batchItems.map(item => item.id),
+            };
+        }),
+        items,
+    };
+}

--- a/tests/worker/calendarView.test.js
+++ b/tests/worker/calendarView.test.js
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+    projectPublishedCalendarReport,
+    sortItemsBySourcePublishedAt,
+} from '../../src/daily/calendarView.js';
+
+function item(id, publishedAt, owningBatch = 'night', overrides = {}) {
+    const publishedDate = publishedAt
+        ? new Intl.DateTimeFormat('en-CA', {
+            timeZone: 'Asia/Shanghai',
+            year: 'numeric',
+            month: '2-digit',
+            day: '2-digit',
+        }).format(new Date(publishedAt))
+        : null;
+    return {
+        id,
+        identity_claims: [`claim:${id}`],
+        batch: owningBatch,
+        published_at: publishedAt,
+        published_date: publishedDate,
+        ingested_at: '2026-07-26T00:00:00.000+08:00',
+        ...overrides,
+    };
+}
+
+function report(date, items) {
+    return {
+        date,
+        generated_at: `${date}T00:00:00.000+08:00`,
+        batches: ['morning', 'afternoon', 'night', 'lateNight'].map(id => ({
+            id,
+            label: id,
+            status: id === 'night' ? 'completed' : 'pending',
+            generated_at: id === 'night' ? `${date}T00:00:00.000+08:00` : null,
+            item_ids: items.filter(candidate => candidate.batch === id).map(candidate => candidate.id),
+        })),
+        items,
+    };
+}
+
+describe('source publication calendar view', () => {
+    it('moves late-discovered items to the source publication day', () => {
+        const july25 = report('2026-07-25', [
+            item('midday', '2026-07-25T04:00:00.000Z'),
+        ]);
+        const july26 = report('2026-07-26', [
+            item('late-evening', '2026-07-25T12:00:00.000Z'),
+            item('early-morning', '2026-07-24T22:31:00.000Z'),
+            item('actual-july26', '2026-07-25T16:05:00.000Z'),
+        ]);
+
+        const projected25 = projectPublishedCalendarReport('2026-07-25', [july25, july26]);
+        const projected26 = projectPublishedCalendarReport('2026-07-26', [july25, july26]);
+
+        expect(projected25.items.map(candidate => candidate.id)).toEqual([
+            'late-evening',
+            'midday',
+            'early-morning',
+        ]);
+        expect(projected25.items.map(candidate => candidate.batch)).toEqual([
+            'afternoon',
+            'morning',
+            'morning',
+        ]);
+        expect(projected26.items.map(candidate => candidate.id)).toEqual(['actual-july26']);
+        expect(projected26.items[0].batch).toBe('lateNight');
+    });
+
+    it('orders exact source timestamps newest first and keeps unknown dates on their owning report', () => {
+        const unknown = item('unknown', null, 'morning');
+        const items = [
+            item('older', '2026-07-25T01:00:00.000Z'),
+            unknown,
+            item('newer', '2026-07-25T03:00:00.000Z'),
+        ];
+        expect(sortItemsBySourcePublishedAt(items).map(candidate => candidate.id)).toEqual([
+            'newer',
+            'older',
+            'unknown',
+        ]);
+        expect(projectPublishedCalendarReport('2026-07-25', [report('2026-07-25', items)]).items)
+            .toContainEqual(unknown);
+    });
+
+    it('deduplicates the same source identity across ingestion reports', () => {
+        const first = item('first', '2026-07-25T03:00:00.000Z', 'morning', {
+            identity_claims: ['shared'],
+        });
+        const repeated = item('repeated', '2026-07-25T03:00:00.000Z', 'night', {
+            identity_claims: ['shared'],
+        });
+        const projected = projectPublishedCalendarReport('2026-07-25', [
+            report('2026-07-25', [first]),
+            report('2026-07-26', [repeated]),
+        ]);
+        expect(projected.items).toHaveLength(1);
+    });
+});


### PR DESCRIPTION
## Summary
- project late-discovered items back onto the source publication calendar day
- render the full daily timeline globally newest-first by source timestamp
- keep homepage, archive, search index, and route verification on the same projection
- add regressions for the July 25/26 bootstrap misclassification

## Validation
- root test suite: 47 files, 710 tests passed
- Astro verify: check, lint, 85 tests, build, CSP, and 649-route verification passed
- real data build: July 26 changes from 7 misdated items to 0; July 25 includes the late-discovered July 25 items in source-time order