### PR TITLE
style: add editorial neo-brutalist theme

### DIFF
--- a/astro/src/layouts/BaseLayout.astro
+++ b/astro/src/layouts/BaseLayout.astro
@@ -50,7 +50,7 @@ const navLinks = isEnglish
 		<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
 		<meta name="generator" content={Astro.generator} />
 		<meta name="description" content={description} />
-		<meta name="theme-color" content="#ffffff" />
+		<meta name="theme-color" content="#fbf7ef" />
 		{noindex && <meta name="robots" content="noindex, nofollow" />}
 		<meta property="og:type" content="website" />
 		<meta property="og:title" content={title} />

--- a/astro/src/styles/knowledge-home.css
+++ b/astro/src/styles/knowledge-home.css
@@ -1,4 +1,5 @@
 .knowledge-home {
+	position: relative;
 	width: min(calc(100% - 48px), 1200px);
 	margin-inline: auto;
 	padding: clamp(64px, 8vw, 112px) 0 clamp(72px, 10vw, 128px);
@@ -31,29 +32,41 @@
 
 .knowledge-home-badges span {
 	padding: 4px 9px;
-	border-radius: 6px;
-	background: color-mix(in srgb, var(--blue) 8%, var(--paper));
+	border: 1px solid var(--ink);
+	border-radius: 2px;
+	background: var(--blue-soft);
 	color: var(--blue);
 }
 
 .knowledge-home-badges span:last-child {
 	background: var(--accent-soft);
-	color: color-mix(in srgb, var(--ink) 78%, #6d5710);
+	color: var(--ink);
 }
 
 .knowledge-home-hero h1 {
 	max-width: 13ch;
 	margin: 0;
 	font-family: var(--serif);
-	font-size: clamp(2.25rem, 3.5vw, 3rem);
+	font-size: clamp(2.5rem, 4.2vw, 3.65rem);
 	font-weight: 400;
 	letter-spacing: -0.035em;
 	line-height: 1.12;
 }
 
 :lang(zh-CN) .knowledge-home-hero h1 {
-	font-weight: 700;
+	font-weight: 800;
 	letter-spacing: -0.04em;
+}
+
+.knowledge-home-hero h1::after {
+	display: block;
+	width: 92px;
+	height: 10px;
+	margin-top: 18px;
+	border: 1px solid var(--ink);
+	background: var(--accent);
+	content: '';
+	transform: rotate(-2deg);
 }
 
 .knowledge-home-lede {
@@ -71,11 +84,11 @@
 	gap: 10px;
 	max-width: 590px;
 	margin-top: 30px;
-	padding: 6px 6px 6px 15px;
-	border: 1px solid color-mix(in srgb, var(--blue) 18%, var(--rule));
-	border-radius: 12px;
+	padding: 0 0 0 15px;
+	border: 2px solid var(--ink);
+	border-radius: 4px;
 	background: var(--paper-raised);
-	box-shadow: 0 8px 24px color-mix(in srgb, var(--blue) 6%, transparent);
+	box-shadow: 6px 6px 0 var(--blue);
 }
 
 .knowledge-home-search i {
@@ -97,12 +110,13 @@
 }
 
 .knowledge-home-search button {
-	min-height: 42px;
+	min-height: 52px;
 	padding: 0 20px;
-	border: 1px solid var(--blue);
-	border-radius: 9px;
-	background: var(--blue);
-	color: #ffffff;
+	border: 0;
+	border-left: 2px solid var(--ink);
+	border-radius: 0;
+	background: var(--accent);
+	color: #171b23;
 	font-weight: 650;
 	cursor: pointer;
 	transition:
@@ -112,17 +126,17 @@
 }
 
 .knowledge-home-search button:hover {
-	border-color: var(--blue-strong);
-	background: var(--blue-strong);
-	transform: translateY(-1px);
+	background: var(--blue);
+	color: #ffffff;
+	transform: none;
 }
 
 .knowledge-map {
 	overflow: hidden;
-	border: 1px solid color-mix(in srgb, var(--blue) 12%, var(--rule));
-	border-radius: 18px;
+	border: 2px solid var(--ink);
+	border-radius: 6px;
 	background: var(--paper-raised);
-	box-shadow: 0 20px 50px color-mix(in srgb, #0b1220 14%, transparent);
+	box-shadow: 9px 9px 0 var(--accent);
 }
 
 .knowledge-map-chrome {
@@ -131,17 +145,18 @@
 	align-items: center;
 	min-height: 48px;
 	padding: 0 16px;
-	border-bottom: 1px solid var(--rule);
-	background: var(--paper-muted);
+	border-bottom: 2px solid var(--ink);
+	background: var(--blue);
 }
 
 .knowledge-map-chrome > span:last-child {
 	grid-column: 2;
 	justify-self: center;
 	padding: 4px 14px;
-	border-radius: 6px;
-	background: color-mix(in srgb, var(--ink) 5%, transparent);
-	color: var(--ink-faint);
+	border: 1px solid color-mix(in srgb, #ffffff 60%, transparent);
+	border-radius: 2px;
+	background: color-mix(in srgb, #ffffff 12%, transparent);
+	color: #ffffff;
 	font-size: 0.7rem;
 }
 
@@ -154,7 +169,8 @@
 	display: block;
 	width: 10px;
 	height: 10px;
-	border-radius: 50%;
+	border: 1px solid #171b23;
+	border-radius: 1px;
 	background: #fb7185;
 }
 
@@ -183,9 +199,10 @@
 	display: inline-grid;
 	width: 40px;
 	height: 40px;
-	border-radius: 9px;
-	background: color-mix(in srgb, var(--blue) 10%, var(--paper));
-	color: var(--blue);
+	border: 1px solid var(--ink);
+	border-radius: 3px;
+	background: var(--accent);
+	color: #171b23;
 	place-items: center;
 }
 
@@ -207,8 +224,8 @@
 
 .knowledge-map-body header em {
 	padding: 4px 7px;
-	border: 1px dashed color-mix(in srgb, var(--blue) 28%, var(--rule));
-	border-radius: 5px;
+	border: 1px dashed var(--ink);
+	border-radius: 2px;
 	color: var(--blue);
 	font-family: var(--mono);
 	font-size: 0.6rem;
@@ -227,18 +244,19 @@
 	gap: 3px 10px;
 	min-width: 0;
 	padding: 14px;
-	border: 1px solid color-mix(in srgb, var(--blue) 11%, var(--rule));
-	border-radius: 10px;
+	border: 1px solid var(--ink);
+	border-radius: 3px;
 	background: color-mix(in srgb, var(--paper) 78%, var(--paper-muted));
 	text-decoration: none;
 	transition:
-		border-color 160ms ease,
+		box-shadow 160ms ease,
 		transform 160ms ease;
 }
 
 .knowledge-map-grid a:hover {
-	border-color: color-mix(in srgb, var(--blue) 36%, var(--rule));
-	transform: translateY(-2px);
+	box-shadow: 3px 3px 0 var(--blue);
+	color: inherit;
+	transform: translate(-2px, -2px);
 }
 
 .knowledge-map-grid i {
@@ -268,8 +286,8 @@
 	gap: 7px;
 	margin-top: 12px;
 	padding: 13px;
-	border: 1px dashed color-mix(in srgb, var(--blue) 16%, var(--rule));
-	border-radius: 10px;
+	border: 1px dashed var(--ink);
+	border-radius: 3px;
 }
 
 .knowledge-map-routes > span {
@@ -282,8 +300,9 @@
 
 .knowledge-map-routes a {
 	padding: 7px 9px;
-	border-radius: 6px;
-	background: color-mix(in srgb, var(--blue) 6%, var(--paper));
+	border: 1px solid var(--rule);
+	border-radius: 2px;
+	background: var(--paper-muted);
 	color: var(--blue);
 	font-family: var(--mono);
 	font-size: 0.64rem;
@@ -292,7 +311,7 @@
 
 .knowledge-home-section {
 	padding: clamp(64px, 8vw, 96px) 0;
-	border-top: 1px dashed color-mix(in srgb, var(--blue) 18%, var(--rule));
+	border-top: 2px solid var(--ink);
 }
 
 .knowledge-home-section-heading {
@@ -307,10 +326,10 @@
 	width: fit-content;
 	margin: 0 0 12px;
 	padding: 4px 9px;
-	border: 1px dashed color-mix(in srgb, var(--blue) 24%, var(--rule));
-	border-radius: 6px;
-	background: color-mix(in srgb, var(--blue) 6%, transparent);
-	color: var(--blue);
+	border: 1px solid var(--ink);
+	border-radius: 2px;
+	background: var(--accent);
+	color: #171b23;
 }
 
 .knowledge-home-section-heading h2 {
@@ -338,12 +357,22 @@
 .knowledge-home-section-heading > a {
 	flex: 0 0 auto;
 	padding: 9px 14px;
-	border: 1px solid color-mix(in srgb, var(--blue) 18%, var(--rule));
-	border-radius: 9px;
+	border: 1px solid var(--ink);
+	border-radius: 3px;
 	background: var(--paper-raised);
+	box-shadow: 3px 3px 0 var(--blue);
 	color: var(--blue);
 	font-size: 0.78rem;
 	text-decoration: none;
+	transition:
+		box-shadow 140ms ease,
+		transform 140ms ease;
+}
+
+.knowledge-home-section-heading > a:hover {
+	box-shadow: 5px 5px 0 var(--blue);
+	color: var(--ink);
+	transform: translate(-2px, -2px);
 }
 
 .knowledge-collection-grid {
@@ -356,10 +385,10 @@
 	position: relative;
 	min-height: 238px;
 	padding: 22px;
-	border: 1px solid color-mix(in srgb, var(--blue) 12%, var(--rule));
-	border-radius: 14px;
+	border: 2px solid var(--ink);
+	border-radius: 4px;
 	background: var(--paper-raised);
-	box-shadow: 0 8px 24px color-mix(in srgb, var(--blue) 4%, transparent);
+	box-shadow: 5px 5px 0 var(--hard-shadow);
 	text-decoration: none;
 	transition:
 		transform 180ms ease,
@@ -368,10 +397,18 @@
 }
 
 .knowledge-collection-card:hover {
-	border-color: color-mix(in srgb, var(--blue) 32%, var(--rule));
-	box-shadow: 0 14px 32px color-mix(in srgb, var(--blue) 9%, transparent);
+	border-color: var(--ink);
+	box-shadow: 8px 8px 0 var(--blue);
 	color: inherit;
-	transform: translateY(-4px);
+	transform: translate(-3px, -3px);
+}
+
+.knowledge-collection-card:nth-child(3n + 2) {
+	background: var(--accent-soft);
+}
+
+.knowledge-collection-card:nth-child(3n + 3) {
+	background: var(--blue-soft);
 }
 
 .knowledge-collection-icon {
@@ -382,7 +419,9 @@
 	position: absolute;
 	top: 26px;
 	right: 22px;
-	color: var(--blue);
+	padding: 3px 6px;
+	background: var(--ink);
+	color: var(--paper-raised);
 }
 
 .knowledge-collection-card h3 {
@@ -406,8 +445,8 @@
 
 .knowledge-recent-list {
 	display: grid;
-	grid-template-columns: repeat(3, minmax(0, 1fr));
-	gap: 20px;
+	grid-template-columns: repeat(2, minmax(0, 1fr));
+	gap: 0 36px;
 }
 
 .knowledge-recent-list article {
@@ -415,11 +454,12 @@
 	grid-template-columns: 1fr;
 	align-content: start;
 	gap: 0;
-	min-height: 236px;
-	padding: 22px;
-	border: 1px solid color-mix(in srgb, var(--blue) 12%, var(--rule));
-	border-radius: 14px;
-	background: var(--paper-raised);
+	min-height: 210px;
+	padding: 24px 0;
+	border: 0;
+	border-top: 2px solid var(--ink);
+	border-radius: 0;
+	background: transparent;
 	transition:
 		transform 180ms ease,
 		border-color 180ms ease,
@@ -427,9 +467,9 @@
 }
 
 .knowledge-recent-list article:hover {
-	border-color: color-mix(in srgb, var(--blue) 30%, var(--rule));
-	box-shadow: 0 14px 32px color-mix(in srgb, var(--blue) 8%, transparent);
-	transform: translateY(-3px);
+	border-color: var(--ink);
+	box-shadow: none;
+	transform: translateX(4px);
 }
 
 .knowledge-recent-index {
@@ -437,9 +477,11 @@
 	width: 38px;
 	height: 38px;
 	margin-bottom: 28px;
-	border-radius: 9px;
-	background: color-mix(in srgb, var(--blue) 10%, var(--paper));
-	color: var(--blue);
+	border: 1px solid var(--ink);
+	border-radius: 2px;
+	background: var(--blue);
+	box-shadow: 3px 3px 0 var(--accent);
+	color: #ffffff;
 	font-family: var(--mono);
 	font-size: 0.7rem;
 	place-items: center;
@@ -531,6 +573,12 @@
 	.knowledge-collection-grid,
 	.knowledge-recent-list {
 		grid-template-columns: 1fr;
+	}
+
+	.knowledge-home-search,
+	.knowledge-map,
+	.knowledge-collection-card {
+		box-shadow: 4px 4px 0 var(--blue);
 	}
 
 	.knowledge-map-routes > span {

--- a/astro/src/styles/ricoui-theme.css
+++ b/astro/src/styles/ricoui-theme.css
@@ -15,27 +15,27 @@
 }
 
 /*
- * Bubble's Brain × Ricoui Retro Blue
+ * Bubble's Brain × editorial neo-brutalism
  *
- * The visual language follows the MIT-licensed Ricoui Astro Starter while
- * retaining this project's existing routes, components, and accessibility
- * behavior.
+ * A restrained hybrid: hard edges and offset shadows establish the brand,
+ * while article and directory surfaces stay quiet enough for long reading.
  */
 
 :root {
-	--paper: #fdfaf5;
-	--paper-raised: #ffffff;
-	--paper-muted: #f3f6fb;
-	--ink: #3f4a5a;
-	--ink-soft: #5e6877;
-	--ink-faint: #7a8190;
-	--rule: #dfe4ed;
-	--blue: #2d6dc3;
-	--blue-strong: #0066ff;
-	--blue-soft: #eaf2fc;
-	--accent: #fad13b;
-	--accent-soft: #fff6cf;
-	--focus: #0066ff;
+	--paper: #fbf7ef;
+	--paper-raised: #fffdfa;
+	--paper-muted: #edf1f8;
+	--ink: #171b23;
+	--ink-soft: #414a59;
+	--ink-faint: #697180;
+	--rule: #aeb7c5;
+	--blue: #1f62d3;
+	--blue-strong: #004fc4;
+	--blue-soft: #dfeaff;
+	--accent: #ffd83d;
+	--accent-soft: #fff0a8;
+	--focus: #005de0;
+	--hard-shadow: #171b23;
 	--sans:
 		Inter, 'PingFang SC', 'Hiragino Sans GB', 'Microsoft YaHei', ui-sans-serif, system-ui,
 		sans-serif;
@@ -50,25 +50,31 @@
 }
 
 :root[data-theme='dark'] {
-	--paper: #0b1220;
-	--paper-raised: #0f1b2d;
-	--paper-muted: #142238;
-	--ink: #c5cedb;
-	--ink-soft: #aeb9c8;
-	--ink-faint: #8fa1ba;
-	--rule: #2b3b52;
-	--blue: #3884eb;
-	--blue-strong: #8fb9ff;
-	--blue-soft: #172b47;
+	--paper: #11151d;
+	--paper-raised: #171c25;
+	--paper-muted: #202a3a;
+	--ink: #f3efe6;
+	--ink-soft: #c8ced8;
+	--ink-faint: #9ca8ba;
+	--rule: #65718a;
+	--blue: #70a4ff;
+	--blue-strong: #a8c7ff;
+	--blue-soft: #253755;
 	--accent: #fad13b;
-	--accent-soft: #3a3318;
+	--accent-soft: #4b421c;
 	--focus: #8fb9ff;
+	--hard-shadow: #05070a;
 }
 
 body {
 	background: var(--paper);
 	color: var(--ink);
 	font-family: var(--sans);
+}
+
+::selection {
+	background: var(--accent);
+	color: #171b23;
 }
 
 h1,
@@ -93,11 +99,10 @@ h3 {
 	height: auto;
 	margin: 16px auto 0;
 	padding: 8px 10px;
-	border: 1px solid color-mix(in srgb, var(--blue) 14%, var(--rule));
-	border-radius: 18px;
-	background: color-mix(in srgb, var(--paper-raised) 92%, transparent);
-	box-shadow: 0 12px 34px color-mix(in srgb, var(--blue) 8%, transparent);
-	backdrop-filter: blur(18px);
+	border: 2px solid var(--ink);
+	border-radius: 8px;
+	background: var(--paper-raised);
+	box-shadow: 5px 5px 0 var(--blue);
 }
 
 .rail-topline {
@@ -121,11 +126,12 @@ h3 {
 	width: 40px;
 	height: 40px;
 	flex: 0 0 40px;
-	border-radius: 50%;
+	border: 1px solid var(--ink);
+	border-radius: 5px;
 	background: var(--blue);
 	color: #ffffff;
 	place-items: center;
-	box-shadow: 0 4px 10px color-mix(in srgb, var(--blue) 24%, transparent);
+	box-shadow: 2px 2px 0 var(--accent);
 	text-decoration: none;
 }
 
@@ -162,7 +168,8 @@ h3 {
 
 .rail-nav a {
 	padding: 10px 11px;
-	border-radius: 9px;
+	border: 1px solid transparent;
+	border-radius: 3px;
 	color: var(--ink);
 	font-size: 0.78rem;
 	font-weight: 550;
@@ -174,8 +181,9 @@ h3 {
 
 .rail-nav a:hover,
 .rail-nav a[aria-current='page'] {
-	background: color-mix(in srgb, var(--blue) 7%, transparent);
-	color: var(--blue);
+	border-color: var(--ink);
+	background: var(--accent);
+	color: #171b23;
 }
 
 .rail-nav a[aria-current='page']::before {
@@ -198,18 +206,23 @@ h3 {
 	width: auto;
 	min-height: 38px;
 	padding: 0 12px;
-	border: 1px solid color-mix(in srgb, var(--blue) 16%, var(--rule));
-	border-radius: 999px;
+	border: 1px solid var(--ink);
+	border-radius: 3px;
 	background: var(--paper-raised);
 	color: var(--ink);
 	font-size: 0.72rem;
+	transition:
+		box-shadow 140ms ease,
+		transform 140ms ease;
 }
 
 .rail-controls > a:hover,
 .rail-controls > button:hover,
 .rail-controls .auth-trigger:hover {
-	border-color: color-mix(in srgb, var(--blue) 36%, var(--rule));
-	color: var(--blue);
+	border-color: var(--ink);
+	box-shadow: 2px 2px 0 var(--accent);
+	color: var(--ink);
+	transform: translate(-1px, -1px);
 }
 
 .rail-controls .auth-panel {
@@ -217,8 +230,9 @@ h3 {
 	right: 0;
 	bottom: auto;
 	left: auto;
-	border-radius: 12px;
-	box-shadow: 0 18px 40px color-mix(in srgb, #0b1220 16%, transparent);
+	border: 2px solid var(--ink);
+	border-radius: 4px;
+	box-shadow: 5px 5px 0 var(--blue);
 }
 
 .site-canvas {
@@ -235,10 +249,10 @@ h3 {
 	display: inline-flex;
 	width: fit-content;
 	padding: 4px 9px;
-	border: 1px dashed color-mix(in srgb, var(--blue) 26%, var(--rule));
-	border-radius: 6px;
-	background: color-mix(in srgb, var(--blue) 6%, transparent);
-	color: var(--blue);
+	border: 1px solid var(--ink);
+	border-radius: 2px;
+	background: var(--accent);
+	color: #171b23;
 }
 
 .directory-hero {
@@ -251,10 +265,10 @@ h3 {
 }
 
 .content-directory article {
-	border: 1px solid color-mix(in srgb, var(--blue) 12%, var(--rule));
-	border-radius: 14px;
+	border: 1px solid var(--ink);
+	border-radius: 4px;
 	background: var(--paper-raised);
-	box-shadow: 0 8px 24px color-mix(in srgb, var(--blue) 4%, transparent);
+	box-shadow: 4px 4px 0 var(--rule);
 	transition:
 		transform 180ms ease,
 		border-color 180ms ease,
@@ -262,9 +276,9 @@ h3 {
 }
 
 .content-directory article:hover {
-	border-color: color-mix(in srgb, var(--blue) 28%, var(--rule));
-	box-shadow: 0 14px 32px color-mix(in srgb, var(--blue) 9%, transparent);
-	transform: translateY(-3px);
+	border-color: var(--ink);
+	box-shadow: 6px 6px 0 var(--blue);
+	transform: translate(-2px, -2px);
 }
 
 .content-directory:is(
@@ -305,7 +319,7 @@ h3 {
 	width: min(calc(100% - 48px), 1200px);
 	margin: 72px auto 0;
 	padding: 48px 0 28px;
-	border-top: 1px dashed color-mix(in srgb, var(--blue) 20%, var(--rule));
+	border-top: 2px solid var(--ink);
 }
 
 .site-footer-intro {
@@ -351,7 +365,7 @@ h3 {
 	justify-content: space-between;
 	gap: 20px;
 	padding-top: 24px;
-	border-top: 1px dashed color-mix(in srgb, var(--blue) 12%, var(--rule));
+	border-top: 1px solid var(--rule);
 	color: var(--ink-faint);
 	font-size: 0.72rem;
 }
@@ -403,8 +417,8 @@ h3 {
 		width: 40px;
 		height: 40px;
 		min-height: 40px;
-		border: 1px solid color-mix(in srgb, var(--blue) 14%, var(--rule));
-		border-radius: 50%;
+		border: 1px solid var(--ink);
+		border-radius: 3px;
 		background: var(--paper-raised);
 	}
 
@@ -413,8 +427,8 @@ h3 {
 		width: 40px;
 		height: 40px;
 		margin-left: 4px;
-		border: 1px solid color-mix(in srgb, var(--blue) 14%, var(--rule));
-		border-radius: 50%;
+		border: 1px solid var(--ink);
+		border-radius: 3px;
 		background: var(--paper-raised);
 		place-items: center;
 	}
@@ -428,11 +442,10 @@ h3 {
 		max-height: calc(100dvh - 96px);
 		overflow-y: auto;
 		padding: 14px;
-		border: 1px dashed color-mix(in srgb, var(--blue) 24%, var(--rule));
-		border-radius: 16px;
-		background: color-mix(in srgb, var(--paper-raised) 96%, transparent);
-		box-shadow: 0 18px 46px color-mix(in srgb, #0b1220 18%, transparent);
-		backdrop-filter: blur(18px);
+		border: 2px solid var(--ink);
+		border-radius: 4px;
+		background: var(--paper-raised);
+		box-shadow: 5px 5px 0 var(--blue);
 	}
 
 	.rail-menu.is-open {


### PR DESCRIPTION
## What changed

- introduce a restrained editorial neo-brutalist visual system with warm paper, stronger ink, blue, and yellow tokens
- give navigation, search, knowledge-map, and collection entry points hard borders and offset shadows
- turn recent additions into a quieter editorial two-column list
- preserve long-form reading width, proportional article media, dark mode, bilingual pages, and mobile behavior

## Why

The existing theme is readable but visually close to common rounded SaaS patterns. This hybrid keeps the knowledge base calm for long reading while giving the public entry points a clearer and more memorable identity.

## Validation

- desktop light and dark themes inspected in a real browser
- Chinese and English homepages inspected
- mobile homepage inspected at 390 x 844
- long-form Highlight article and proportional images inspected
- Prettier passed for all changed files
- Astro check: 0 errors, warnings, or hints
- Astro lint passed
- Astro tests: 26/26 passed
- root tests: 52 files, 790 tests passed
- Astro build and CSP verification passed
- site verification: 532 routes and 15 XML endpoints