### PR TITLE
style: remove about page subtitle

### DIFF
--- a/astro/src/components/LegacyPage.astro
+++ b/astro/src/components/LegacyPage.astro
@@ -266,7 +266,7 @@ const libraryApi =
 									? label.en
 									: label.zh}
 						</h1>
-						<p>{description}</p>
+						{record.section !== 'about' && <p>{description}</p>}
 					</div>
 					<p class="directory-count">
 						<>


### PR DESCRIPTION
## Summary

- hide the generated subtitle on the About archive page
- preserve the SEO description and subtitles on other archive pages

## Verification

- npm run verify
- confirmed generated Chinese and English About headers contain no subtitle paragraph