### PR TITLE
refactor: speed up knowledge base releases

### DIFF
--- a/.github/workflows/content-release.yml
+++ b/.github/workflows/content-release.yml
@@ -392,13 +392,13 @@ jobs:
           node "$RUNNER_TEMP/content-release-helper.mjs" callback artifact_registered "$evidence"
 
       - name: Materialize exact registered R2 artifact
-        if: ${{ steps.resume.outputs.stage != 'build' }}
+        if: ${{ steps.resume.outputs.stage == 'preview' }}
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.R2_ARTIFACT_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_ARTIFACT_SECRET_ACCESS_KEY }}
           AWS_DEFAULT_REGION: auto
           R2_ENDPOINT: https://${{ secrets.CLOUDFLARE_ACCOUNT_ID }}.r2.cloudflarestorage.com
-          R2_MATERIALIZE_CONCURRENCY: "8"
+          R2_MATERIALIZE_CONCURRENCY: "16"
         run: |
           node scripts/materialize-content-addressed-artifact.mjs server-resume-plan.json astro/dist/client > materialize-summary.json
           jq -e '.site_release_id == env.SITE_RELEASE_ID and .artifact_sha256 == env.ARTIFACT_SHA256' materialize-summary.json >/dev/null
@@ -415,9 +415,11 @@ jobs:
           echo "PREVIEW_URL=$preview_url" >> "$GITHUB_ENV"
 
       - name: Verify Preview route parity and exact bytes
+        if: ${{ steps.resume.outputs.stage != 'promote' }}
         run: node scripts/verify-preview.mjs "$PREVIEW_URL" "$EXACT_CODE_SHA" astro/dist/client/release-manifests/site-route-manifest.json
 
       - name: Record Preview evidence
+        if: ${{ steps.resume.outputs.stage != 'promote' }}
         run: |
           evidence="$(jq -nc --arg url "$PREVIEW_URL" --arg artifact "$ARTIFACT_SHA256" --arg content "$CONTENT_ROOT_SHA256" --arg code "$EXACT_CODE_SHA" --arg contract "$RESUME_CONTRACT_VERSION" '{preview_url:$url,artifact_sha256:$artifact,content_sha256:$content,code_sha:$code,route_parity:true,resume_contract_version:($contract | if length > 0 then . else null end)}')"
           node "$RUNNER_TEMP/content-release-helper.mjs" callback preview_verified "$evidence"

--- a/scripts/validate-content-production-config.mjs
+++ b/scripts/validate-content-production-config.mjs
@@ -275,6 +275,31 @@ export function validateWranglerDocuments(documents) {
     );
   }
 
+  const stabilityOffsetsMs = required(
+    "Broker: PRODUCTION_STABILITY_OFFSETS_MS",
+    tomlString(
+      documents["wrangler.content-broker.toml"],
+      "PRODUCTION_STABILITY_OFFSETS_MS",
+    ),
+  )
+    .split(",")
+    .map((entry) => Number(entry.trim()));
+  if (
+    stabilityOffsetsMs.length < 3 ||
+    stabilityOffsetsMs.length > 5 ||
+    stabilityOffsetsMs.some(
+      (offset, index) =>
+        !Number.isSafeInteger(offset) ||
+        offset < 1_000 ||
+        offset > 300_000 ||
+        (index > 0 && offset <= stabilityOffsetsMs[index - 1]),
+    )
+  ) {
+    fail(
+      "Broker PRODUCTION_STABILITY_OFFSETS_MS must contain 3-5 increasing millisecond offsets",
+    );
+  }
+
   const purgeUrls = required(
     "Broker: CONTENT_API_PURGE_URLS",
     tomlString(
@@ -291,6 +316,7 @@ export function validateWranglerDocuments(documents) {
   return {
     files: WRANGLER_FILES.length,
     maximumInconsistencyMs,
+    stabilityOffsetsMs,
     minimumExactVerifierCount,
     minimumVerifierCount,
     transformedHtmlVerifierOrigins: new Set(transformedHtmlVerifierUrls).size,

--- a/tests/worker/contentProductionConfig.test.js
+++ b/tests/worker/contentProductionConfig.test.js
@@ -79,12 +79,24 @@ describe("content production preflight", () => {
     );
     expect(validateWranglerDocuments(configuredWranglerDocuments())).toEqual({
       files: 7,
-      maximumInconsistencyMs: 300000,
+      maximumInconsistencyMs: 120000,
       minimumExactVerifierCount: 2,
       minimumVerifierCount: 3,
+      stabilityOffsetsMs: [5000, 15000, 30000],
       transformedHtmlVerifierOrigins: 1,
       verifierOrigins: 2,
     });
+
+    const invalidStability = configuredWranglerDocuments();
+    invalidStability["wrangler.content-broker.toml"] = invalidStability[
+      "wrangler.content-broker.toml"
+    ].replace(
+      'PRODUCTION_STABILITY_OFFSETS_MS = "5000,15000,30000"',
+      'PRODUCTION_STABILITY_OFFSETS_MS = "5000,5000,30000"',
+    );
+    expect(() => validateWranglerDocuments(invalidStability)).toThrow(
+      /PRODUCTION_STABILITY_OFFSETS_MS/,
+    );
   });
 
   it("rejects an Attestation audience that differs from its Access application", () => {

--- a/tests/worker/contentReleaseWorkflow.test.js
+++ b/tests/worker/contentReleaseWorkflow.test.js
@@ -44,12 +44,19 @@ describe("fenced content release workflow", () => {
     expect(workflow).toContain(
       "node scripts/materialize-content-addressed-artifact.mjs server-resume-plan.json astro/dist/client",
     );
+    expect(workflow).toMatch(
+      /- name: Materialize exact registered R2 artifact\n\s+if: \$\{\{ steps\.resume\.outputs\.stage == 'preview' \}\}/,
+    );
     expect(workflow).toContain(
       "if: ${{ steps.resume.outputs.stage == 'build' }}",
     );
-    expect(workflow).toContain(
-      "if: ${{ steps.resume.outputs.stage != 'promote' }}",
+    expect(workflow).toMatch(
+      /- name: Verify Preview route parity and exact bytes\n\s+if: \$\{\{ steps\.resume\.outputs\.stage != 'promote' \}\}/,
     );
+    expect(workflow).toMatch(
+      /- name: Record Preview evidence\n\s+if: \$\{\{ steps\.resume\.outputs\.stage != 'promote' \}\}/,
+    );
+    expect(workflow).toContain('R2_MATERIALIZE_CONCURRENCY: "16"');
     expect(workflow).toContain(
       'node scripts/verify-preview.mjs "$PREVIEW_URL" "$EXACT_CODE_SHA"',
     );

--- a/workers/content/broker/index.test.ts
+++ b/workers/content/broker/index.test.ts
@@ -1853,13 +1853,20 @@ describe("production convergence verification", () => {
       verifyDeployment(
         context,
         "https://deploy.pages.dev",
-        value.env,
+        {
+          ...value.env,
+          MAX_PRODUCTION_INCONSISTENCY_MS: "120000",
+          PRODUCTION_STABILITY_OFFSETS_MS: "5000,15000,30000",
+        },
         { kind: "tar", files: knowledgeFiles },
         clock.startedAt,
         clock.dependencies,
       ),
     ).resolves.toMatchObject({
       multi_edge_verified: true,
+      maximum_inconsistency_ms: 120000,
+      stability_elapsed_ms: 30000,
+      stability_offsets: [5000, 15000, 30000],
       endpoints: [
         { exact_paths: ["/", "/search/index.json"] },
         { exact_paths: ["/", "/search/index.json"] },

--- a/workers/content/broker/index.ts
+++ b/workers/content/broker/index.ts
@@ -21,6 +21,7 @@ type Env = {
   VERIFY_MIN_ENDPOINTS?: string;
   VERIFY_MIN_EXACT_ENDPOINTS?: string;
   MAX_PRODUCTION_INCONSISTENCY_MS?: string;
+  PRODUCTION_STABILITY_OFFSETS_MS?: string;
 };
 
 type JsonRecord = Record<string, unknown>;
@@ -103,6 +104,29 @@ type VerificationDependencies = {
 type VerificationProbeResult =
   | { ok: true; evidence: JsonRecord }
   | { ok: false; failure: VerificationFailure };
+
+const DEFAULT_STABILITY_OFFSETS_MS = [15_000, 45_000, 120_000];
+
+function productionStabilityOffsets(value?: string): number[] {
+  if (!String(value || "").trim()) return DEFAULT_STABILITY_OFFSETS_MS;
+  const offsets = String(value)
+    .split(",")
+    .map((entry) => Number(entry.trim()));
+  if (
+    offsets.length < 3 ||
+    offsets.length > 5 ||
+    offsets.some(
+      (offset, index) =>
+        !Number.isSafeInteger(offset) ||
+        offset < 1_000 ||
+        offset > 300_000 ||
+        (index > 0 && offset <= offsets[index - 1]),
+    )
+  ) {
+    throw new Error("Production stability offsets are invalid");
+  }
+  return offsets;
+}
 
 const UUID =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
@@ -1148,9 +1172,9 @@ export async function verifyDeployment(
       failures,
     );
   }
-  const stabilityOffsets = dependencies.stabilityOffsetsMs ?? [
-    15_000, 45_000, 120_000,
-  ];
+  const stabilityOffsets =
+    dependencies.stabilityOffsetsMs ??
+    productionStabilityOffsets(env.PRODUCTION_STABILITY_OFFSETS_MS);
   if (
     stabilityOffsets.some(
       (offset, index) =>

--- a/wrangler.content-broker.toml
+++ b/wrangler.content-broker.toml
@@ -16,7 +16,11 @@ VERIFY_MIN_EXACT_ENDPOINTS = "2"
 # From production upload start through exact multi-origin convergence. Pending
 # origins are probed in parallel until this hard limit; exceeding it restores
 # the last-known-good release while leaving the database pointer unchanged.
-MAX_PRODUCTION_INCONSISTENCY_MS = "300000"
+MAX_PRODUCTION_INCONSISTENCY_MS = "120000"
+# Knowledge-base releases are immutable static artifacts. After exact
+# multi-origin convergence, three probes over 30 seconds catch immediate edge
+# drift without retaining the former two-minute daily-publication hold.
+PRODUCTION_STABILITY_OFFSETS_MS = "5000,15000,30000"
 # Configure at least two independently routed verifier origins before enabling publication.
 PRODUCTION_VERIFY_URLS = "https://bubblenews.today,https://ai-bubblebrain-daily-news.pages.dev"
 # Cloudflare Email Address Obfuscation intentionally rewrites HTML on the


### PR DESCRIPTION
## Summary

- skip full R2 materialization and duplicate Preview verification for promotion-only resumes
- shorten immutable knowledge-base stability probes from 120 seconds to 30 seconds
- reduce the failed-convergence ceiling from 300 seconds to 120 seconds
- increase preview-resume materialization concurrency from 8 to 16

Production still verifies the deployment URL, custom domain, Pages alias, exact route manifest and critical bytes before committing the pointer. Rollback behavior remains unchanged.

## Verification

- npm test — 52 files, 788 tests passed
- npm run content:broker:check
- npm run content:production:preflight
- git diff --check