### PR TITLE
feat: add bilingual Claude Design article

### DIFF
--- a/astro/src/lib/highlights.test.ts
+++ b/astro/src/lib/highlights.test.ts
@@ -11,6 +11,8 @@ const expectedArticleRoutes = [
 	'/highlights/2025-11-18-how-three-startups-use-claudecode/',
 	'/highlights/2026-07-24-why-software-factories-fail/',
 	'/en/highlights/2026-07-24-why-software-factories-fail/',
+	'/highlights/2026-07-25-claude-design/',
+	'/en/highlights/2026-07-25-claude-design/',
 ];
 
 function highlightRecords(entries: LegacyContentEntry[]) {

--- a/content/highlights/2026-07-25-claude-design.en.md
+++ b/content/highlights/2026-07-25-claude-design.en.md
@@ -1,0 +1,106 @@
+---
+externalId: "claude-design"
+kind: "article"
+title: "Claude Design"
+description: "HyperFrames explains how Claude Design's brand-aware HTML and CSS output can move directly into a video workflow, and where Claude Code improves the final render."
+date: 2026-07-25
+sourceUrl: "https://x.com/HyperFrames_/status/2081184676430160379"
+cover: "https://pbs.twimg.com/media/HOHZIi2awAAbSIF?format=jpg&name=large"
+tags: ["Claude", "Design", "HyperFrames", "Video"]
+featured: true
+draft: false
+---
+
+[Original article by HyperFrames](https://x.com/HyperFrames_/status/2081184676430160379)
+
+![Image](https://pbs.twimg.com/media/HOHZIi2awAAbSIF?format=jpg&name=large)
+
+# Day 20 of 30: Hyperframes with Claude Design
+
+Nineteen days of this series have started from the same place: the design already exists. HyperFrames captures a website, reads the brand out of the pixels, and writes it into a [FRAME.md](http://frame.md/). That works because somebody already did the design work.
+
+Day 20 covers the other half: when the design does not exist yet. Anthropic has a tool for exactly that moment, and because of one convenient fact about how it works, it plugs straight into a HyperFrames pipeline.
+
+## What Claude Design is
+
+[Claude Design](https://claude.com/product/design) is Anthropic's design tool, live at [claude.ai/design](https://claude.ai/design) as a research preview for Pro, Max, Team, and Enterprise plans. You describe what you want, Claude designs it on a canvas, and you refine it the way you would in a design tool instead of a chat window: click an element and leave an inline comment, drag the sliders it spawns for color and type size, or just edit the thing directly.
+
+Two details make it different from every "AI makes you a mockup" tool before it:
+
+- **It has taste.** The model behind it is trained for design work, and it shows. Layouts, spacing, and type come out considered instead of generated. It is the closest thing yet to Figma for non-designers, but simpler: no artboards to learn, no pen tool, just intent and iteration.
+- **It learns your brand first.** During onboarding, Claude Design builds a design system for your team by reading your codebase and design files. Every project after that automatically uses your colors, your typography, your components.
+
+## The unlock
+
+Everything it produces is on-brand by construction instead of by correction.
+
+Our HeyGen design system already lives in it: the ABC Solar Display and TT Norms Pro families, the full color token set, and about forty real components, from buttons to player controls. So when we ask Claude Design to ideate a frame, a title card, or an end screen, it is not guessing at HeyGen's look. It is composing with the same pieces our product ships with.
+
+## Using it with HyperFrames
+
+Here is the part that makes this a video story and not just a design story: Claude Design projects are real HTML and CSS. And HyperFrames renders video from HTML. There is no translation layer between the two.
+
+So the workflow is four steps:
+
+1. **Give it your design system.** Onboarding builds one from your codebase and design files, or sync an existing component library from Claude Code with /design-sync.
+2. **Ideate in Claude Design.** Describe the frames you want. Comment, slide, and nudge until the taste is right. This is the Figma-for-non-designers step.
+3. **Download the project.** What comes out is not a screenshot of a design. It is the design: working HTML, CSS, fonts, and tokens.
+4. **Hand it to Claude Code.** Because HyperFrames speaks the same language, the downloaded design is not a reference to recreate. It is source material. Claude Code drops it into the composition and animates it: the layout becomes the scene, the components become the cast.
+
+Design tool on one side, video tool on the other, and the border between them disappears because both sides are HTML.
+
+The real run
+
+We did this for Day 20 itself. One sentence into Claude Design, with the Prism design system and the day's background pattern attached:
+
+```text
+make me a 15 sec sizzle animation for HeyGen HyperFrames Day 20 Claude Design. using our brand fonts and colors
+```
+
+Before touching the canvas it asked the questions a producer would ask: where the video will live, what aspect ratio, how to use the uploaded pattern, tone, typography, audio. We answered the ones that mattered (a landing page loop, 1:1 square, the pattern as the background, no audio in the file so music can come in post) and told it to decide the rest.
+
+![Image](https://pbs.twimg.com/media/HOHYfL1bsAA_4FV?format=jpg&name=large)
+
+What came back was a 15 second, 1080 by 1080 looping sizzle in four beats: a grid of twenty frames lighting up one by one, the HYPERFRAMES title in ABC Solar Display, a counter rolling to Day 20, and the HeyGen lockup end card. TT Norms Pro Mono for the film chrome, Prism blue accents, the pattern tinted toward brand blue. It even shipped its own Tweaks panel: pattern opacity, accent color, and a film-chrome toggle.
+
+Exporting is one click. Share, then Export, and you get the MP4 next to the thing this whole day is about: the entire project as HTML.
+
+![Image](https://pbs.twimg.com/media/HOHqqLBbsAAY2eS?format=png&name=large)
+
+That downloaded HTML project is what goes to Claude Code next. One honest note from our run: the export's background flickered. Claude Design's player restarts the pattern video in every scene and its exporter steps through the video frame by frame, so the bed never settles. Keep that in mind, because fixing it is exactly what the handoff is for.
+
+## The final output
+
+We handed the downloaded project to Claude Code and rebuilt it as a HyperFrames composition. Same four scenes, same type, same easings. One structural change: the pattern video becomes a single continuous background layer that plays once under the whole cut instead of restarting in every scene. HyperFrames owns media playback at render time, so the bed is frame-exact. Measured frame to frame, the old export's background jumped at every scene cut. This one holds steady for the full 15 seconds.
+
+**Output:**
+
+![](https://pbs.twimg.com/amplify_video_thumb/2081182786984222720/img/HXOnWsItNGEAEON7.jpg?name=large)
+
+## The pro move: teach Claude Design to speak HyperFrames
+
+Everything above used Claude Design out of the box, which is why the export needed a rebuild on the way in. There is an official shortcut. HyperFrames ships an instruction file, [claude-design-hyperframes.md](https://github.com/heygen-com/hyperframes/blob/main/docs/guides/claude-design-hyperframes.md), built for exactly this pairing.
+
+Attach that file in a new Claude Design chat along with your brief, screenshots, and brand assets. It hands Claude Design pre-valid HyperFrames skeletons with the structural rules already embedded, so the model spends its taste on palette, typography, scene content, and GSAP motion instead of on format. What comes back is a ready HyperFrames project: index.html, preview.html, README.md, and DESIGN.md.
+
+Download it and refine in Claude Code (or Cursor):
+
+```text
+npx skills add heygen-com/hyperframes
+npx hyperframes lint
+npx hyperframes preview
+```
+
+Three tips from the official guide:
+
+- **Attachments beat everything.** Screenshots and brand guides steer the design harder than pasted text, and both beat URLs.
+- **Do not judge motion in the pane.** The in-pane preview scrubber is unreliable; preview locally.
+- **Claude Design does not lint.** Run npx hyperframes lint locally to catch structural issues before you render.
+
+⭐ If this series is useful, [star the HyperFrames repo](https://github.com/heygen-com/hyperframes).
+
+- Claude Design: [claude.ai/design](https://claude.ai/design) · [announcement](https://www.anthropic.com/news/claude-design-anthropic-labs)
+- Official pairing guide: [Claude Design for HyperFrames](https://hyperframes.heygen.com/guides/claude-design)
+- Install the skills: npx skills add heygen-com/hyperframes
+
+Day 20 down. 10 to go.

--- a/content/highlights/2026-07-25-claude-design.md
+++ b/content/highlights/2026-07-25-claude-design.md
@@ -1,0 +1,106 @@
+---
+externalId: "claude-design"
+kind: "article"
+title: "Claude Design"
+description: "HyperFrames 介绍 Claude Design 如何基于品牌设计系统生成可直接使用的 HTML 和 CSS，以及如何交给 Claude Code 完成更稳定的视频制作流程。"
+date: 2026-07-25
+sourceUrl: "https://x.com/HyperFrames_/status/2081184676430160379"
+cover: "https://pbs.twimg.com/media/HOHZIi2awAAbSIF?format=jpg&name=large"
+tags: ["Claude", "设计", "HyperFrames", "视频"]
+featured: true
+draft: false
+---
+
+[原文：Claude Design — HyperFrames](https://x.com/HyperFrames_/status/2081184676430160379)
+
+![图片](https://pbs.twimg.com/media/HOHZIi2awAAbSIF?format=jpg&name=large)
+
+# 30 天第 20 天：用 Claude Design 制作 HyperFrames
+
+这个系列的前十九天都从同一个起点开始：设计已经存在。HyperFrames 会捕获一个网站，从像素中读出品牌特征，再把它写进一个 [FRAME.md](http://frame.md/) 文件。这套方法之所以有效，是因为已经有人完成了设计工作。
+
+第 20 天讨论的是另一半：当设计还不存在时该怎么办。Anthropic 正好为这个时刻提供了一款工具，而它的工作方式有一个很方便的特点，因此可以直接接入 HyperFrames 的流程。
+
+## 什么是 Claude Design
+
+[Claude Design](https://claude.com/product/design) 是 Anthropic 的设计工具，目前以研究预览的形式在 [claude.ai/design](https://claude.ai/design) 上向 Pro、Max、Team 和 Enterprise 套餐开放。你描述自己想要的东西，Claude 就会在画布上完成设计；然后你可以像使用设计工具一样继续打磨，而不是困在聊天窗口里：点击某个元素留下行内评论，拖动它生成的滑块调整颜色和字号，或者直接编辑对象。
+
+有两个特点，让它不同于过去所有“AI 帮你生成模型稿”的工具：
+
+- **它有审美。** 背后的模型专门针对设计工作训练，结果里看得出来。布局、间距和字体都像是经过推敲，而不是随手生成。它可能是迄今最接近“面向非设计师的 Figma”的产品，但又更简单：不需要学习画板，也没有钢笔工具，只有意图和迭代。
+- **它会先学习你的品牌。** 在引导过程中，Claude Design 会读取你的代码库和设计文件，为团队建立一套设计系统。之后的每一个项目都会自动使用你的颜色、字体和组件。
+
+## 关键突破
+
+它生成的一切从一开始就符合品牌规范，而不需要事后纠正。
+
+我们的 HeyGen 设计系统已经放在里面：ABC Solar Display 和 TT Norms Pro 字体家族、完整的颜色 token，以及从按钮到播放器控件的大约四十个真实组件。因此，当我们让 Claude Design 构思某个画面、标题卡或片尾画面时，它并不是在猜 HeyGen 应该长什么样，而是在使用产品实际发布时所用的同一套积木进行组合。
+
+## 如何和 HyperFrames 配合使用
+
+下面这个特点让它不只是一个设计案例，也是一个视频案例：Claude Design 项目是真正的 HTML 和 CSS，而 HyperFrames 正是从 HTML 渲染视频。两者之间不需要任何转换层。
+
+整个流程分为四步：
+
+1. **把设计系统交给它。** 引导流程可以从代码库和设计文件中建立一套设计系统；你也可以在 Claude Code 中使用 /design-sync，同步已有的组件库。
+2. **在 Claude Design 中构思。** 描述你想要的画面，通过评论、滑块和细微调整不断迭代，直到审美方向正确。这就是“面向非设计师的 Figma”环节。
+3. **下载项目。** 得到的不是一张设计截图，而是设计本身：可以运行的 HTML、CSS、字体和 token。
+4. **把它交给 Claude Code。** 因为 HyperFrames 使用的是同一种语言，下载下来的设计并不是一份需要重新实现的参考图，而是可以直接使用的源材料。Claude Code 会把它放进合成项目并添加动画：布局变成场景，组件变成演员。
+
+一边是设计工具，另一边是视频工具；因为两边都使用 HTML，它们之间的边界也就消失了。
+
+实际运行
+
+我们用第 20 天的内容亲自走了一遍流程。把 Prism 设计系统和当天使用的背景图案作为附件，只给 Claude Design 输入了一句话：
+
+```text
+make me a 15 sec sizzle animation for HeyGen HyperFrames Day 20 Claude Design. using our brand fonts and colors
+```
+
+在接触画布之前，它先问了制作人会问的问题：视频会放在哪里、使用什么宽高比、怎样使用上传的图案、整体语气、字体和音频。我们回答了真正重要的问题——用于落地页循环播放、1:1 方形画面、把图案用作背景、文件本身不带音频以便后期添加音乐——然后让它自行决定其余细节。
+
+![图片](https://pbs.twimg.com/media/HOHYfL1bsAA_4FV?format=jpg&name=large)
+
+最终得到的是一段 15 秒、1080 × 1080 的循环宣传动画，共有四个节拍：二十个画面组成的网格逐个亮起；使用 ABC Solar Display 字体显示 HYPERFRAMES 标题；计数器滚动到 Day 20；最后是 HeyGen 品牌组合标志的片尾卡。胶片界面元素使用 TT Norms Pro Mono，点缀色是 Prism 蓝，背景图案也被调成接近品牌蓝的色调。它甚至自带一个 Tweaks 调节面板，可以控制图案透明度、强调色和胶片界面开关。
+
+导出只需点击一次。先点 Share，再点 Export，你会同时得到 MP4，以及这一天真正讨论的东西：完整的 HTML 项目。
+
+![图片](https://pbs.twimg.com/media/HOHqqLBbsAAY2eS?format=png&name=large)
+
+接下来，这个下载下来的 HTML 项目会被交给 Claude Code。这里如实说明我们遇到的一个问题：导出视频的背景发生了闪烁。Claude Design 的播放器会在每个场景里重新启动图案视频，而它的导出器又逐帧推进视频，因此背景始终无法稳定下来。请记住这一点，因为解决它恰恰就是交接给 Claude Code 的意义。
+
+## 最终成果
+
+我们把下载的项目交给 Claude Code，并将它重新构建为一个 HyperFrames 合成项目。四个场景相同，字体相同，缓动曲线也相同，只做了一项结构调整：图案视频改成单个连续背景层，在整段视频下方只播放一次，而不再在每个场景中重新开始。HyperFrames 在渲染时接管媒体播放，因此背景可以做到逐帧精确。逐帧测量后可以看到，旧导出的背景会在每次场景切换时跳动，而这个版本在完整的 15 秒内都保持稳定。
+
+**输出：**
+
+![](https://pbs.twimg.com/amplify_video_thumb/2081182786984222720/img/HXOnWsItNGEAEON7.jpg?name=large)
+
+## 进阶玩法：让 Claude Design 学会 HyperFrames 的语言
+
+上面的流程使用的是开箱即用的 Claude Design，因此导出结果在接入时还需要重新构建。其实有一条官方捷径。HyperFrames 提供了一个专门为这种组合方式编写的指令文件：[claude-design-hyperframes.md](https://github.com/heygen-com/hyperframes/blob/main/docs/guides/claude-design-hyperframes.md)。
+
+在新的 Claude Design 对话中附上这个文件，再加入你的需求说明、截图和品牌素材。它会向 Claude Design 提供已经符合 HyperFrames 规范、并且内置结构规则的项目骨架，让模型把审美能力花在配色、字体、场景内容和 GSAP 动效上，而不是格式上。最终得到的是一个可以直接使用的 HyperFrames 项目，其中包含 index.html、preview.html、README.md 和 DESIGN.md。
+
+下载后，在 Claude Code（或 Cursor）中继续打磨：
+
+```text
+npx skills add heygen-com/hyperframes
+npx hyperframes lint
+npx hyperframes preview
+```
+
+官方指南给出了三个建议：
+
+- **附件比其他方式都有效。** 截图和品牌指南对设计方向的影响比粘贴文本更强，而两者又都比 URL 更有效。
+- **不要在面板里判断动效。** 面板内的预览拖动器并不可靠，请在本地预览。
+- **Claude Design 不会执行 lint。** 在本地运行 `npx hyperframes lint`，在渲染前发现结构问题。
+
+⭐ 如果这个系列对你有帮助，请为 [HyperFrames 仓库点一颗 Star](https://github.com/heygen-com/hyperframes)。
+
+- Claude Design：[claude.ai/design](https://claude.ai/design) · [官方公告](https://www.anthropic.com/news/claude-design-anthropic-labs)
+- 官方配套指南：[Claude Design for HyperFrames](https://hyperframes.heygen.com/guides/claude-design)
+- 安装 Skills：npx skills add heygen-com/hyperframes
+
+第 20 天完成。还剩 10 天。


### PR DESCRIPTION
## Summary

- add the complete English `Claude Design` article to Selected Reading
- add a full Chinese translation with matching structure, images, links, and commands
- preserve visible attribution to the original HyperFrames post
- remove one captured `<video>` fragment with no playable source while retaining its poster image
- register both localized article routes in the highlights contract

## Verification

- root test suite: 48 files and 721 tests passed
- Astro verify passed with Node 22.17.0
- built 321 pages and verified 653 routes
- both language versions contain 5 sections and 4 images
- Selected Reading contains 37 Chinese and 26 English entries
- confirmed no rejected template headings or broken video tags
