### PR TITLE
fix: allow prompt library asset retirement

### DIFF
--- a/workers/content/deployer/index.test.ts
+++ b/workers/content/deployer/index.test.ts
@@ -958,6 +958,44 @@ describe("automatic code release boundary", () => {
     );
   });
 
+  it("allows removing the retired Prompt library client asset", () => {
+    expect(
+      validateCodeReleaseChangeSet(
+        comparison([
+          {
+            filename: "static/js/prompt-library-detail.js",
+            status: "removed",
+          },
+        ]),
+        {
+          baseCodeSha,
+          targetCodeSha,
+          structuredCutoverDate: "2026-07-16",
+        },
+      ),
+    ).toHaveLength(1);
+  });
+
+  it("rejects recreating the retired Prompt library client asset", () => {
+    expect(() =>
+      validateCodeReleaseChangeSet(
+        comparison([
+          {
+            filename: "static/js/prompt-library-detail.js",
+            status: "added",
+          },
+        ]),
+        {
+          baseCodeSha,
+          targetCodeSha,
+          structuredCutoverDate: "2026-07-16",
+        },
+      ),
+    ).toThrow(
+      "Code release may only remove retired Prompt library path: static/js/prompt-library-detail.js",
+    );
+  });
+
   it("returns a retryable conflict when the requested SHA is already superseded", async () => {
     const currentMainSha = "c".repeat(40);
     const end = vi.fn(async () => undefined);

--- a/workers/content/deployer/index.ts
+++ b/workers/content/deployer/index.ts
@@ -295,6 +295,9 @@ const RETIRED_HIGHLIGHT_INDEXES = new Set([
   "static/highlights.json",
   "static/en/highlights.json",
 ]);
+const RETIRED_PROMPT_LIBRARY_PATHS = new Set([
+  "static/js/prompt-library-detail.js",
+]);
 const RETIRED_DAILY_PATHS = new Set([
   "assets/daily.json",
   "data/daily/.gitkeep",
@@ -345,6 +348,13 @@ function classifyCodeReleasePath(
     if (status === "removed") return "publishable";
     throw new Error(
       `Code release may only remove retired highlight index: ${path}`,
+    );
+  }
+
+  if (RETIRED_PROMPT_LIBRARY_PATHS.has(path)) {
+    if (status === "removed") return "publishable";
+    throw new Error(
+      `Code release may only remove retired Prompt library path: ${path}`,
     );
   }
 


### PR DESCRIPTION
## Root cause

Automatic Code Release rejected main@5b41892 because deleting `static/js/prompt-library-detail.js` was not classified by the production deployer.

## Fix

- add an exact retirement rule for `static/js/prompt-library-detail.js`
- allow only the `removed` status
- continue rejecting any attempt to add or modify the retired asset
- add regression tests for both boundaries

## Validation

- targeted deployer and release tests: 56 passed
- full root suite: 52 files, 790 tests passed
- `npm run content:deployer:check`
- `git diff --check`
