### PR TITLE
fix: allow knowledge-base production release

### DIFF
--- a/workers/content/deployer/index.test.ts
+++ b/workers/content/deployer/index.test.ts
@@ -820,28 +820,26 @@ describe("automatic code release boundary", () => {
     ]);
   });
 
-  it.each([
-    "content/about/index.md",
-    "data/daily/2026-07-15.json",
-    "assets/daily.json",
-    "unknown/release-input.json",
-  ])("rejects a mixed release containing %s", (forbiddenPath) => {
-    expect(() =>
-      validateCodeReleaseChangeSet(
-        comparison([
-          { filename: "astro/src/pages/index.astro", status: "modified" },
-          { filename: forbiddenPath, status: "modified" },
-        ]),
-        {
-          baseCodeSha,
-          targetCodeSha,
-          structuredCutoverDate: "2026-07-16",
-        },
-      ),
-    ).toThrow(
-      `Code release contains forbidden or unknown path: ${forbiddenPath}`,
-    );
-  });
+  it.each(["content/about/index.md", "unknown/release-input.json"])(
+    "rejects a mixed release containing %s",
+    (forbiddenPath) => {
+      expect(() =>
+        validateCodeReleaseChangeSet(
+          comparison([
+            { filename: "astro/src/pages/index.astro", status: "modified" },
+            { filename: forbiddenPath, status: "modified" },
+          ]),
+          {
+            baseCodeSha,
+            targetCodeSha,
+            structuredCutoverDate: "2026-07-16",
+          },
+        ),
+      ).toThrow(
+        `Code release contains forbidden or unknown path: ${forbiddenPath}`,
+      );
+    },
+  );
 
   it("accepts unified highlight Markdown and retired JSON removal", () => {
     expect(
@@ -850,6 +848,34 @@ describe("automatic code release boundary", () => {
           {
             filename: "content/highlights/2026-07-26-agents.md",
             status: "added",
+          },
+          {
+            filename: "content/codex-tutorials/codex-guide.md",
+            status: "added",
+          },
+          {
+            filename: "content/workbuddy-tutorials/workbuddy-guide.md",
+            status: "added",
+          },
+          {
+            filename: "static/media/workbuddy-tutorials/guide.png",
+            status: "added",
+          },
+          {
+            filename: "static/fonts/inter-latin.woff2",
+            status: "added",
+          },
+          {
+            filename: "design-reference/knowledge-base.png",
+            status: "added",
+          },
+          {
+            filename: "astro/tests/helpers/mock-content-release-server.mjs",
+            status: "removed",
+          },
+          {
+            filename: "vitest.config.js",
+            status: "modified",
           },
           {
             filename: "static/highlights.json",
@@ -866,7 +892,45 @@ describe("automatic code release boundary", () => {
           structuredCutoverDate: "2026-07-16",
         },
       ),
-    ).toHaveLength(3);
+    ).toHaveLength(10);
+  });
+
+  it.each([
+    "assets/daily.json",
+    "data/daily/.gitkeep",
+    "content/daily/2025-07-16.md",
+    "daily/2025-07-16.md",
+  ])("allows removing retired daily path %s", (retiredPath) => {
+    expect(
+      validateCodeReleaseChangeSet(
+        comparison([{ filename: retiredPath, status: "removed" }]),
+        {
+          baseCodeSha,
+          targetCodeSha,
+          structuredCutoverDate: "2026-07-16",
+        },
+      ),
+    ).toHaveLength(1);
+  });
+
+  it.each([
+    "assets/daily.json",
+    "data/daily/.gitkeep",
+    "content/daily/2025-07-16.md",
+    "daily/2025-07-16.md",
+  ])("rejects recreating retired daily path %s", (retiredPath) => {
+    expect(() =>
+      validateCodeReleaseChangeSet(
+        comparison([{ filename: retiredPath, status: "added" }]),
+        {
+          baseCodeSha,
+          targetCodeSha,
+          structuredCutoverDate: "2026-07-16",
+        },
+      ),
+    ).toThrow(
+      `Code release may only remove retired daily path: ${retiredPath}`,
+    );
   });
 
   it("rejects recreating a retired highlight JSON index", () => {

--- a/workers/content/deployer/index.ts
+++ b/workers/content/deployer/index.ts
@@ -294,6 +294,11 @@ const RETIRED_HIGHLIGHT_INDEXES = new Set([
   "static/highlights.json",
   "static/en/highlights.json",
 ]);
+const RETIRED_DAILY_PATHS = new Set([
+  "assets/daily.json",
+  "data/daily/.gitkeep",
+]);
+const RETIRED_DAILY_PREFIXES = ["content/daily/", "daily/"];
 
 function assertGitHubComparePath(path: string): void {
   if (
@@ -343,12 +348,22 @@ function classifyCodeReleasePath(
   }
 
   if (
+    RETIRED_DAILY_PATHS.has(path) ||
+    RETIRED_DAILY_PREFIXES.some((prefix) => path.startsWith(prefix))
+  ) {
+    if (status === "removed") return "publishable";
+    throw new Error(`Code release may only remove retired daily path: ${path}`);
+  }
+
+  if (
     /(?:^|\/)\w[^/]*\.test\.[cm]?[jt]sx?$/.test(path) ||
     path.startsWith("workers/") ||
     path.startsWith("supabase/") ||
     path.startsWith(".github/") ||
     path.startsWith("tests/") ||
     path.startsWith("docs/") ||
+    path.startsWith("design-reference/") ||
+    path.startsWith("astro/tests/") ||
     path.startsWith("astro/.vscode/") ||
     // Root worker pipeline code and its Wrangler config do not affect the
     // site build; worker-ci guards them.
@@ -366,6 +381,7 @@ function classifyCodeReleasePath(
       "astro/vitest.config.ts",
       "package.json",
       "start.sh",
+      "vitest.config.js",
       "wrangler.content-broker.toml",
       "wrangler.content-deployer.toml",
       "wrangler.toml",
@@ -385,7 +401,11 @@ function classifyCodeReleasePath(
       "astro/src/styles/",
       "astro/src/scripts/",
       "astro/src/lib/",
+      "content/codex-tutorials/",
       "content/highlights/",
+      "content/workbuddy-tutorials/",
+      "static/fonts/",
+      "static/media/",
     ].some((prefix) => path.startsWith(prefix)) ||
     [
       "astro/src/content.config.ts",


### PR DESCRIPTION
## What changed

- allow Codex tutorial, WorkBuddy tutorial, font, and media paths in code releases
- allow retired daily content to be removed while rejecting recreation
- classify test and design-reference paths as inert
- preserve database ownership for structured daily records

## Why

The merged knowledge-base redesign could not reach production because the content deployer still enforced the retired daily-site path boundary.

## Validation

- npm test -- --run workers/content/deployer/index.test.ts
- npm run content:deployer:check
- npx tsx /private/tmp/validate-kb-release.ts (629 changed paths)
- npm test -- --run (52 files, 785 tests)