### PR TITLE
fix: allow HTML verifier helper in code releases

### DIFF
--- a/workers/content/deployer/index.test.ts
+++ b/workers/content/deployer/index.test.ts
@@ -646,6 +646,10 @@ describe("automatic code release boundary", () => {
             status: "modified",
           },
           {
+            filename: "scripts/html-local-references.mjs",
+            status: "added",
+          },
+          {
             filename: "scripts/request-production-promotion.mjs",
             status: "modified",
           },
@@ -714,7 +718,7 @@ describe("automatic code release boundary", () => {
           structuredCutoverDate: "2026-07-16",
         },
       ),
-    ).toHaveLength(38);
+    ).toHaveLength(39);
   });
 
   it.each([

--- a/workers/content/deployer/index.ts
+++ b/workers/content/deployer/index.ts
@@ -258,6 +258,7 @@ const INERT_ROOT_SCRIPTS = new Set([
   "scripts/check-content-observability.mjs",
   "scripts/check-content-observation-window.mjs",
   "scripts/create-content-addressed-artifact.mjs",
+  "scripts/html-local-references.mjs",
   "scripts/materialize-content-addressed-artifact.mjs",
   "scripts/pull-daily-content.sh",
   "scripts/request-code-release.mjs",


### PR DESCRIPTION
## What changed

- classify the new HTML reference parser as an inert root verification script
- retain the fail-closed release boundary for every other unknown path
- cover the exact helper path in the automatic code release boundary test

## Root cause

After #203 merged, the production deployer rejected `scripts/html-local-references.mjs` because the strict code-release allowlist contained `scripts/verify-site.mjs` but not its newly extracted helper module.

## Validation

- `npm test -- --run workers/content/deployer/index.test.ts`: 41 passed
- `git diff --check`: passed