### PR TITLE
fix: provide content contract to release builds

### DIFF
--- a/.github/workflows/content-release.yml
+++ b/.github/workflows/content-release.yml
@@ -58,6 +58,11 @@ jobs:
       CONTENT_RELEASE_SEQUENCE: ${{ github.event.inputs.site_release_sequence }}
       EXPECTED_PREDECESSOR_ID: ${{ github.event.inputs.expected_predecessor_id }}
       CONTENT_ROOT_SHA256: ${{ github.event.inputs.expected_content_sha }}
+      CONTENT_SCHEMA_VERSION: ${{ vars.CONTENT_SCHEMA_VERSION || '1' }}
+      CONTENT_TAXONOMY_VERSION: ${{ vars.CONTENT_TAXONOMY_VERSION || '1' }}
+      CONTENT_SERIALIZER_VERSION: ${{ vars.CONTENT_SERIALIZER_VERSION || 'daily-json-c14n-v1' }}
+      CONTENT_SEARCH_CONTRACT_VERSION: ${{ vars.CONTENT_SEARCH_CONTRACT_VERSION || 'search-v1' }}
+      CONTENT_SOURCE_CONTRACT_VERSION: ${{ vars.CONTENT_SOURCE_CONTRACT_VERSION || 'daily-source-v1' }}
       EXACT_CODE_SHA: ${{ github.event.inputs.code_sha }}
       SOURCE_CODE_SHA: ${{ github.event.inputs.source_code_sha }}
       BUILD_ENVIRONMENT_VERSION: ${{ github.event.inputs.build_environment_version }}

--- a/tests/worker/contentReleaseWorkflow.test.js
+++ b/tests/worker/contentReleaseWorkflow.test.js
@@ -47,6 +47,21 @@ describe("fenced content release workflow", () => {
       'node scripts/verify-preview.mjs "$PREVIEW_URL" "$EXACT_CODE_SHA"',
     );
     expect(workflow).toContain(
+      "CONTENT_SCHEMA_VERSION: ${{ vars.CONTENT_SCHEMA_VERSION || '1' }}",
+    );
+    expect(workflow).toContain(
+      "CONTENT_TAXONOMY_VERSION: ${{ vars.CONTENT_TAXONOMY_VERSION || '1' }}",
+    );
+    expect(workflow).toContain(
+      "CONTENT_SERIALIZER_VERSION: ${{ vars.CONTENT_SERIALIZER_VERSION || 'daily-json-c14n-v1' }}",
+    );
+    expect(workflow).toContain(
+      "CONTENT_SEARCH_CONTRACT_VERSION: ${{ vars.CONTENT_SEARCH_CONTRACT_VERSION || 'search-v1' }}",
+    );
+    expect(workflow).toContain(
+      "CONTENT_SOURCE_CONTRACT_VERSION: ${{ vars.CONTENT_SOURCE_CONTRACT_VERSION || 'daily-source-v1' }}",
+    );
+    expect(workflow).toContain(
       "node scripts/request-production-promotion.mjs > broker-result.json",
     );
     expect(workflow).toContain(


### PR DESCRIPTION
## What changed

- provide the pinned content schema, taxonomy, serializer, search, and source contract versions to Exact Content Release builds
- keep repository/environment overrides available while defaulting to the production contract currently stored in release metadata
- add workflow contract coverage for all five required fields

## Root cause

The production release build set a release identity but omitted the content contract environment. Site manifest generation correctly failed closed with Invalid content schema version.

## Validation

- npm test -- --run tests/worker/contentReleaseWorkflow.test.js tests/worker/contentRouteBuildContract.test.js
- npm test -- --run (52 files, 785 tests)