### PR TITLE
fix: prevent mobile search overflow

### DIFF
--- a/astro/src/pages/search/index.astro
+++ b/astro/src/pages/search/index.astro
@@ -42,7 +42,7 @@ const sectionLabels = new Map(index.items.map((item) => [item.section, item.sect
 				<select
 					id="knowledge-section"
 					name="section"
-					class="sr-only"
+					hidden
 					tabindex="-1"
 					aria-hidden="true"
 				>


### PR DESCRIPTION
## What changed

- mark the native knowledge-section select as truly hidden
- keep the custom section menu as the visible and interactive control

## Why

The visually hidden select was still receiving `width: 100%` from the search-form CSS, which expanded beyond narrow viewports and caused horizontal scrolling.

## Validation

- root test suite: 52 files / 790 tests passed
- Astro verification: check, lint, 26 tests, build, CSP, and 556 route checks passed
- browser checks at 320, 375, 390, and 430px: no horizontal overflow
- query, section selection, result count, and URL synchronization verified