### PR TITLE
style: refine homepage motion and supporting copy

### DIFF
--- a/astro/src/components/KnowledgeIndexHome.astro
+++ b/astro/src/components/KnowledgeIndexHome.astro
@@ -24,7 +24,6 @@ const sectionCopy: Array<{
 	section: LegacySection;
 	label: string;
 	description: string;
-	mark: string;
 	icon: string;
 }> = isEnglish
 	? [
@@ -32,7 +31,6 @@ const sectionCopy: Array<{
 				section: 'highlights',
 				label: 'Highlights',
 				description: 'Curated primary sources and durable explainers.',
-				mark: 'READ',
 				icon: 'ph-book-open-text',
 			},
 		]
@@ -41,21 +39,18 @@ const sectionCopy: Array<{
 				section: 'codex-tutorials',
 				label: 'Codex 教程',
 				description: '从入门到实战，系统掌握 Codex 的使用方法。',
-				mark: '上手',
 				icon: 'ph-terminal-window',
 			},
 			{
 				section: 'workbuddy-tutorials',
 				label: 'WorkBuddy 教程',
 				description: '从办公协作到自动化，系统掌握 WorkBuddy 的使用方法。',
-				mark: '办公',
 				icon: 'ph-briefcase',
 			},
 			{
 				section: 'highlights',
 				label: '精选阅读',
 				description: '值得长期保存的一手资料与深度解读。',
-				mark: '阅读',
 				icon: 'ph-book-open-text',
 			},
 		];
@@ -116,13 +111,6 @@ const labelFor = (section: LegacySection) =>
 			<div>
 				<p>{isEnglish ? 'EXPLORE THE LIBRARY' : '浏览知识库'}</p>
 				<h2 id={`library-heading-${locale}`}>{isEnglish ? 'Knowledge collections' : '知识栏目'}</h2>
-				<span
-					>{
-						isEnglish
-							? 'One focused collection, one searchable archive.'
-							: '三个清晰栏目，组成一个可检索的长期知识档案。'
-					}</span
-				>
 			</div>
 		</header>
 		<div class="knowledge-collection-grid">
@@ -132,7 +120,6 @@ const labelFor = (section: LegacySection) =>
 						<span class="knowledge-collection-icon">
 							<i class={`ph ${item.icon}`} aria-hidden="true" />
 						</span>
-						<span class="knowledge-collection-mark">{item.mark}</span>
 						<h3>{item.label}</h3>
 						<p>{item.description}</p>
 						<span class="knowledge-collection-count">

--- a/astro/src/layouts/BaseLayout.astro
+++ b/astro/src/layouts/BaseLayout.astro
@@ -156,7 +156,6 @@ const navLinks = isEnglish
 					</div>
 					<div class="site-footer-meta">
 						<span>© {new Date().getFullYear()} Bubble's Brain</span>
-						<span>{isEnglish ? 'Curated, not automated.' : '人工整理，不追逐信息流。'}</span>
 					</div>
 				</footer>
 			</div>

--- a/astro/src/scripts/heroLetter3d.ts
+++ b/astro/src/scripts/heroLetter3d.ts
@@ -99,6 +99,7 @@ export const mountHeroLetter3d = (host: HTMLElement) => {
 	let pointerX = 0;
 	let pointerY = 0;
 	let animationFrame = 0;
+	let isReady = false;
 	const clock = new THREE.Clock();
 
 	const onPointerMove = (event: PointerEvent) => {
@@ -129,6 +130,11 @@ export const mountHeroLetter3d = (host: HTMLElement) => {
 			letter.rotation.y = -0.34;
 		}
 		renderer.render(scene, camera);
+		if (!isReady) {
+			isReady = true;
+			host.classList.add('is-ready');
+			host.closest('.knowledge-home-hero')?.classList.add('is-3d-ready');
+		}
 		animationFrame = window.requestAnimationFrame(render);
 	};
 
@@ -137,7 +143,6 @@ export const mountHeroLetter3d = (host: HTMLElement) => {
 	window.addEventListener('pointermove', onPointerMove, { passive: true });
 	resize();
 	render();
-	host.classList.add('is-ready');
 
 	return () => {
 		window.cancelAnimationFrame(animationFrame);
@@ -148,6 +153,7 @@ export const mountHeroLetter3d = (host: HTMLElement) => {
 		sideMaterial.dispose();
 		renderer.dispose();
 		renderer.domElement.remove();
+		host.closest('.knowledge-home-hero')?.classList.remove('is-3d-ready');
 		host.dataset.mounted = 'false';
 	};
 };

--- a/astro/src/styles/knowledge-home.css
+++ b/astro/src/styles/knowledge-home.css
@@ -23,7 +23,6 @@
 .knowledge-home-badges span,
 .knowledge-home-section-heading > div > p,
 .knowledge-recent-meta,
-.knowledge-collection-mark,
 .knowledge-collection-count {
 	font-family: var(--mono);
 	font-size: 0.68rem;
@@ -426,15 +425,6 @@
 	font-size: 1.35rem;
 }
 
-.knowledge-collection-mark {
-	position: absolute;
-	top: 26px;
-	right: 22px;
-	padding: 0;
-	background: transparent;
-	color: var(--blue);
-}
-
 .knowledge-collection-card h3 {
 	margin: 0;
 	color: var(--ink);
@@ -753,19 +743,23 @@
 .knowledge-home-hero h1 b {
 	display: block;
 	font: inherit;
+	transform: translateY(110%);
+}
+
+.knowledge-home-hero.is-3d-ready h1 b {
 	animation: hero-title-reveal 760ms cubic-bezier(0.22, 1, 0.36, 1) both;
 }
 
-.knowledge-home-hero h1 span:nth-child(1) b {
-	animation-delay: 400ms;
+.knowledge-home-hero.is-3d-ready h1 span:nth-child(1) b {
+	animation-delay: 0ms;
 }
 
-.knowledge-home-hero h1 span:nth-child(2) b {
-	animation-delay: 540ms;
+.knowledge-home-hero.is-3d-ready h1 span:nth-child(2) b {
+	animation-delay: 90ms;
 }
 
-.knowledge-home-hero h1 span:nth-child(3) b {
-	animation-delay: 680ms;
+.knowledge-home-hero.is-3d-ready h1 span:nth-child(3) b {
+	animation-delay: 180ms;
 }
 
 .knowledge-home > .knowledge-home-section {
@@ -868,5 +862,13 @@
 	.knowledge-home-hero-action,
 	.knowledge-home-hero h1 b {
 		animation: none;
+	}
+
+	.knowledge-home-hero-letter canvas {
+		transition: none;
+	}
+
+	.knowledge-home-hero.is-3d-ready h1 b {
+		transform: none;
 	}
 }

--- a/astro/src/styles/ricoui-theme.css
+++ b/astro/src/styles/ricoui-theme.css
@@ -371,7 +371,7 @@ h3 {
 .site-footer-meta {
 	display: flex;
 	grid-column: 1 / -1;
-	justify-content: space-between;
+	justify-content: flex-start;
 	gap: 20px;
 	padding-top: 24px;
 	border-top: 1px solid var(--rule);


### PR DESCRIPTION
## Summary
- synchronize the 3D B reveal with the homepage title
- remove collection helper copy and card badges
- remove the footer curation tagline

## Validation
- root test suite: 790 tests
- Astro test suite: 28 tests
- Astro check, ESLint, production build, CSP, and site verification
- local browser verification with no console errors or horizontal overflow