### PR TITLE
fix: remove homepage hero loading flash

### DIFF
--- a/astro/src/components/KnowledgeIndexHome.astro
+++ b/astro/src/components/KnowledgeIndexHome.astro
@@ -81,9 +81,7 @@ const labelFor = (section: LegacySection) =>
 
 <section class="knowledge-home">
 	<header class="knowledge-home-hero">
-		<div class="knowledge-home-hero-letter" data-hero-letter-3d aria-hidden="true">
-			<span class="knowledge-home-hero-letter-fallback">B</span>
-		</div>
+		<div class="knowledge-home-hero-letter" data-hero-letter-3d aria-hidden="true"></div>
 		<div class="knowledge-home-hero-wash" aria-hidden="true"></div>
 
 		<div class="knowledge-home-hero-inner">
@@ -100,13 +98,6 @@ const labelFor = (section: LegacySection) =>
 				</div>
 
 				<div class="knowledge-home-hero-title-row">
-					<p class="knowledge-home-hero-description">
-						{
-							isEnglish
-								? 'CURATED SOURCES, PRACTICAL GUIDES, AND FIELD NOTES—ORGANIZED FOR RETRIEVAL.'
-								: '精选教程、一手资料与实践笔记，整理成可检索、可长期复用的 AI 知识。'
-						}
-					</p>
 					<h1 aria-label="Bubble's Knowledege">
 						<span><b>BUBBLE'S</b></span>
 						<span><b>KNOWLEDEGE</b></span>

--- a/astro/src/styles/knowledge-home.css
+++ b/astro/src/styles/knowledge-home.css
@@ -632,7 +632,7 @@
 }
 
 .knowledge-home-hero-letter {
-	left: clamp(-48px, -2vw, -16px);
+	left: clamp(42px, 5vw, 76px);
 	right: auto;
 	width: min(55vw, 790px);
 	filter: drop-shadow(0 22px 40px rgb(51 47 43 / 0.08));
@@ -646,28 +646,11 @@
 	width: 100%;
 	height: 100%;
 	opacity: 0;
-	transition: opacity 500ms ease;
+	transition: opacity 180ms ease-out;
 }
 
 .knowledge-home-hero-letter.is-ready canvas {
 	opacity: 1;
-}
-
-.knowledge-home-hero-letter-fallback {
-	position: absolute;
-	top: 50%;
-	left: 50%;
-	color: #dedad4;
-	font-family: Inter, var(--sans);
-	font-size: min(86vh, 54vw);
-	font-weight: 760;
-	line-height: 0.8;
-	transform: translate(-50%, -50%);
-	transition: opacity 300ms ease;
-}
-
-.knowledge-home-hero-letter.is-ready .knowledge-home-hero-letter-fallback {
-	opacity: 0;
 }
 
 .knowledge-home-hero-wash {
@@ -708,7 +691,7 @@
 }
 
 .knowledge-home-hero-top p,
-.knowledge-home-hero-description {
+.knowledge-home-hero-top p {
 	margin: 0;
 	font-size: clamp(0.58rem, 0.8vw, 0.78rem);
 	font-weight: 650;
@@ -743,12 +726,7 @@
 
 .knowledge-home-hero-title-row {
 	align-items: end;
-}
-
-.knowledge-home-hero-description {
-	width: clamp(150px, 22vw, 280px);
-	flex: 0 0 auto;
-	animation: hero-fade-up 650ms 780ms cubic-bezier(0.22, 1, 0.36, 1) both;
+	justify-content: flex-end;
 }
 
 .knowledge-home-hero h1 {
@@ -867,12 +845,6 @@
 		gap: 14px;
 	}
 
-	.knowledge-home-hero-description {
-		width: min(100%, 40ch);
-		font-size: 0.5rem;
-		letter-spacing: 0.1em;
-	}
-
 	.knowledge-home-hero h1 {
 		width: 100%;
 		font-size: clamp(2.15rem, 11.7vw, 3rem);
@@ -880,7 +852,7 @@
 	}
 
 	.knowledge-home-hero-letter {
-		left: -34vw;
+		left: -23vw;
 		width: 102vw;
 		height: 70%;
 		top: 13%;
@@ -894,7 +866,6 @@
 @media (prefers-reduced-motion: reduce) {
 	.knowledge-home-hero-top,
 	.knowledge-home-hero-action,
-	.knowledge-home-hero-description,
 	.knowledge-home-hero h1 b {
 		animation: none;
 	}


### PR DESCRIPTION
## What changed

- remove the static fallback B that flashed before Three.js initialized
- reveal the first rendered 3D canvas with a shorter fade
- move the 3D letter farther right on desktop and mobile
- remove the small lower-left hero description

## Why

The SSR fallback used a different glyph from the Three.js geometry, producing a visible shape swap during page load. Rendering no fallback eliminates the flash while retaining a brief first-frame fade.

## Validation

- root tests: 52 files / 790 tests
- Astro tests: 9 files / 28 tests
- Astro check: 0 errors / 0 warnings
- ESLint
- production build
- CSP verification
- site verification: 550 routes and 15 XML endpoints
- local desktop and mobile browser checks with no horizontal overflow or console errors
