### PR TITLE
fix: allow knowledge tutorial release paths

### DIFF
--- a/workers/content/deployer/index.test.ts
+++ b/workers/content/deployer/index.test.ts
@@ -905,6 +905,38 @@ describe("automatic code release boundary", () => {
     ).toHaveLength(11);
   });
 
+  it("accepts the Vibe Coding and Pi tutorial release paths", () => {
+    const releasePaths = [
+      "astro/src/data/vibeCodingPatternDetails.ts",
+      "astro/src/data/vibeCodingTermDetails.ts",
+      "astro/src/data/vibeCodingTerms.ts",
+      "content/pi-agent-tutorials/pi-agent-overview.md",
+      "static/js/knowledge-home-v2.js",
+      "static/js/vibe-coding-flow-lab.js",
+      "static/js/vibe-coding-pattern-detail.js",
+      "static/js/vibe-coding-terms.js",
+      "static/images/brain-cat.jpg",
+      "static/images/cat-pose-1.jpg",
+      "static/images/cat-pose-2.jpg",
+      "static/images/cat-pose-3.jpg",
+      "static/images/cat-pose-4.jpg",
+      "static/images/cat-pose-5.jpg",
+    ];
+
+    expect(
+      validateCodeReleaseChangeSet(
+        comparison(
+          releasePaths.map((filename) => ({ filename, status: "added" })),
+        ),
+        {
+          baseCodeSha,
+          targetCodeSha,
+          structuredCutoverDate: "2026-07-16",
+        },
+      ),
+    ).toHaveLength(releasePaths.length);
+  });
+
   it.each([
     "assets/daily.json",
     "data/daily/.gitkeep",

--- a/workers/content/deployer/index.ts
+++ b/workers/content/deployer/index.ts
@@ -415,12 +415,16 @@ function classifyCodeReleasePath(
       "content/codex-tutorials/",
       "content/deepseek-harness-tutorials/",
       "content/highlights/",
+      "content/pi-agent-tutorials/",
       "content/workbuddy-tutorials/",
       "static/fonts/",
       "static/media/",
     ].some((prefix) => path.startsWith(prefix)) ||
     [
       "astro/src/content.config.ts",
+      "astro/src/data/vibeCodingPatternDetails.ts",
+      "astro/src/data/vibeCodingTermDetails.ts",
+      "astro/src/data/vibeCodingTerms.ts",
       "astro/public/favicon.ico",
       "astro/public/favicon.svg",
       "astro/astro.config.mjs",
@@ -435,9 +439,19 @@ function classifyCodeReleasePath(
       "static/css/daily-timeline.css",
       "static/js/ai-infographic.js",
       "static/js/daily-timeline.js",
+      "static/js/knowledge-home-v2.js",
       "static/js/knowledge-search.js",
       "static/js/navigation.js",
       "static/js/site-shell.js",
+      "static/js/vibe-coding-flow-lab.js",
+      "static/js/vibe-coding-pattern-detail.js",
+      "static/js/vibe-coding-terms.js",
+      "static/images/brain-cat.jpg",
+      "static/images/cat-pose-1.jpg",
+      "static/images/cat-pose-2.jpg",
+      "static/images/cat-pose-3.jpg",
+      "static/images/cat-pose-4.jpg",
+      "static/images/cat-pose-5.jpg",
     ].includes(path)
   ) {
     return "publishable";


### PR DESCRIPTION
## Summary

- allow the exact new Vibe Coding data modules and client scripts
- allow the Pi Agent tutorial content collection
- allow the six homepage image assets required by the knowledge UI
- keep all other unknown paths fail-closed

## Validation

- `npx vitest run workers/content/deployer/index.test.ts` (50 tests)
- `git diff --check`