### PR TITLE
fix: rebind directory search after page navigation

### DIFF
--- a/astro/src/scripts/legacy-directory.js
+++ b/astro/src/scripts/legacy-directory.js
@@ -2,7 +2,12 @@
 // <script> import in LegacyPage.astro. The production deployer does not allow
 // releasing static/js/legacy-directory.js, so the Astro site maintains its
 // own copy here; the static/ copy remains for the legacy Hugo renderer only.
-(() => {
+let cleanupDirectory = () => {};
+
+function setupDirectory() {
+	cleanupDirectory();
+	cleanupDirectory = () => {};
+
 	const root = document.querySelector('[data-directory-page]');
 	if (!(root instanceof HTMLElement)) return;
 	const input = root.querySelector('[data-directory-query]');
@@ -11,6 +16,8 @@
 	const count = root.querySelector('[data-directory-count]');
 	const kind = root.dataset.directoryPage;
 	if (!(input instanceof HTMLInputElement)) return;
+	const controller = new AbortController();
+	cleanupDirectory = () => controller.abort();
 
 	const locale = document.documentElement.lang || 'zh-CN';
 	const apply = () => {
@@ -31,7 +38,7 @@
 			group.hidden = !anyVisible;
 		}
 	};
-	input.addEventListener('input', apply);
+	input.addEventListener('input', apply, { signal: controller.signal });
 
 	const api = root.dataset.libraryApi;
 	if (!api || !(list instanceof HTMLElement)) return;
@@ -218,7 +225,7 @@
 		apply();
 	};
 
-	fetch(api, { headers: { Accept: 'application/json' } })
+	fetch(api, { headers: { Accept: 'application/json' }, signal: controller.signal })
 		.then((response) => {
 			if (!response.ok) throw new Error('content library unavailable');
 			return response.json();
@@ -229,4 +236,7 @@
 		.catch(() => {
 			// Server-rendered legacy content remains the no-JS and outage fallback.
 		});
-})();
+}
+
+document.addEventListener('astro:page-load', setupDirectory);
+setupDirectory();

--- a/astro/src/scripts/legacy-directory.test.ts
+++ b/astro/src/scripts/legacy-directory.test.ts
@@ -1,0 +1,16 @@
+import { readFileSync } from 'node:fs';
+
+import { describe, expect, it } from 'vitest';
+
+const source = readFileSync(new URL('./legacy-directory.js', import.meta.url), 'utf8');
+
+describe('legacy directory lifecycle', () => {
+	it('rebinds directory search after Astro client-side navigation', () => {
+		expect(source).toContain("document.addEventListener('astro:page-load', setupDirectory);");
+		expect(source).toContain(
+			"input.addEventListener('input', apply, { signal: controller.signal });",
+		);
+		expect(source).toContain('cleanupDirectory = () => controller.abort();');
+		expect(source).toMatch(/\nsetupDirectory\(\);\s*$/);
+	});
+});


### PR DESCRIPTION
## What changed

- reinitialize archive search after every Astro client-side page navigation
- abort stale input listeners and content requests when a page is replaced
- add lifecycle regression coverage

## Root cause

The directory script ran once when its module loaded. Astro view transitions replaced the directory DOM without rerunning that module, so newly rendered search inputs had no input listener.

## User impact

Search now works without a hard refresh in Codex 教程, WorkBuddy 教程, 精选阅读, and other archive pages using the shared directory script.

## Validation

- Astro check: 0 errors, warnings, or hints
- Astro lint: passed
- Astro tests: 9 files, 26 tests passed
- Root tests: 52 files, 790 tests passed
- Astro build, CSP verification, and site verification passed
- Real browser navigation verified WorkBuddy 1/2, Codex 1/3, and Highlights 1/44 search results