### PR TITLE
fix: move Grok release notes to allowed docs path

### DIFF
--- a/docs/GROK_X_INGESTION.md
+++ b/docs/GROK_X_INGESTION.md
@@ -1,0 +1,17 @@
+# Grok X ingestion
+
+The structured daily workflow runs Grok X Search alongside the existing Folo
+sources. `grok_x` is a `socialMedia` provider whose primary identity is the
+canonical X status URL.
+
+- Production handles are configured with `GROK_X_HANDLES` and split into
+  groups of at most 20 per xAI request.
+- Regular runs use a three-hour overlapping publication window.
+- The Beijing-midnight run uses a 48-hour reconciliation window.
+- Image and video understanding are required and remain enabled.
+- Every returned URL, handle, status ID, and exact timestamp is validated
+  locally before the item enters normalization and deduplication.
+- Any failed handle group discards the complete Grok result for that run.
+- Grok provider failures are non-blocking warnings, so Folo and later cron
+  runs continue.
+- `XAI_API_KEY` is a Cloudflare Worker secret and must never be committed.

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -13,7 +13,7 @@
 
 ## Source registry v1
 
-`src/daily/sourceRegistry.js` is the complete registry for the active adapters plus retired
+`src/daily/sourceRegistry.js` is the complete registry for the 11 active adapters plus retired
 providers kept for historical identity. `source_type` is
 the stable provider key and is never inferred from a display name. `content_type` is the separate
 rendering class. `src/daily/sourceAdapters.js` maps every active legacy adapter object to exactly one
@@ -33,7 +33,6 @@ payload.
 | `jiqizhixin` | `paper` | source ID |
 | `twitter` | `socialMedia` | source ID |
 | `twitter_extra` | `socialMedia` | source ID |
-| `grok_x` | `socialMedia` | canonical URL |
 | `reddit` (retired) | `socialMedia` | source ID |
 
 Adding or renaming a provider requires a registry entry and identity-policy tests. Display-name


### PR DESCRIPTION
## Summary
- revert the schemas README edit that the production code-release policy rejects
- preserve the Grok ingestion notes under the allowed docs path
- leave provider code, tests, configuration, and the production secret unchanged

## Reason
Automatic Code Release correctly rejected the merged change set because schemas/README.md is not an allowed code-release path. This follow-up makes the net production diff policy-safe without weakening the release guard.