### PR TITLE
fix: preserve promoted Folo checkpoints during KV propagation

### DIFF
--- a/src/daily/foloIncremental.js
+++ b/src/daily/foloIncremental.js
@@ -94,6 +94,7 @@ export async function resolveFoloIncrementalPlan(
     {
         runAt,
         kv = env.DATA_KV,
+        committedPlan = null,
     } = {},
 ) {
     const normalizedRunAt = explicitInstant(runAt);
@@ -132,7 +133,23 @@ export async function resolveFoloIncrementalPlan(
         48,
         'FOLO_INCREMENTAL_RECONCILE_HOURS',
     );
-    const state = await readState(kv);
+    let state = await readState(kv);
+    const committedAt = explicitInstant(committedPlan?.run_at);
+    // Workers KV list results can lag a successful checkpoint write. Carry the
+    // checkpoint promoted in this invocation so the next fetch cannot bootstrap
+    // again while the append-only key propagates.
+    if (
+        committedPlan?.enabled === true
+        && committedAt
+        && (!state || Date.parse(committedAt) > Date.parse(state.completed_at))
+    ) {
+        state = {
+            completed_at: committedAt,
+            last_reconciled_at: ['bootstrap', 'reconcile'].includes(committedPlan.mode)
+                ? committedAt
+                : explicitInstant(committedPlan.last_reconciled_at),
+        };
+    }
     if (!state) {
         return {
             enabled: true,

--- a/src/daily/structuredWorkflow.js
+++ b/src/daily/structuredWorkflow.js
@@ -275,8 +275,9 @@ async function promoteMergedFoloCheckpointsWithoutBlocking(env, deps) {
         console.warn('[StructuredDaily] pending Folo checkpoints could not be listed', {
             errorType: error?.name || 'Error',
         });
-        return;
+        return null;
     }
+    let latestCommittedPlan = null;
     const pullCache = new Map();
     for (const candidate of pending) {
         try {
@@ -290,6 +291,12 @@ async function promoteMergedFoloCheckpointsWithoutBlocking(env, deps) {
             if (pull?.state === 'open') continue;
             if (pull?.state === 'closed' && pull?.merged_at) {
                 await deps.commitFoloIncrementalPlan(env, candidate.plan);
+                if (
+                    !latestCommittedPlan
+                    || Date.parse(candidate.plan.run_at) > Date.parse(latestCommittedPlan.run_at)
+                ) {
+                    latestCommittedPlan = candidate.plan;
+                }
             }
             if (pull?.state === 'closed') {
                 await deps.removePendingFoloIncrementalPlan(env, candidate.key);
@@ -300,6 +307,7 @@ async function promoteMergedFoloCheckpointsWithoutBlocking(env, deps) {
             });
         }
     }
+    return latestCommittedPlan;
 }
 
 async function reconcileConfirmedMirror(env, marker, confirmedSha, reportDate, triggerId, deps) {
@@ -726,14 +734,18 @@ export async function runStructuredDailyWorkflow(
     let failureStage = 'unknown';
     try {
         failureStage = 'git_publish';
-        await promoteMergedFoloCheckpointsWithoutBlocking(env, deps);
+        const committedFoloIncrementalPlan =
+            await promoteMergedFoloCheckpointsWithoutBlocking(env, deps);
         const confirmed = await confirmedTriggerResult(env, triggerId, reportDate, batch, deps);
         if (confirmed) return confirmed;
 
         failureStage = 'fetch';
         const foloCookie = await deps.getFoloCookie(env);
         const fetchPageCap = scheduledFetchPageCap(env, batch, runAt);
-        const foloIncrementalPlan = await deps.resolveFoloIncrementalPlan(env, { runAt });
+        const foloIncrementalPlan = await deps.resolveFoloIncrementalPlan(env, {
+            runAt,
+            committedPlan: committedFoloIncrementalPlan,
+        });
         const fetched = await deps.fetchData(env, foloCookie, {
             fetchPageCap,
             foloIncrementalPlan,

--- a/tests/worker/foloIncremental.test.js
+++ b/tests/worker/foloIncremental.test.js
@@ -62,6 +62,29 @@ describe('Folo incremental state', () => {
         });
     });
 
+    it('uses a just-promoted checkpoint while its append-only KV listing is stale', async () => {
+        const kv = memoryKv();
+        const incremental = await resolveFoloIncrementalPlan(
+            { ...enabledEnv, DATA_KV: kv },
+            {
+                runAt: '2026-07-25T01:00:00Z',
+                committedPlan: {
+                    enabled: true,
+                    mode: 'bootstrap',
+                    run_at: '2026-07-25T00:00:00.000Z',
+                },
+            },
+        );
+
+        expect(incremental).toMatchObject({
+            mode: 'incremental',
+            previous_checkpoint_at: '2026-07-25T00:00:00.000Z',
+            last_reconciled_at: '2026-07-25T00:00:00.000Z',
+            inserted_after: '2026-07-24T23:50:00.000Z',
+        });
+        expect(kv.list).toHaveBeenCalled();
+    });
+
     it('forces a periodic full reconciliation and never moves the cursor backwards', async () => {
         const kv = memoryKv({
             version: 1,

--- a/tests/worker/structuredWorkflow.test.js
+++ b/tests/worker/structuredWorkflow.test.js
@@ -270,6 +270,10 @@ describe('structured publication workflow', () => {
             env,
             'daily:folo-incremental:v2:pending:key',
         );
+        expect(deps.resolveFoloIncrementalPlan).toHaveBeenCalledWith(env, {
+            runAt: runInput.runAt,
+            committedPlan: plan,
+        });
     });
 
     it('editorializes fresh items and same-day legacy social items before publishing', async () => {


### PR DESCRIPTION
## Summary
- carry a checkpoint promoted from a merged publication PR into the current fetch plan
- avoid a second bootstrap while the append-only Workers KV listing propagates
- add regression coverage for stale KV list visibility and workflow handoff

## Verification
- `npm test` (47 files, 711 tests)
- `npm run worker:check`
- `git diff --check`

## Production evidence
The Beijing 2026-07-26 01:00 scheduled run succeeded but reported `mode: bootstrap` after its 00:00 checkpoint was committed in the same invocation. Workers KV exposed the exact checkpoint key externally while the invocation-local prefix listing remained stale. This change preserves the newly committed checkpoint in memory for the resolver, without advancing checkpoints before PR merge.