### PR TITLE
fix: classify preview media contract for releases

### DIFF
--- a/workers/content/deployer/index.test.ts
+++ b/workers/content/deployer/index.test.ts
@@ -687,6 +687,10 @@ describe("automatic code release boundary", () => {
             status: "modified",
           },
           {
+            filename: "scripts/preview-media-types.mjs",
+            status: "modified",
+          },
+          {
             filename: "wrangler.content-broker.toml",
             status: "modified",
           },
@@ -723,7 +727,7 @@ describe("automatic code release boundary", () => {
           structuredCutoverDate: "2026-07-16",
         },
       ),
-    ).toHaveLength(40);
+    ).toHaveLength(41);
   });
 
   it.each([

--- a/workers/content/deployer/index.ts
+++ b/workers/content/deployer/index.ts
@@ -261,6 +261,7 @@ const INERT_ROOT_SCRIPTS = new Set([
   "scripts/daily-localization-contract.mjs",
   "scripts/html-local-references.mjs",
   "scripts/materialize-content-addressed-artifact.mjs",
+  "scripts/preview-media-types.mjs",
   "scripts/pull-daily-content.sh",
   "scripts/request-code-release.mjs",
   "scripts/request-content-release-plan.mjs",


### PR DESCRIPTION
## Summary
- classify the exact Preview media-type contract file as inert release infrastructure
- keep the allowlist scoped to one file rather than the whole scripts directory
- cover the file in the deployer change-set contract test

## Validation
- `npm test -- --run workers/content/deployer/index.test.ts`
- `npm test -- --run` (52 files / 787 tests)
- `npm run content:deployer:check`
- `git diff --check`