### PR TITLE
refactor: remove knowledge base stability wait

### DIFF
--- a/scripts/validate-content-production-config.mjs
+++ b/scripts/validate-content-production-config.mjs
@@ -275,17 +275,21 @@ export function validateWranglerDocuments(documents) {
     );
   }
 
-  const stabilityOffsetsMs = required(
+  const stabilityOffsetsValue = required(
     "Broker: PRODUCTION_STABILITY_OFFSETS_MS",
     tomlString(
       documents["wrangler.content-broker.toml"],
       "PRODUCTION_STABILITY_OFFSETS_MS",
     ),
-  )
-    .split(",")
-    .map((entry) => Number(entry.trim()));
+  );
+  const stabilityOffsetsMs =
+    stabilityOffsetsValue === "none"
+      ? []
+      : stabilityOffsetsValue
+          .split(",")
+          .map((entry) => Number(entry.trim()));
   if (
-    stabilityOffsetsMs.length < 3 ||
+    (stabilityOffsetsMs.length > 0 && stabilityOffsetsMs.length < 3) ||
     stabilityOffsetsMs.length > 5 ||
     stabilityOffsetsMs.some(
       (offset, index) =>

--- a/tests/worker/contentProductionConfig.test.js
+++ b/tests/worker/contentProductionConfig.test.js
@@ -82,7 +82,7 @@ describe("content production preflight", () => {
       maximumInconsistencyMs: 120000,
       minimumExactVerifierCount: 2,
       minimumVerifierCount: 3,
-      stabilityOffsetsMs: [5000, 15000, 30000],
+      stabilityOffsetsMs: [],
       transformedHtmlVerifierOrigins: 1,
       verifierOrigins: 2,
     });
@@ -91,7 +91,7 @@ describe("content production preflight", () => {
     invalidStability["wrangler.content-broker.toml"] = invalidStability[
       "wrangler.content-broker.toml"
     ].replace(
-      'PRODUCTION_STABILITY_OFFSETS_MS = "5000,15000,30000"',
+      'PRODUCTION_STABILITY_OFFSETS_MS = "none"',
       'PRODUCTION_STABILITY_OFFSETS_MS = "5000,5000,30000"',
     );
     expect(() => validateWranglerDocuments(invalidStability)).toThrow(

--- a/workers/content/broker/index.test.ts
+++ b/workers/content/broker/index.test.ts
@@ -1856,7 +1856,7 @@ describe("production convergence verification", () => {
         {
           ...value.env,
           MAX_PRODUCTION_INCONSISTENCY_MS: "120000",
-          PRODUCTION_STABILITY_OFFSETS_MS: "5000,15000,30000",
+          PRODUCTION_STABILITY_OFFSETS_MS: "none",
         },
         { kind: "tar", files: knowledgeFiles },
         clock.startedAt,
@@ -1865,8 +1865,8 @@ describe("production convergence verification", () => {
     ).resolves.toMatchObject({
       multi_edge_verified: true,
       maximum_inconsistency_ms: 120000,
-      stability_elapsed_ms: 30000,
-      stability_offsets: [5000, 15000, 30000],
+      stability_elapsed_ms: 0,
+      stability_offsets: [],
       endpoints: [
         { exact_paths: ["/", "/search/index.json"] },
         { exact_paths: ["/", "/search/index.json"] },

--- a/workers/content/broker/index.ts
+++ b/workers/content/broker/index.ts
@@ -108,8 +108,10 @@ type VerificationProbeResult =
 const DEFAULT_STABILITY_OFFSETS_MS = [15_000, 45_000, 120_000];
 
 function productionStabilityOffsets(value?: string): number[] {
-  if (!String(value || "").trim()) return DEFAULT_STABILITY_OFFSETS_MS;
-  const offsets = String(value)
+  const configured = String(value || "").trim();
+  if (!configured) return DEFAULT_STABILITY_OFFSETS_MS;
+  if (configured === "none") return [];
+  const offsets = configured
     .split(",")
     .map((entry) => Number(entry.trim()));
   if (

--- a/wrangler.content-broker.toml
+++ b/wrangler.content-broker.toml
@@ -17,10 +17,10 @@ VERIFY_MIN_EXACT_ENDPOINTS = "2"
 # origins are probed in parallel until this hard limit; exceeding it restores
 # the last-known-good release while leaving the database pointer unchanged.
 MAX_PRODUCTION_INCONSISTENCY_MS = "120000"
-# Knowledge-base releases are immutable static artifacts. After exact
-# multi-origin convergence, three probes over 30 seconds catch immediate edge
-# drift without retaining the former two-minute daily-publication hold.
-PRODUCTION_STABILITY_OFFSETS_MS = "5000,15000,30000"
+# Knowledge-base releases are immutable static artifacts. Exact multi-origin
+# verification runs before the pointer commits, and the scheduled reconciler
+# continues checking production afterwards, so no time-based hold is needed.
+PRODUCTION_STABILITY_OFFSETS_MS = "none"
 # Configure at least two independently routed verifier origins before enabling publication.
 PRODUCTION_VERIFY_URLS = "https://bubblenews.today,https://ai-bubblebrain-daily-news.pages.dev"
 # Cloudflare Email Address Obfuscation intentionally rewrites HTML on the


### PR DESCRIPTION
## Summary

- disable time-based stability probes for immutable knowledge-base releases
- retain immediate exact verification across the deployment URL, custom domain and Pages alias
- retain atomic pointer commits, failed-deployment rollback and five-minute scheduled reconciliation
- keep the configuration explicit and fail closed for malformed non-empty probe schedules

## Verification

- npm test: 52 files and 788 tests passed
- npm run content:broker:check
- npm run content:production:preflight
- git diff --check