### PR TITLE
fix: allow tutorial media in preview verification

### DIFF
--- a/scripts/preview-media-types.mjs
+++ b/scripts/preview-media-types.mjs
@@ -6,6 +6,8 @@ const PREVIEW_MEDIA_TYPES = new Set([
   "font/ttf",
   "font/woff",
   "font/woff2",
+  "image/gif",
+  "image/jpeg",
   "image/png",
   "image/svg+xml",
   "image/vnd.microsoft.icon",

--- a/tests/worker/previewMediaTypes.test.js
+++ b/tests/worker/previewMediaTypes.test.js
@@ -11,6 +11,13 @@ describe("Preview media-type contract", () => {
     expect(expectedPreviewMediaType(contentType)).toBe(contentType);
   });
 
+  it.each([
+    "image/gif",
+    "image/jpeg",
+  ])("accepts tutorial media type %s", (contentType) => {
+    expect(expectedPreviewMediaType(contentType)).toBe(contentType);
+  });
+
   it("fails closed for an undeclared media type", () => {
     expect(expectedPreviewMediaType("application/x-unknown")).toBeUndefined();
   });


### PR DESCRIPTION
## Summary
- allow JPEG and GIF assets in Preview byte/type verification
- cover both tutorial media types with fail-closed contract tests

## Validation
- `npm test -- --run tests/worker/previewMediaTypes.test.js`
- `npm test -- --run` (52 files / 787 tests)
- `git diff --check`