### PR TITLE
fix: accept UTC 15 scheduled release traces

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -266,7 +266,11 @@ function scheduledFailureMarker(error, scheduled, startedAt) {
                     ? 'git_publish'
                     : 'unknown',
         source_result: {
-            status: 'failed',
+            status:
+                error?.name === 'ScheduledDatabaseMirrorError' &&
+                evidence?.source_result?.status === 'succeeded'
+                    ? 'succeeded'
+                    : 'failed',
             completed_at: evidence?.source_result?.completed_at || null,
             counts: sourceCounts,
             error_count: sourceErrors.length,

--- a/supabase/migrations/20260724000400_scheduled_run_observability.sql
+++ b/supabase/migrations/20260724000400_scheduled_run_observability.sql
@@ -153,7 +153,7 @@ begin
   if p_scheduled_at is null
     or p_scheduled_at <> date_trunc('hour', p_scheduled_at)
     or extract(hour from p_scheduled_at at time zone 'UTC')::integer
-      not in (0, 2, 4, 6, 8, 10, 12, 14, 16, 17, 18, 19, 20, 21, 22, 23)
+      not in (0, 2, 4, 6, 8, 10, 12, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23)
     or p_scheduled_at < timestamptz '2020-01-01 00:00:00+00'
     or p_scheduled_at > clock_timestamp() + interval '5 minutes'
     or p_event_type not in ('started', 'release_registered', 'succeeded', 'failed')

--- a/supabase/migrations/20260727000100_accept_utc15_scheduled_run_trace.sql
+++ b/supabase/migrations/20260727000100_accept_utc15_scheduled_run_trace.sql
@@ -1,0 +1,39 @@
+begin;
+
+set local role content_rpc_owner;
+
+-- The Worker runs at 23:00 Beijing (15:00 UTC), but the observability RPC
+-- omitted that production slot. finalize_site_release_v1 records its
+-- release_registered trace in the same transaction, so the invalid hour
+-- rolled back the release and left later runs waiting behind its head claim.
+--
+-- Patch the deployed function in place instead of copying its large body.
+-- Fresh databases already contain the corrected definition in the source
+-- migration above; production databases still contain the old guard.
+do $migration$
+declare
+  function_definition text;
+  updated_definition text;
+  old_hours constant text :=
+    'not in (0, 2, 4, 6, 8, 10, 12, 14, 16, 17, 18, 19, 20, 21, 22, 23)';
+  new_hours constant text :=
+    'not in (0, 2, 4, 6, 8, 10, 12, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23)';
+begin
+  select pg_get_functiondef(
+    'private.record_scheduled_run_trace_v1(text,timestamptz,text,jsonb)'::regprocedure
+  ) into function_definition;
+
+  if position(new_hours in function_definition) > 0 then
+    return;
+  end if;
+  if position(old_hours in function_definition) = 0 then
+    raise exception
+      'scheduled run trace production-hour guard changed unexpectedly';
+  end if;
+
+  updated_definition := replace(function_definition, old_hours, new_hours);
+  execute updated_definition;
+end;
+$migration$;
+
+commit;

--- a/supabase/tests/database/scheduled_run_observability.test.sql
+++ b/supabase/tests/database/scheduled_run_observability.test.sql
@@ -1,7 +1,7 @@
 begin;
 
 create extension if not exists pgtap with schema extensions;
-select plan(10);
+select plan(11);
 
 select has_table(
   'private',
@@ -75,6 +75,20 @@ select throws_ok(
   '22023',
   'Invalid scheduled run trace',
   'off-contract half-hour traces fail closed'
+);
+select lives_ok(
+  $$select private.record_scheduled_run_trace_v1(
+    'scheduled:1785164400000',
+    timestamptz '2026-07-27 15:00:00+00',
+    'started',
+    jsonb_build_object(
+      'status', 'started',
+      'stage', 'started',
+      'started_at', '2026-07-27T15:00:00.000Z',
+      'finished_at', null
+    )
+  )$$,
+  'the 23:00 Beijing production slot accepts its UTC 15:00 trace'
 );
 select is(
   (

--- a/tests/worker/contentProductionConfig.test.js
+++ b/tests/worker/contentProductionConfig.test.js
@@ -347,6 +347,7 @@ describe("Supabase migration writer compatibility", () => {
       "20260717001000_content_observability.sql",
       "20260717001100_content_observation_evidence.sql",
       "20260724000400_scheduled_run_observability.sql",
+      "20260727000100_accept_utc15_scheduled_run_trace.sql",
     ];
     for (const migration of migrations) {
       const sql = readFileSync(`supabase/migrations/${migration}`, "utf8");

--- a/tests/worker/scheduledRunMigration.test.js
+++ b/tests/worker/scheduledRunMigration.test.js
@@ -1,17 +1,28 @@
 import { readFile } from 'node:fs/promises';
 import { beforeAll, describe, expect, it } from 'vitest';
+import { SCHEDULE_UTC_HOURS } from '../../src/daily/scheduleContract.js';
 
 describe('scheduled run observability migration', () => {
     let sql;
+    let repairSql;
 
     beforeAll(async () => {
-        sql = await readFile(
-            new URL(
-                '../../supabase/migrations/20260724000400_scheduled_run_observability.sql',
-                import.meta.url,
+        [sql, repairSql] = await Promise.all([
+            readFile(
+                new URL(
+                    '../../supabase/migrations/20260724000400_scheduled_run_observability.sql',
+                    import.meta.url,
+                ),
+                'utf8',
             ),
-            'utf8',
-        );
+            readFile(
+                new URL(
+                    '../../supabase/migrations/20260727000100_accept_utc15_scheduled_run_trace.sql',
+                    import.meta.url,
+                ),
+                'utf8',
+            ),
+        ]);
     });
 
     it('keeps an append-only audit and a monotonic current projection', () => {
@@ -22,10 +33,14 @@ describe('scheduled run observability migration', () => {
     });
 
     it('accepts only exact production schedule hours', () => {
+        const productionHours = `not in (${SCHEDULE_UTC_HOURS.join(', ')})`;
         expect(sql).toContain("p_scheduled_at <> date_trunc('hour', p_scheduled_at)");
-        expect(sql).toContain(
-            'not in (0, 2, 4, 6, 8, 10, 12, 14, 16, 17, 18, 19, 20, 21, 22, 23)',
+        expect(sql).toContain(productionHours);
+        expect(repairSql).toContain(
+            "'not in (0, 2, 4, 6, 8, 10, 12, 14, 16, 17, 18, 19, 20, 21, 22, 23)'",
         );
+        expect(repairSql).toContain(`'${productionHours}'`);
+        expect(repairSql).toContain('execute updated_definition');
     });
 
     it('associates fresh releases with their run in the finalize transaction', () => {

--- a/tests/worker/workerRegression.test.js
+++ b/tests/worker/workerRegression.test.js
@@ -367,7 +367,7 @@ describe('worker regression guards', () => {
             failure_stage: 'database_mirror',
             content_sha256: 'a'.repeat(64),
             source_result: {
-                status: 'failed',
+                status: 'succeeded',
                 counts: { news: 3 },
             },
         });


### PR DESCRIPTION
## Summary
- align the scheduled-run database hour guard with the real Worker cron, including UTC 15:00 / Beijing 23:00
- add a forward migration that safely patches the already-deployed function
- preserve successful source status when only database mirroring fails

## Root cause
The 23:00 Beijing run finalized a release inside a transaction that records a scheduled trace. The database whitelist omitted UTC 15, so the trace raised `22023 Invalid scheduled run trace` and rolled back the release. Later 00:00 and 01:00 snapshots were blocked behind the stranded head claim.

## Verification
- `npm test`: 740 tests passed
- `bash scripts/test-supabase-local.sh`: 342 pgTAP tests, second-run migration idempotency, and failure matrix passed
- production diagnosis was read-only; deployment/replay will reuse the existing backlog and release fences