### PR TITLE
feat: add bilingual Templates & Variables article

### DIFF
--- a/astro/src/lib/highlights.test.ts
+++ b/astro/src/lib/highlights.test.ts
@@ -21,6 +21,8 @@ const expectedArticleRoutes = [
 	'/en/highlights/2026-07-28-why-software-factories-fail-benchmarking-new-frontier/',
 	'/highlights/2026-07-28-we-rewrote-our-agent-durable-object-pi-agents-sdk-code-mode/',
 	'/en/highlights/2026-07-28-we-rewrote-our-agent-durable-object-pi-agents-sdk-code-mode/',
+	'/highlights/2026-07-29-templates-variables/',
+	'/en/highlights/2026-07-29-templates-variables/',
 ];
 
 function highlightRecords(entries: LegacyContentEntry[]) {

--- a/content/highlights/2026-07-29-templates-variables.en.md
+++ b/content/highlights/2026-07-29-templates-variables.en.md
@@ -1,0 +1,144 @@
+---
+externalId: "templates-variables"
+kind: "article"
+title: "Templates & Variables"
+description: "HyperFrames explains how typed composition variables turn one video build into reusable templates for personalized local, cloud, and Lambda batch rendering."
+date: 2026-07-29
+sourceUrl: "https://x.com/HyperFrames_/status/2082197435246600341"
+cover: "https://pbs.twimg.com/media/HOVxksYaUAAUjJ9?format=jpg&name=large"
+tags: ["HyperFrames", "Templates", "Variables", "Video Automation"]
+featured: true
+draft: false
+---
+
+[Original article by HyperFrames](https://x.com/HyperFrames_/status/2082197435246600341)
+
+![Image](https://pbs.twimg.com/media/HOVxksYaUAAUjJ9?format=jpg&name=large)
+
+# Day 23 of 30: Turning your video into a template
+
+For 22 days, every render in this series has produced exactly one video. New headline meant a new edit. New name meant a new render. Day 23 removes that ceiling. Variables turn a HyperFrames composition into a template, and a template turns one build into as many videos as you have rows of data.
+
+```text
+npx hyperframes render --batch rows.json --output "renders/{name}.mp4"
+```
+
+One command. One composition. A folder of personalized videos.
+
+## What a variable is
+
+A variable is a typed slot declared on the composition root. The declaration is the schema, and everything else reads from it.
+
+```text
+<html data-composition-variables='[
+  {"id":"title","type":"string","label":"Title","default":"Hello"},
+  {"id":"accent","type":"color","label":"Accent","default":"#66d9ef"}
+]'>
+```
+
+Seven types are supported: **string** (optional placeholder and maxLength), **number** (min, max, step, unit), **color**, **boolean**, and **enum** (an options list is required). Every declaration must ship a useful default. The composition previews and renders on defaults alone, so it stays a normal video until someone overrides it. Two more types, font and image, cover asset-shaped values.
+
+## Wiring values in, no script required
+
+Most substitutions need zero JavaScript. Three declarative bindings cover the common cases:
+
+- data-var-text="title" swaps the element's own text and preserves its children, so animated spans survive.
+- data-var-src="heroImage" swaps an image’s src. The authored src stays in place as the fallback.
+- Every scalar variable is applied automatically as a --{id} CSS custom property on the composition root, so color: var(--accent) responds to overrides with no boilerplate.
+
+```text
+<h1 class="clip" data-start="0" data-duration="5" data-var-text="title">Fallback</h1>
+<img class="clip" data-start="0" data-duration="5" data-var-src="heroImage" src="fallback.jpg" />
+```
+
+For anything past direct substitution (loops, conditionals, derived values) read the values once at init:
+
+```text
+const { title = "Untitled", accent = "#66d9ef" } = __hyperframes.getVariables();
+```
+
+Sub-compositions get the same treatment per instance. One card.html can appear three times in a master file with three different titles via data-variable-values:
+
+```text
+<div
+  data-composition-id="card-pro"
+  data-composition-src="compositions/card.html"
+  data-variable-values='{"title":"Pro","accent":"#ff4d4f"}'
+></div>
+```
+
+## Overriding at render time
+
+Values come in from the CLI as plain JSON:
+
+```text
+# Inline JSON
+npx hyperframes render --variables '{"title":"Q4 Report"}'
+
+# From a file
+npx hyperframes render --variables-file vars.json
+
+# CI mode: undeclared keys and wrong types become errors
+npx hyperframes render --variables '{"title":"Q4"}' --strict-variables
+```
+
+And then the flag that changes what the tool is. Batch mode points the renderer at a file of data rows, and the output path takes {key} placeholders from each row:
+
+```text
+npx hyperframes render --batch rows.json --output "renders/{name}.mp4"
+```
+
+Each row merges over the declared defaults exactly as if it had been passed with --variables. Ten rows in, ten videos out.
+
+## Rendering the fleet in the cloud
+
+Day 21 covered cloud rendering. Templates are the reason that infrastructure exists. Two paths, same idea: the template goes up once, and every render after that is just a new set of values.
+
+**HeyGen-hosted cloud.** The first render uploads the project and prints an asset\_id. Every render after that reuses it. No re-zip, no re-upload:
+
+```text
+# Upload and render once
+hyperframes cloud render ./card-template
+
+# Re-render with new values, skipping the upload entirely
+hyperframes cloud render --asset-id asst_abc123 --variables '{"name":"Ada"}'
+hyperframes cloud render --asset-id asst_abc123 --variables '{"name":"Linus"}'
+```
+
+**Your own AWS.** Deploy the Lambda stack once, upload the template once with lambda sites create, then feed lambda render-batch a JSONL file with one line per recipient. Each line is an object with its own outputKey and variables. It runs 50 renders concurrently by default:
+
+```text
+hyperframes lambda render-batch ./my-template \
+  --site-id abc1234deadbeef0 \
+  --batch ./recipients.jsonl \
+  --width 1920 --height 1080
+```
+
+For local projects the CLI validates your variables against the declared schema before anything uploads. For asset-id renders the check happens server side.
+
+## Field notes
+
+- **Two JSON shapes, easy to confuse.** The declaration is an array of {id, type, label, default} objects. The values are an object keyed by id. Mixing them up is the number one variables mistake.
+- **Precedence is per composition, not one global chain.** A sub-composition reads its own declared defaults, overridden by data-variable-values on its host. CLI values override the top-level composition only, and never reach a sub-composition.
+- **Not everything can be a variable.** Canvas size, root duration, frame rate, and codec are parsed once at compile time. Variables change content, not the container.
+- **Media src is not variable-swappable.** data-var-src works on an \<img>, but on \<video> and \<audio> the renderer plays and mixes the authored src, so a variable-swapped src never reaches the output. To vary framework-owned media, change the authored src, one sub-composition instance per clip.
+- **Variables carry data, not files.** The convention across every deploy target: typed values go in variables, and media assets go in as URL references the composition resolves at render time.
+
+## How we built today's video
+
+Today's film is the feature demonstrating itself. There is exactly one card composition in the project, compositions/card.html, and it declares three variables: a label, a title, and an accent color. The master file instances that single template eight times. The first instance passes no values at all, so what you see is the card running on its declared defaults. Then Austin, Seattle, Atlanta, and Miami each arrive as a data-variable-values override on a new instance, and the closing grid is four more instances side by side. Nothing on screen was designed twice. Four city market updates, one template, and the only thing that changed between them is a row of JSON.
+
+## Output
+
+The finished Day 23 video: 22 seconds, four cities, one template.
+
+<video preload="none" tabindex="-1" playsinline="" aria-label="Embedded video" poster="https://pbs.twimg.com/amplify_video_thumb/2082196246132092928/img/UndjWtJC1tc33Zq0.jpg" style="width: 100%; height: 100%; position: absolute; background-color: black; top: 0%; left: 0%; transform: rotate(0deg) scale(1.005);"><source type="video/mp4"></video>
+
+![](https://pbs.twimg.com/amplify_video_thumb/2082196246132092928/img/UndjWtJC1tc33Zq0.jpg?name=large)
+
+⭐ If this series is useful, [star the HyperFrames repo](https://github.com/heygen-com/hyperframes).
+
+- Variables docs: [hyperframes.heygen.com/concepts/variables](https://hyperframes.heygen.com/concepts/variables)
+- Cloud templates: [hyperframes.heygen.com/deploy/cloud](https://hyperframes.heygen.com/deploy/cloud#templates-and-variables)
+- Templates on Lambda: [hyperframes.heygen.com/deploy/templates-on-lambda](https://hyperframes.heygen.com/deploy/templates-on-lambda)
+- Install the skills: npx skills add heygen-com/hyperframes

--- a/content/highlights/2026-07-29-templates-variables.md
+++ b/content/highlights/2026-07-29-templates-variables.md
@@ -1,0 +1,144 @@
+---
+externalId: "templates-variables"
+kind: "article"
+title: "模板与变量"
+description: "HyperFrames 介绍如何用带类型的合成项目变量，将一次视频构建变成可复用模板，并在本地、托管云端和 Lambda 中批量生成个性化视频。"
+date: 2026-07-29
+sourceUrl: "https://x.com/HyperFrames_/status/2082197435246600341"
+cover: "https://pbs.twimg.com/media/HOVxksYaUAAUjJ9?format=jpg&name=large"
+tags: ["HyperFrames", "模板", "变量", "视频自动化"]
+featured: true
+draft: false
+---
+
+[原文：Templates & Variables — HyperFrames](https://x.com/HyperFrames_/status/2082197435246600341)
+
+![图片](https://pbs.twimg.com/media/HOVxksYaUAAUjJ9?format=jpg&name=large)
+
+# 30 天第 23 天：把你的视频变成模板
+
+在前 22 天里，这个系列的每次渲染都只会生成一支视频。换一个标题，就意味着重新编辑；换一个名字，就意味着重新渲染。第 23 天打破了这个上限。变量可以把一个 HyperFrames 合成项目变成模板，而模板可以让一次构建根据数据表中的每一行，生成任意数量的视频。
+
+```text
+npx hyperframes render --batch rows.json --output "renders/{name}.mp4"
+```
+
+一条命令，一个合成项目，一个装满个性化视频的文件夹。
+
+## 什么是变量
+
+变量是在合成项目根节点上声明的带类型占位槽。声明本身就是模式定义（schema），其他所有内容都从这里读取。
+
+```text
+<html data-composition-variables='[
+  {"id":"title","type":"string","label":"Title","default":"Hello"},
+  {"id":"accent","type":"color","label":"Accent","default":"#66d9ef"}
+]'>
+```
+
+目前支持七种类型：**string**（可选 placeholder 和 maxLength）、**number**（min、max、step、unit）、**color**、**boolean** 和 **enum**（必须提供 options 列表），另外还有 font 与 image 两种类型，用于表示素材形态的值。每项声明都必须提供一个实用的默认值。仅凭这些默认值，合成项目就能够正常预览和渲染；在有人覆盖变量之前，它仍然是一支普通视频。
+
+## 接入变量值，无须编写脚本
+
+大多数替换操作完全不需要 JavaScript。三种声明式绑定覆盖了常见场景：
+
+- `data-var-text="title"` 会替换元素自身的文本，同时保留其子元素，因此用于动画的 span 不会丢失。
+- `data-var-src="heroImage"` 会替换图片的 `src`；创作时写入的 `src` 会继续作为回退值。
+- 每个标量变量都会自动作为 `--{id}` CSS 自定义属性应用到合成项目根节点，因此 `color: var(--accent)` 无须样板代码就能响应覆盖值。
+
+```text
+<h1 class="clip" data-start="0" data-duration="5" data-var-text="title">Fallback</h1>
+<img class="clip" data-start="0" data-duration="5" data-var-src="heroImage" src="fallback.jpg" />
+```
+
+如果需求不只是直接替换，例如需要循环、条件判断或派生值，可以在初始化时读取一次变量：
+
+```text
+const { title = "Untitled", accent = "#66d9ef" } = __hyperframes.getVariables();
+```
+
+子合成项目也会按每个实例采用相同机制。借助 `data-variable-values`，同一个 `card.html` 可以在主文件中出现三次，并分别使用三个不同的标题：
+
+```text
+<div
+  data-composition-id="card-pro"
+  data-composition-src="compositions/card.html"
+  data-variable-values='{"title":"Pro","accent":"#ff4d4f"}'
+></div>
+```
+
+## 在渲染时覆盖变量
+
+变量值以普通 JSON 的形式从 CLI 传入：
+
+```text
+# 内联 JSON
+npx hyperframes render --variables '{"title":"Q4 Report"}'
+
+# 从文件读取
+npx hyperframes render --variables-file vars.json
+
+# CI 模式：未声明的键和错误类型都会成为错误
+npx hyperframes render --variables '{"title":"Q4"}' --strict-variables
+```
+
+接下来这个参数会从根本上改变工具的用途。批处理模式让渲染器读取一个由多行数据组成的文件，而输出路径可以使用每行数据中的 `{key}` 占位符：
+
+```text
+npx hyperframes render --batch rows.json --output "renders/{name}.mp4"
+```
+
+每一行数据都会覆盖已声明的默认值，效果与单独通过 `--variables` 传入完全相同。输入十行，就会输出十支视频。
+
+## 在云端批量渲染整个视频集
+
+第 21 天介绍了云端渲染，而模板正是那套基础设施存在的理由。这里有两条路径，但思路相同：模板只上传一次，之后的每次渲染只需传入一组新的变量值。
+
+**HeyGen 托管云端。** 首次渲染会上传项目并输出一个 `asset_id`。之后的每次渲染都会复用它，不必重新压缩，也不必重新上传：
+
+```text
+# 上传并渲染一次
+hyperframes cloud render ./card-template
+
+# 使用新变量再次渲染，完全跳过上传
+hyperframes cloud render --asset-id asst_abc123 --variables '{"name":"Ada"}'
+hyperframes cloud render --asset-id asst_abc123 --variables '{"name":"Linus"}'
+```
+
+**你自己的 AWS。** 只需部署一次 Lambda 技术栈，再通过 `lambda sites create` 上传一次模板，然后向 `lambda render-batch` 提供一个 JSONL 文件，每位接收者占一行。每一行都是一个拥有自身 `outputKey` 和 `variables` 的对象。默认情况下，它会并发运行 50 个渲染任务：
+
+```text
+hyperframes lambda render-batch ./my-template \
+  --site-id abc1234deadbeef0 \
+  --batch ./recipients.jsonl \
+  --width 1920 --height 1080
+```
+
+对于本地项目，CLI 会在上传任何内容之前，按照已声明的模式定义校验变量。对于使用 `asset-id` 的渲染，校验会在服务端完成。
+
+## 实践笔记
+
+- **两种 JSON 结构很容易混淆。** 声明是由 `{id, type, label, default}` 对象组成的数组；变量值则是一个以 `id` 为键的对象。把两者混在一起，是最常见的变量使用错误。
+- **优先级按合成项目分别计算，并不存在一条全局覆盖链。** 子合成项目先读取自己的默认值，再由宿主元素上的 `data-variable-values` 覆盖。CLI 变量值只覆盖顶层合成项目，绝不会传递到子合成项目。
+- **并非所有内容都能成为变量。** 画布尺寸、根节点时长、帧率和编解码器会在编译时一次性解析。变量改变的是内容，不是承载内容的容器。
+- **媒体 `src` 不能通过变量替换。** `data-var-src` 对 `\\<img>` 有效；但对于 `\\<video>` 和 `\\<audio>`，渲染器会播放并混合创作时写入的 `src`，所以变量替换后的 `src` 不会进入最终输出。如果要改变由框架管理的媒体，请修改创作时的 `src`，并为每个片段使用一个子合成项目实例。
+- **变量传递的是数据，不是文件。** 所有部署目标都遵循同一约定：带类型的值放进变量，媒体素材则使用 URL 引用，由合成项目在渲染时解析。
+
+## 今天的视频是如何制作的
+
+今天的影片本身就是这个功能的演示。项目中只有一个卡片合成项目 `compositions/card.html`，它声明了三个变量：标签、标题和强调色。主文件把这个模板实例化了八次。第一个实例完全没有传入变量，因此你看到的是卡片仅使用其声明的默认值运行。接着，Austin、Seattle、Atlanta 和 Miami 分别通过新实例上的 `data-variable-values` 传入覆盖值；最后的收尾网格则由另外四个并排实例组成。画面中的任何内容都没有被重复设计。四座城市的市场更新，只使用一个模板；每次变化的仅仅是一行 JSON 数据。
+
+## 输出
+
+第 23 天的最终视频：22 秒，四座城市，一个模板。
+
+<video preload="none" tabindex="-1" playsinline="" aria-label="嵌入视频" poster="https://pbs.twimg.com/amplify_video_thumb/2082196246132092928/img/UndjWtJC1tc33Zq0.jpg" style="width: 100%; height: 100%; position: absolute; background-color: black; top: 0%; left: 0%; transform: rotate(0deg) scale(1.005);"><source type="video/mp4"></video>
+
+![](https://pbs.twimg.com/amplify_video_thumb/2082196246132092928/img/UndjWtJC1tc33Zq0.jpg?name=large)
+
+⭐ 如果这个系列对你有帮助，请为 [HyperFrames 仓库加星](https://github.com/heygen-com/hyperframes)。
+
+- 变量文档：[hyperframes.heygen.com/concepts/variables](https://hyperframes.heygen.com/concepts/variables)
+- 云端模板：[hyperframes.heygen.com/deploy/cloud](https://hyperframes.heygen.com/deploy/cloud#templates-and-variables)
+- Lambda 模板：[hyperframes.heygen.com/deploy/templates-on-lambda](https://hyperframes.heygen.com/deploy/templates-on-lambda)
+- 安装 skills：`npx skills add heygen-com/hyperframes`


### PR DESCRIPTION
## What changed

- add the complete English source article from the Templates & Variables clipping
- add a full context-aware Chinese translation while preserving commands, variable names, HTML bindings, links, images, and the embedded video
- register both new highlight routes in the unified content tests

## Content fidelity

- English body matches the clipping exactly apart from the repository-standard terminal newline
- both locales retain 7 sections, 9 code blocks, 2 images, and 1 embedded video
- preserves batch rendering, strict variable validation, sub-composition precedence, cloud asset reuse, and Lambda examples
- does not introduce the generic interpretation template

## Validation

- root: 49 test files, 758 tests passed
- Astro: 13 test files, 88 tests passed
- built 333 pages and 667 routes
- CSP and site verification passed
- rendered HTML contains both bilingual routes and all key examples
- git diff --check passed