### PR TITLE
style: switch light theme to white background

### DIFF
--- a/astro/src/layouts/BaseLayout.astro
+++ b/astro/src/layouts/BaseLayout.astro
@@ -64,7 +64,7 @@ const navLinks = isEnglish
 		<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
 		<meta name="generator" content={Astro.generator} />
 		<meta name="description" content={description} />
-		<meta name="theme-color" content="#dfdfc1" />
+		<meta name="theme-color" content="#ffffff" />
 		{noindex && <meta name="robots" content="noindex, nofollow" />}
 		<meta property="og:type" content="website" />
 		<meta property="og:title" content={title} />

--- a/astro/src/styles/migration.css
+++ b/astro/src/styles/migration.css
@@ -4,15 +4,15 @@
 	color-scheme: light;
 	font-family:
 		'PingFang SC', 'Hiragino Sans GB', 'Microsoft YaHei', ui-sans-serif, system-ui, sans-serif;
-	background: #dfdfc1;
+	background: #ffffff;
 	color: #20201e;
-	--paper: #dfdfc1;
-	--paper-raised: #e8e8d0;
-	--paper-muted: #d6d6b4;
+	--paper: #ffffff;
+	--paper-raised: #f7f7f5;
+	--paper-muted: #efefec;
 	--ink: #20201e;
 	--ink-soft: #504e49;
 	--ink-faint: #5f5b55;
-	--rule: #bebe9a;
+	--rule: #d7d7d2;
 	--blue: #254f99;
 	--blue-soft: #dfe7f4;
 	--red: #9e332b;


### PR DESCRIPTION
## Summary
- replace the warm yellow-green site canvas with a white light-theme background
- use subtle neutral gray raised and muted surfaces so navigation, cards, code blocks, and calendar layers remain distinct
- update the browser theme color to white
- keep dark theme colors unchanged

## Verification
- npm run verify (Astro)
- 88 tests passed
- 325 pages built; 657 routes verified
- Playwright visual checks: daily archive, daily detail, and long-form highlight article