### PR TITLE
fix: verify knowledge-base production artifacts

### DIFF
--- a/workers/content/broker/index.test.ts
+++ b/workers/content/broker/index.test.ts
@@ -1843,6 +1843,30 @@ describe("production convergence verification", () => {
     });
   });
 
+  it("verifies knowledge-base artifacts without retired daily routes", async () => {
+    const value = setup();
+    const clock = controlledClock();
+    const knowledgeFiles = files.filter(
+      (file) => !file.path.startsWith("daily/") && !file.path.startsWith("data/daily/"),
+    );
+    await expect(
+      verifyDeployment(
+        context,
+        "https://deploy.pages.dev",
+        value.env,
+        { kind: "tar", files: knowledgeFiles },
+        clock.startedAt,
+        clock.dependencies,
+      ),
+    ).resolves.toMatchObject({
+      multi_edge_verified: true,
+      endpoints: [
+        { exact_paths: ["/", "/search/index.json"] },
+        { exact_paths: ["/", "/search/index.json"] },
+      ],
+    });
+  });
+
   it("allows declared custom-domain HTML transforms while keeping two exact-byte origins", async () => {
     const value = setup(false, 0, true);
     const clock = controlledClock();

--- a/workers/content/broker/index.ts
+++ b/workers/content/broker/index.ts
@@ -764,11 +764,17 @@ async function criticalArtifactFiles(
     .filter((path) => /^data\/daily\/\d{4}-\d{2}-\d{2}\.json$/.test(path))
     .sort()
     .at(-1);
-  if (!dailyJson)
-    throw new Error("Artifact has no release-pinned daily JSON to verify");
-  const date = dailyJson.slice("data/daily/".length, -".json".length);
-  const dailyHtml = `daily/${date.slice(0, 4)}/${date.slice(5, 7)}/${date}/index.html`;
-  const required = ["index.html", dailyHtml, dailyJson, "search/index.json"];
+  const hasDailyHtml = inventory.some((path) =>
+    /^daily\/\d{4}\/\d{2}\/\d{4}-\d{2}-\d{2}\/index\.html$/.test(path),
+  );
+  if (hasDailyHtml && !dailyJson)
+    throw new Error("Artifact daily route has no release-pinned JSON");
+  const required = ["index.html", "search/index.json"];
+  if (dailyJson) {
+    const date = dailyJson.slice("data/daily/".length, -".json".length);
+    const dailyHtml = `daily/${date.slice(0, 4)}/${date.slice(5, 7)}/${date}/index.html`;
+    required.splice(1, 0, dailyHtml, dailyJson);
+  }
   const files: TarFile[] = [];
   for (const path of required) {
     if (bundle.kind === "tar") {


### PR DESCRIPTION
## Summary
- verify home and search bytes for knowledge-base artifacts without retired daily routes
- preserve daily HTML/JSON byte verification when a release still contains daily content
- fail closed when a daily HTML route exists without its release-pinned JSON

## Validation
- `npm test -- --run workers/content/broker/index.test.ts`
- `npm test -- --run` (52 files / 788 tests)
- `npm run content:broker:check`
- `git diff --check`