### PR TITLE
style: preserve article image aspect ratios

### DIFF
--- a/astro/src/styles/migration.css
+++ b/astro/src/styles/migration.css
@@ -1078,7 +1078,9 @@ h1 {
 
 .legacy-content img,
 .article-content img {
+	width: auto;
 	max-width: min(100%, 680px);
+	object-fit: contain;
 }
 
 .error-page nav,


### PR DESCRIPTION
## What changed

- Explicitly keep article image width automatic while respecting the existing 680px/content-width cap.
- Use `object-fit: contain` so images are never cropped when scaled.

## Why

Article images should resize responsively without stretching, cropping, or overflowing the body column.

## User impact

Images in legacy daily articles and knowledge-base articles retain their intrinsic aspect ratio on desktop and mobile.

## Validation

- `npm run check --prefix astro`
- `npm run lint --prefix astro`
- `npm run test --prefix astro` (26 tests)
- `npm run build --prefix astro`
- `npm run verify:csp --prefix astro`
- `npm run verify:site --prefix astro` (544 routes, 17 XML endpoints)
- Browser verification at 1440px and 390px against an article with 14 images; no overflow or aspect-ratio drift