### PR TITLE
fix: parse only real HTML link attributes

### DIFF
--- a/scripts/html-local-references.mjs
+++ b/scripts/html-local-references.mjs
@@ -1,0 +1,147 @@
+const DEFAULT_SITE_ORIGIN = "https://bubblenews.today";
+const URL_ATTRIBUTES = new Set([
+  "href",
+  "src",
+  "action",
+  "poster",
+  "data",
+  "cite",
+]);
+
+function parseStartTag(tag) {
+  if (!tag.startsWith("<")) return null;
+  let cursor = 1;
+  while (/\s/.test(tag[cursor] || "")) cursor += 1;
+  const nameStart = cursor;
+  while (/[^\s/>]/.test(tag[cursor] || "")) cursor += 1;
+  const name = tag.slice(nameStart, cursor).toLowerCase();
+  if (!name || name.startsWith("!") || name.startsWith("?")) return null;
+
+  const attributes = new Map();
+  while (cursor < tag.length) {
+    while (/\s/.test(tag[cursor] || "")) cursor += 1;
+    if (!tag[cursor] || tag[cursor] === ">" || tag[cursor] === "/") break;
+
+    const attributeStart = cursor;
+    while (/[^\s=/>]/.test(tag[cursor] || "")) cursor += 1;
+    const attributeName = tag
+      .slice(attributeStart, cursor)
+      .toLowerCase();
+    if (!attributeName) {
+      cursor += 1;
+      continue;
+    }
+
+    while (/\s/.test(tag[cursor] || "")) cursor += 1;
+    let value = "";
+    if (tag[cursor] === "=") {
+      cursor += 1;
+      while (/\s/.test(tag[cursor] || "")) cursor += 1;
+      const quote = tag[cursor];
+      if (quote === '"' || quote === "'") {
+        cursor += 1;
+        const valueStart = cursor;
+        while (cursor < tag.length && tag[cursor] !== quote) cursor += 1;
+        value = tag.slice(valueStart, cursor);
+        if (tag[cursor] === quote) cursor += 1;
+      } else {
+        const valueStart = cursor;
+        while (/[^\s>]/.test(tag[cursor] || "")) cursor += 1;
+        value = tag.slice(valueStart, cursor);
+      }
+    }
+    if (!attributes.has(attributeName)) attributes.set(attributeName, value);
+  }
+  return { name, attributes };
+}
+
+function startTags(markup) {
+  const tags = [];
+  let cursor = 0;
+  while (cursor < markup.length) {
+    const start = markup.indexOf("<", cursor);
+    if (start < 0) break;
+    if (markup.startsWith("<!--", start)) {
+      const commentEnd = markup.indexOf("-->", start + 4);
+      cursor = commentEnd < 0 ? markup.length : commentEnd + 3;
+      continue;
+    }
+    const first = markup[start + 1];
+    if (!first || !/[a-z]/i.test(first)) {
+      cursor = start + 1;
+      continue;
+    }
+
+    let quote = null;
+    let end = start + 1;
+    for (; end < markup.length; end += 1) {
+      const character = markup[end];
+      if (quote) {
+        if (character === quote) quote = null;
+      } else if (character === '"' || character === "'") {
+        quote = character;
+      } else if (character === ">") {
+        tags.push(markup.slice(start, end + 1));
+        end += 1;
+        break;
+      }
+    }
+    cursor = Math.max(start + 1, end);
+  }
+  return tags;
+}
+
+export function tagAttribute(tag, name) {
+  return parseStartTag(tag)?.attributes.get(String(name).toLowerCase()) ?? null;
+}
+
+export function extractLocalReferences(
+  html,
+  pageRoute,
+  siteOrigin = DEFAULT_SITE_ORIGIN,
+) {
+  const references = [];
+  const add = (value) => {
+    const normalized = value.trim();
+    if (
+      !normalized ||
+      normalized.startsWith("#") ||
+      /^(?:mailto|tel|data|blob|javascript):/i.test(normalized)
+    )
+      return;
+    let url;
+    try {
+      url = new URL(normalized, new URL(pageRoute, siteOrigin));
+    } catch {
+      return;
+    }
+    if (url.origin === siteOrigin) references.push(url.pathname);
+  };
+  const markup = html
+    .replace(/<script\b[\s\S]*?<\/script>/gi, "")
+    .replace(/<style\b[\s\S]*?<\/style>/gi, "")
+    .replace(/<pre\b[\s\S]*?<\/pre>/gi, "")
+    .replace(/<code\b[\s\S]*?<\/code>/gi, "");
+
+  for (const tag of startTags(markup)) {
+    const parsed = parseStartTag(tag);
+    if (!parsed) continue;
+    for (const [name, value] of parsed.attributes) {
+      if (URL_ATTRIBUTES.has(name)) add(value);
+      if (name === "srcset") {
+        for (const candidate of value.split(","))
+          add(candidate.trim().split(/\s+/, 1)[0]);
+      }
+    }
+    if (
+      parsed.name === "meta" &&
+      parsed.attributes.get("http-equiv")?.toLowerCase() === "refresh"
+    ) {
+      const target = parsed.attributes
+        .get("content")
+        ?.match(/url\s*=\s*(.+)$/i)?.[1];
+      if (target) add(target);
+    }
+  }
+  return references;
+}

--- a/scripts/verify-site.mjs
+++ b/scripts/verify-site.mjs
@@ -6,6 +6,10 @@ import { fileURLToPath } from "node:url";
 import { XMLParser } from "fast-xml-parser";
 import { projectPublishedCalendarReport } from "../src/daily/calendarView.js";
 import { assertRouteBuildContract } from "./content-route-build-contract.mjs";
+import {
+  extractLocalReferences,
+  tagAttribute,
+} from "./html-local-references.mjs";
 
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const astroRoot = resolve(repoRoot, "astro");
@@ -36,13 +40,6 @@ async function artifactFingerprint(directory, excludedPath) {
     aggregate.update("\n");
   }
   return aggregate.digest("hex");
-}
-
-function tagAttribute(tag, name) {
-  const match = tag.match(
-    new RegExp(`\\b${name}\\s*=\\s*(?:"([^"]*)"|'([^']*)'|([^\\s>]+))`, "i"),
-  );
-  return match ? (match[1] ?? match[2] ?? match[3] ?? null) : null;
 }
 
 async function exists(path) {
@@ -76,50 +73,6 @@ function releaseOutput(path) {
     ![".DS_Store", "_headers", "_redirects", ".assetsignore"].includes(path) &&
     !path.endsWith("/.DS_Store")
   );
-}
-
-function extractLocalReferences(html, pageRoute) {
-  const references = [];
-  const add = (value) => {
-    const normalized = value.trim();
-    if (
-      !normalized ||
-      normalized.startsWith("#") ||
-      /^(?:mailto|tel|data|blob|javascript):/i.test(normalized)
-    )
-      return;
-    let url;
-    try {
-      url = new URL(normalized, new URL(pageRoute, siteOrigin));
-    } catch {
-      return;
-    }
-    if (url.origin === siteOrigin) references.push(url.pathname);
-  };
-  const markup = html
-    .replace(/<script\b[\s\S]*?<\/script>/gi, "")
-    .replace(/<style\b[\s\S]*?<\/style>/gi, "")
-    .replace(/<pre\b[\s\S]*?<\/pre>/gi, "")
-    .replace(/<code\b[\s\S]*?<\/code>/gi, "");
-  const attributes = markup.matchAll(
-    /\b(?:href|src|action|poster|data|cite)\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s>]+))/gi,
-  );
-  for (const match of attributes) {
-    add(match[1] ?? match[2] ?? match[3] ?? "");
-  }
-  for (const match of markup.matchAll(
-    /\bsrcset\s*=\s*(?:"([^"]*)"|'([^']*)')/gi,
-  )) {
-    for (const candidate of (match[1] ?? match[2] ?? "").split(","))
-      add(candidate.trim().split(/\s+/, 1)[0]);
-  }
-  for (const match of markup.matchAll(
-    /<meta\b[^>]*http-equiv=["']?refresh["']?[^>]*content=["']([^"']+)["'][^>]*>/gi,
-  )) {
-    const target = match[1].match(/url\s*=\s*(.+)$/i)?.[1];
-    if (target) add(target);
-  }
-  return references;
 }
 
 function headerBlock(text, routePattern) {

--- a/tests/worker/htmlLocalReferences.test.js
+++ b/tests/worker/htmlLocalReferences.test.js
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  extractLocalReferences,
+  tagAttribute,
+} from "../../scripts/html-local-references.mjs";
+
+describe("HTML local-reference extraction", () => {
+  it("reads only real tag attributes, not attribute values or visible text", () => {
+    const html = `
+      <main
+        data-search="example src=&quot; href=/inside-value data = {"
+        data-code="data = {"
+      >
+        <p>data = { and href="/inside-text/"</p>
+        <a href="/real/">Real</a>
+      </main>
+    `;
+
+    expect(extractLocalReferences(html, "/daily/")).toEqual(["/real/"]);
+  });
+
+  it("ignores references inside scripts, styles, pre, and code", () => {
+    const html = `
+      <script>const href = "/script/";</script>
+      <style>src="/style/"</style>
+      <pre>href="/pre/"</pre>
+      <code>href="/code/"</code>
+      <img src="/image.png">
+    `;
+
+    expect(extractLocalReferences(html, "/")).toEqual(["/image.png"]);
+  });
+
+  it("resolves real URL attributes, srcsets, and refresh targets", () => {
+    const html = `
+      <a href="../older/">Older</a>
+      <form action="/search/"></form>
+      <img srcset="/small.png 1x, /large.png 2x">
+      <meta http-equiv="refresh" content="0; url=/login/">
+      <a href="https://outside.example/path/">External</a>
+    `;
+
+    expect(extractLocalReferences(html, "/daily/current/")).toEqual([
+      "/daily/older/",
+      "/search/",
+      "/small.png",
+      "/large.png",
+      "/login/",
+    ]);
+  });
+
+  it("does not find a nested attribute-like token", () => {
+    const tag =
+      '<article data-search="src=&quot; href=/not-real/" data-item-id="one">';
+
+    expect(tagAttribute(tag, "data-search")).toContain("href=/not-real/");
+    expect(tagAttribute(tag, "href")).toBeNull();
+  });
+});


### PR DESCRIPTION
## What changed

- parse link-bearing attributes only from actual HTML start tags
- prevent visible text and nested attribute values from being treated as links
- keep checks for real URL attributes, srcset, and meta refresh

## Root cause

The verifier scanned the whole HTML document with attribute-shaped regular expressions. Content such as `data = {` and encoded `src=&quot;` inside `data-search` was misclassified as a real URL, blocking valid content releases with false broken-link reports.

## Validation

- targeted verifier regression tests: 4 passed
- repository suite: 48 files / 721 tests passed
- Astro verification on current main: passed
- full `npm run verify --prefix astro` against PR #200 real 109-item content snapshot: passed; 649 routes, 27 XML endpoints, and 99 sandboxed demos verified