### PR TITLE
feat: add bilingual durable object agent article

### DIFF
--- a/astro/src/lib/highlights.test.ts
+++ b/astro/src/lib/highlights.test.ts
@@ -19,6 +19,8 @@ const expectedArticleRoutes = [
 	'/en/highlights/2026-07-27-prompt-caching-in-agents/',
 	'/highlights/2026-07-28-why-software-factories-fail-benchmarking-new-frontier/',
 	'/en/highlights/2026-07-28-why-software-factories-fail-benchmarking-new-frontier/',
+	'/highlights/2026-07-28-we-rewrote-our-agent-durable-object-pi-agents-sdk-code-mode/',
+	'/en/highlights/2026-07-28-we-rewrote-our-agent-durable-object-pi-agents-sdk-code-mode/',
 ];
 
 function highlightRecords(entries: LegacyContentEntry[]) {

--- a/content/highlights/2026-07-28-we-rewrote-our-agent-durable-object-pi-agents-sdk-code-mode.en.md
+++ b/content/highlights/2026-07-28-we-rewrote-our-agent-durable-object-pi-agents-sdk-code-mode.en.md
@@ -1,0 +1,81 @@
+---
+externalId: "we-rewrote-our-agent-durable-object-pi-agents-sdk-code-mode"
+kind: "article"
+title: "We rewrote our agent to run entirely in a Durable Object with Pi, Agents SDK and Code Mode"
+description: "Miguel explains how camelAI replaced always-on VMs with Durable Objects, SQLite, R2, Pi, Code Mode, dynamic Workers, and narrowly scoped Linux containers."
+date: 2026-07-28
+sourceUrl: "https://x.com/Vercantez/status/2082138839888589200"
+cover: "https://pbs.twimg.com/media/HOU-LQ3aMAEVDxm?format=jpg&name=large"
+tags: ["Durable Objects", "Pi", "Agents SDK", "Code Mode", "camelAI"]
+featured: true
+draft: false
+---
+
+[Original article by Miguel / @Vercantez](https://x.com/Vercantez/status/2082138839888589200)
+
+![Image](https://pbs.twimg.com/media/HOU-LQ3aMAEVDxm?format=jpg&name=large)
+
+We recently finished moving the camelAI agent off of virtual machines. The agent now runs inside a [Cloudflare Durable Object](https://developers.cloudflare.com/durable-objects/), its filesystem lives in SQLite and R2, and it writes JavaScript instead of bash. Most teams run coding agents in a full Linux VM or container sandbox, and we used to as well.
+
+We wanted off VMs because giving every user an always-on machine with attached disk was too expensive to scale. The hard part is that coding agents assume Linux. They are trained to reach for bash, and the harness we launched on required a full VM, so getting here took three redesigns. The tradeoff is that the agent can now only do things we've built an explicit method for, which sounds limiting but has been good for the product.
+
+I'm Miguel, CTO of camelAI. Our codebase recently went open source, so everything in this post is code you can read at [github.com/qaml-ai/camelAI](https://github.com/qaml-ai/camelAI). I'll link to the relevant files as we go. Here's the progression.
+
+## Step zero: the VM era
+
+We launched on the Claude Code harness, which needs a full virtual machine to run. We tried several VM providers, none of them fit our persistence and performance requirements, and we ended up [building our own container service](https://camelai.com/blog/we-tried-every-container-service-then-built-our-own). That post is still up, but we no longer run any of that infrastructure.
+
+The container service worked, but it was heavy. An always-on VM for every user is expensive, and so is holding every user's files on fast attached disk. Scaling it means scaling real machines with real disks, which was going to be prohibitively expensive at the user counts we're aiming for. So instead of getting clever about VM orchestration, we started designing around not needing a VM at all.
+
+## Step one: take the agent out of the VM
+
+The Claude Code harness is inseparable from its VM, so the first move was building our own harness. We built it on [pi](https://github.com/badlogic/pi-mono), Mario Zechner's open-source coding agent. pi is a stack of libraries. The highest layer assumes a normal operating system, but the lower layers give you the agent primitives, like the agent loop and state management, without caring where they run. We didn't change any pi code. We imported those lower layers and built [our own harness](https://github.com/qaml-ai/camelAI/blob/main/workers/main/src/chat-thread-do.ts) on top of them, running inside a Cloudflare Durable Object instead of a Linux environment.
+
+A Durable Object is a small stateful compute instance that spins up on Cloudflare's edge, close to the user who created it. Each chat thread gets its own Durable Object, which brought latency down on its own compared to routing everything through a centralized VM host.
+
+At this stage we kept the VMs, but the agent no longer lived inside one. It called into the VM remotely when it needed to run commands. Anthropic describes this same split for its managed agents, the brain separated from the hands. It gave us some nice properties:
+
+- The agent starts responding before the VM is awake, because it doesn't wait on a machine to boot.
+- The VM can go back to sleep while the agent keeps working, or never wake up at all if the turn doesn't need any commands.
+- One brain can control multiple hands. A single agent could operate several VMs at once.
+
+We call those hands projects. Each project came with a VM for executing commands and a git repo created programmatically through [Cloudflare Artifacts](https://developers.cloudflare.com/artifacts/), which is git-compatible storage you can provision on the fly from a Worker. The agent didn't really know it was running outside the VM. It still had bash and worked like any other coding agent.
+
+The problem is that this fixed latency and nothing else. We still had a VM per user, so we still had all of the cost and scaling problems from the original design.
+
+## Step two: remove the VM
+
+The next version kept the same project structure but dropped the VM behind it. Each project is now backed by [a filesystem that lives inside a Durable Object](https://github.com/qaml-ai/camelAI/blob/main/workers/main/src/workspace-filesystem-do.ts), with [R2](https://developers.cloudflare.com/r2/) behind it for larger files.
+
+We didn't invent this. Cloudflare's agents team built [Shell](https://www.npmjs.com/package/@cloudflare/shell), an experimental filesystem and execution runtime for Workers, and we reused their code heavily. The mechanics are simple. A Durable Object's storage is a SQLite database with a 10 GB cap, and each row has a maximum size. Small files live directly in SQLite rows. Files over roughly 1.5 MB get written to R2, and the SQLite row just holds a pointer. To the agent it looks like a normal filesystem, but underneath it's a database and object storage, so persistence is stored data rather than infrastructure we have to keep alive.
+
+Version history still runs through Artifacts, so every project keeps a git history without us hosting a git server.
+
+## Step three: remove bash
+
+Removing bash felt drastic. Coding agents are trained to reach for bash, and bash is why everyone runs them in VMs in the first place. It was also a problem beyond cost. An agent with bash and network access needs credentials to do anything useful, and our attempts at authenticated proxy URLs were getting hacky and hard to enforce.
+
+So we removed it. Instead of bash, the agent writes JavaScript, executed through [Code Mode](https://blog.cloudflare.com/code-mode/) and Cloudflare's [dynamic Worker loaders](https://blog.cloudflare.com/dynamic-workers). Each execution runs in a fresh V8 isolate that boots in milliseconds and uses a few megabytes of memory. The sandbox comes pre-loaded with the user's data connections and with [methods for everything the platform can do](https://github.com/qaml-ai/camelAI/blob/main/workers/main/src/code-mode-tools.ts). Credentials never enter the sandbox. The agent calls a connection's methods, and authentication happens on our side.
+
+When you look at what agents actually use bash for, losing it costs less than you'd expect. Most of it is file operations, which the agent has native tools for. We give it read, write, and edit, plus our own [grep and glob implementations](https://github.com/qaml-ai/camelAI/blob/main/workers/main/src/pi-container-tools.ts). That covers the 80-20. The rest is specific commands for specific jobs, and those became explicit methods:
+
+- wrangler deploy through a proxy became a deploy\_project method we fully control. Since we know exactly when a deploy happens, we can hook it and open a live preview automatically. Before, we had to sniff proxied wrangler traffic to guess which thread had deployed something.
+- Building the user's app and running Python notebooks became their own methods, both backed by short-lived containers.
+
+We kept containers for those two jobs because they genuinely need Linux. User apps are built with Vite, Tailwind, and React Router, and adding dependencies means running bun install. We considered running builds inside a Worker, since the thing being built is itself a Worker, but that path isn't well supported, and Workers have a 128 MB memory limit and a fraction of a CPU. Builds would be slow and plenty of projects would blow past the memory cap. So instead a build spins up a container through the [Cloudflare Sandbox SDK](https://github.com/cloudflare/sandbox-sdk), copies the project in, runs the job, returns the result, and shuts the container down. Notebook runs work the same way. We still use full Linux, but only for the seconds of work that actually need it.
+
+The honest downside is that we have to anticipate what the agent needs. With bash it could figure things out on its own. Now, if a capability is missing, we have to add it. In practice that pressure has been good for the product, because it forces us to think about what users are doing and build a first-class path for it instead of letting the agent improvise.
+
+There was an unexpected benefit too. Bash is open-ended, and cheap models struggle in open-ended environments. With a smaller set of explicit methods they perform noticeably better, which matters because keeping camelAI cheap to run is the point of this architecture.
+
+## Where that leaves us
+
+The stack is now Durable Objects for the agent and its filesystem, R2 for large files, Artifacts for git history, pi as the harness, and Code Mode with dynamic Workers for execution. It deploys like any other Cloudflare app, and there are no external container services to manage.
+
+Dynamic Workers are billed per execution, not per second of uptime. Thousands of executions cost about what a few minutes of container time costs on the services we used to evaluate. Latency is low because everything runs on the edge near the user, and scaling is Cloudflare's problem instead of ours.
+
+Users still build and deploy full-stack apps to live URLs, and the agent still reads, writes, greps, and deploys. From the user's side, nothing changed.
+
+## TL;DR
+
+We started with the Claude Code harness on a self-built VM service, which was expensive and hard to scale. First we moved the agent itself into a Cloudflare Durable Object and let it control VMs remotely, which fixed latency but not cost. Then we replaced the VMs entirely with a filesystem stored in Durable Object SQLite and R2, based on Cloudflare's Shell project, with git history through Cloudflare Artifacts. Finally we removed bash and gave the agent a JavaScript sandbox via Code Mode and dynamic Workers, with explicit methods for deploys, builds, and notebooks. The result is cheaper by orders of magnitude, lower latency, simpler to operate, and easier for smaller models to drive. All of it is open source at [github.com/qaml-ai/camelAI](https://github.com/qaml-ai/camelAI).

--- a/content/highlights/2026-07-28-we-rewrote-our-agent-durable-object-pi-agents-sdk-code-mode.md
+++ b/content/highlights/2026-07-28-we-rewrote-our-agent-durable-object-pi-agents-sdk-code-mode.md
@@ -1,0 +1,81 @@
+---
+externalId: "we-rewrote-our-agent-durable-object-pi-agents-sdk-code-mode"
+kind: "article"
+title: "我们用 Pi、Agents SDK 和 Code Mode 重写了智能体，使其完全运行在 Durable Object 中"
+description: "Miguel 讲述 camelAI 如何用 Durable Objects、SQLite、R2、Pi、Code Mode、动态 Workers 和按需 Linux 容器取代常驻虚拟机。"
+date: 2026-07-28
+sourceUrl: "https://x.com/Vercantez/status/2082138839888589200"
+cover: "https://pbs.twimg.com/media/HOU-LQ3aMAEVDxm?format=jpg&name=large"
+tags: ["Durable Objects", "Pi", "Agents SDK", "Code Mode", "camelAI"]
+featured: true
+draft: false
+---
+
+[原文：We rewrote our agent to run entirely in a Durable Object with Pi, Agents SDK and Code Mode — Miguel / @Vercantez](https://x.com/Vercantez/status/2082138839888589200)
+
+![图片](https://pbs.twimg.com/media/HOU-LQ3aMAEVDxm?format=jpg&name=large)
+
+我们最近完成了 camelAI 智能体脱离虚拟机的迁移。现在，智能体运行在 [Cloudflare Durable Object](https://developers.cloudflare.com/durable-objects/) 内部，文件系统位于 SQLite 和 R2 中，并且它编写的是 JavaScript，而不是 bash。大多数团队会让编程智能体运行在完整的 Linux 虚拟机或容器沙箱中，我们以前也是如此。
+
+我们想摆脱虚拟机，是因为为每个用户提供一台挂载磁盘、持续运行的机器，扩展成本实在太高。难点在于，编程智能体默认自己身处 Linux 环境。它们在训练中已经习惯于调用 bash，而我们最初上线时使用的智能体运行框架（harness）又要求一台完整虚拟机，因此要走到今天这一步，我们先后经历了三次重新设计。代价是，智能体现在只能执行那些我们已经为其构建了明确方法的操作。这听上去像是一种限制，但事实证明，它对产品反而是件好事。
+
+我是 Miguel，camelAI 的 CTO。我们的代码库最近已经开源，因此本文提到的所有内容都有实际代码可供查看，仓库位于 [github.com/qaml-ai/camelAI](https://github.com/qaml-ai/camelAI)。下面我会随着讲述逐一链接到相关文件。这是整个演进过程。
+
+## 第零步：虚拟机时代
+
+我们最初基于 Claude Code harness 上线，而它必须在完整的虚拟机中运行。我们尝试过多家虚拟机提供商，但没有一家能同时满足我们的持久化和性能要求，最后只好[自己构建了一套容器服务](https://camelai.com/blog/we-tried-every-container-service-then-built-our-own)。那篇文章现在仍然可以访问，不过我们已经不再运行其中的任何基础设施。
+
+这套容器服务确实能用，但非常沉重。为每位用户持续运行一台虚拟机成本很高，把每位用户的文件保存在高速挂载磁盘上同样昂贵。扩展这套系统，就意味着扩展由真实机器和真实磁盘组成的基础设施；按照我们希望达到的用户规模，成本将高得难以承受。因此，我们没有继续钻研如何把虚拟机编排做得更巧妙，而是开始围绕“彻底不需要虚拟机”来设计系统。
+
+## 第一步：把智能体移出虚拟机
+
+Claude Code harness 与它所在的虚拟机密不可分，因此第一步是构建我们自己的 harness。我们基于 Mario Zechner 的开源编程智能体 [pi](https://github.com/badlogic/pi-mono) 来实现它。pi 是一套分层的库：最高层假设自己运行在常规操作系统上，但较低层只提供智能体循环、状态管理等智能体基础能力，并不关心实际运行位置。我们没有修改 pi 的任何代码，而是直接导入这些底层库，在其上构建了[自己的 harness](https://github.com/qaml-ai/camelAI/blob/main/workers/main/src/chat-thread-do.ts)，让它运行在 Cloudflare Durable Object 内部，而不是 Linux 环境中。
+
+Durable Object 是一个小型、有状态的计算实例，会在 Cloudflare 边缘网络中靠近创建它的用户的位置启动。每个聊天线程都有自己的 Durable Object；仅仅这一变化，就比让所有流量都经过集中式虚拟机主机显著降低了延迟。
+
+在这个阶段，我们仍然保留了虚拟机，只是智能体本身不再住在虚拟机里。需要运行命令时，它会远程调用虚拟机。Anthropic 在介绍其托管智能体时也描述过同样的拆分方式：把“大脑”与“双手”分开。这为我们带来了一些很好的特性：
+
+- 智能体可以在虚拟机唤醒之前就开始响应，因为它无须等待机器启动。
+- 智能体继续工作时，虚拟机可以重新休眠；如果当前轮次不需要执行任何命令，它甚至完全不必唤醒。
+- 一个“大脑”可以控制多双“手”。单个智能体可以同时操作多台虚拟机。
+
+我们把这些“双手”称为项目（projects）。每个项目都有一台用于执行命令的虚拟机，以及一个通过 [Cloudflare Artifacts](https://developers.cloudflare.com/artifacts/) 以编程方式创建的 Git 仓库。Artifacts 是一种兼容 Git 的存储服务，可以由 Worker 随时按需创建。智能体并不知道自己实际上运行在虚拟机外部；它仍然可以使用 bash，工作方式与其他编程智能体一样。
+
+问题是，这套方案只解决了延迟，其他问题一个也没有解决。每位用户仍然对应一台虚拟机，因此原有设计中的成本与扩展问题依旧存在。
+
+## 第二步：移除虚拟机
+
+下一版保留了同样的项目结构，但移除了项目背后的虚拟机。现在，每个项目都由一个[位于 Durable Object 内部的文件系统](https://github.com/qaml-ai/camelAI/blob/main/workers/main/src/workspace-filesystem-do.ts)提供支持，并使用 [R2](https://developers.cloudflare.com/r2/) 存放较大的文件。
+
+这并不是我们的原创。Cloudflare 的 Agents 团队构建了 [Shell](https://www.npmjs.com/package/@cloudflare/shell)，这是面向 Workers 的实验性文件系统与执行运行时，我们大量复用了其中的代码。其机制很简单：Durable Object 的存储是一个容量上限为 10 GB 的 SQLite 数据库，而且每一行都有大小限制。小文件直接保存在 SQLite 行中；超过约 1.5 MB 的文件会写入 R2，而 SQLite 行只保存一个指针。对智能体来说，它看上去就像普通文件系统；但在底层，它其实是数据库和对象存储。因此，持久化的对象只是存储数据，而不再是我们必须持续维持运行的基础设施。
+
+版本历史仍然通过 Artifacts 管理，因此无须自行托管 Git 服务器，每个项目也能保留完整的 Git 历史。
+
+## 第三步：移除 bash
+
+移除 bash 当时感觉是个非常激进的决定。编程智能体在训练中已经习惯调用 bash，而 bash 本身正是大家一开始需要把智能体放进虚拟机的原因。除了成本之外，它还带来了另一个问题：拥有 bash 和网络访问权限的智能体，必须取得凭据才能完成有用的工作；而我们尝试过的带鉴权代理 URL 方案，正变得越来越取巧，也越来越难以严格约束。
+
+所以我们移除了 bash。智能体改为编写 JavaScript，并通过 [Code Mode](https://blog.cloudflare.com/code-mode/) 和 Cloudflare 的[动态 Worker 加载器](https://blog.cloudflare.com/dynamic-workers)执行。每次执行都会在一个全新的 V8 隔离实例中运行，它能在毫秒内启动，只使用几 MB 内存。沙箱预先加载了用户的数据连接，以及[平台全部能力所对应的方法](https://github.com/qaml-ai/camelAI/blob/main/workers/main/src/code-mode-tools.ts)。凭据永远不会进入沙箱。智能体调用连接提供的方法，身份验证则在我们这一侧完成。
+
+当你真正观察智能体用 bash 做什么时，会发现失去它的代价比想象中小。绝大多数操作都是文件处理，而智能体已经有原生工具可以完成这些事情。我们为它提供了读取、写入和编辑工具，以及自己实现的 [grep 和 glob](https://github.com/qaml-ai/camelAI/blob/main/workers/main/src/pi-container-tools.ts)。这已经覆盖了 80/20 法则中的大多数需求。剩余部分是针对具体任务的具体命令，于是我们把它们变成了明确的方法：
+
+- 以前通过代理执行的 `wrangler deploy`，变成了一个由我们完全控制的 `deploy_project` 方法。因为现在能够准确知道部署何时发生，我们可以在部署时挂接后续流程，自动打开实时预览。过去，我们只能嗅探经过代理的 wrangler 流量，猜测究竟是哪一个线程部署了内容。
+- 构建用户应用和运行 Python notebook 分别成为独立的方法，两者都由短生命周期容器提供支持。
+
+我们为这两项工作保留了容器，因为它们确实需要 Linux。用户应用使用 Vite、Tailwind 和 React Router 构建，添加依赖还需要运行 `bun install`。我们曾考虑直接在 Worker 内构建应用——毕竟被构建的应用本身也是 Worker——但这条路径目前支持并不好，而且 Workers 只有 128 MB 内存上限和一小部分 CPU 算力。构建会非常缓慢，很多项目也会直接超过内存限制。因此，现在每次构建都会通过 [Cloudflare Sandbox SDK](https://github.com/cloudflare/sandbox-sdk)启动一个容器，把项目复制进去，运行任务，返回结果，然后关闭容器。Notebook 运行采用相同的方式。我们仍然会使用完整的 Linux，但仅限于那些真正需要它的几秒钟工作。
+
+必须坦诚承认，这种设计的缺点是，我们必须预先判断智能体需要哪些能力。有了 bash，它可以自行摸索解决问题；而现在，如果缺少某项能力，就必须由我们来补充。但在实践中，这种压力对产品是有益的，因为它迫使我们认真思考用户到底在做什么，并为相应任务构建一等支持路径，而不是任由智能体临场发挥。
+
+此外还有一个意料之外的好处。Bash 是开放式的，低成本模型在开放式环境中往往表现不佳。把能力收敛为一组规模更小、边界明确的方法后，这些模型的表现显著改善。这一点很重要，因为让 camelAI 保持低运行成本，正是这套架构存在的意义。
+
+## 最终形成的架构
+
+现在的技术栈是：Durable Objects 承载智能体及其文件系统，R2 存储大文件，Artifacts 保存 Git 历史，pi 作为 harness，Code Mode 与动态 Workers 负责执行。它可以像其他 Cloudflare 应用一样部署，也不再有任何外部容器服务需要管理。
+
+Dynamic Workers 按执行次数计费，而不是按运行时长的秒数计费。在我们评估过的服务中，数千次执行的成本，大约只相当于几分钟容器运行时间。由于所有内容都运行在靠近用户的边缘节点，延迟很低；系统扩展也从我们的问题变成了 Cloudflare 的问题。
+
+用户仍然可以构建全栈应用，并把它们部署到可公开访问的 URL；智能体也仍然能够读取、写入、搜索和部署。从用户视角来看，一切都没有变化。
+
+## 简而言之
+
+我们最初把 Claude Code harness 运行在一套自建虚拟机服务上，但它成本高昂，而且难以扩展。首先，我们把智能体本身移入 Cloudflare Durable Object，让它远程控制虚拟机；这解决了延迟，却没有解决成本。接着，我们完全移除了虚拟机，参考 Cloudflare Shell 项目，把文件系统存储在 Durable Object 的 SQLite 和 R2 中，并通过 Cloudflare Artifacts 保留 Git 历史。最后，我们移除了 bash，通过 Code Mode 和动态 Workers 为智能体提供 JavaScript 沙箱，并为部署、构建和 notebook 提供明确的方法。最终结果是：成本降低了数个数量级，延迟更低，运维更简单，小型模型也更容易驾驭这套系统。所有代码都已在 [github.com/qaml-ai/camelAI](https://github.com/qaml-ai/camelAI) 开源。


### PR DESCRIPTION
## Summary

- add the complete English article and a context-aware Chinese translation
- preserve all six sections, the image, source links, open-source code references, and architecture progression
- register both bilingual routes in the Astro highlights regression test

## Verification

- root test suite: 49 files, 758 tests passed
- Astro verification: check, lint, 88 tests, build, CSP, and site verification passed
- generated 331 pages and 665 routes
- final output check: six sections, one image, no videos on each language route
