### PR TITLE
fix: allow localization contract in code releases

### DIFF
--- a/workers/content/deployer/index.test.ts
+++ b/workers/content/deployer/index.test.ts
@@ -646,6 +646,10 @@ describe("automatic code release boundary", () => {
             status: "modified",
           },
           {
+            filename: "scripts/daily-localization-contract.mjs",
+            status: "added",
+          },
+          {
             filename: "scripts/html-local-references.mjs",
             status: "added",
           },
@@ -718,7 +722,7 @@ describe("automatic code release boundary", () => {
           structuredCutoverDate: "2026-07-16",
         },
       ),
-    ).toHaveLength(39);
+    ).toHaveLength(40);
   });
 
   it.each([

--- a/workers/content/deployer/index.ts
+++ b/workers/content/deployer/index.ts
@@ -258,6 +258,7 @@ const INERT_ROOT_SCRIPTS = new Set([
   "scripts/check-content-observability.mjs",
   "scripts/check-content-observation-window.mjs",
   "scripts/create-content-addressed-artifact.mjs",
+  "scripts/daily-localization-contract.mjs",
   "scripts/html-local-references.mjs",
   "scripts/materialize-content-addressed-artifact.mjs",
   "scripts/pull-daily-content.sh",


### PR DESCRIPTION
## What changed

- Classifies exactly `scripts/daily-localization-contract.mjs` as an inert root verification script in the production code-release allowlist.
- Extends the existing complete classified-change-set regression test.
- Does not broaden trust to the rest of `scripts/`.

## Root cause

The Chinese localization release contract was added to `main` in PR #279 and imported by `scripts/verify-site.mjs`, but the production content deployer did not know that new helper path. Automatic Code Release therefore rejected the complete change set for PR #281 with `unsafe_code_release`.

## Impact

This unblocks the already-merged English feed localization release while retaining the fail-closed code-release boundary.

## Validation

- `npx vitest run workers/content/deployer/index.test.ts --silent` — 41 tests passed
- `npm run content:deployer:check` — Wrangler dry-run succeeded
- `git diff --check` — passed