### PR TITLE
feat: summarize oversized term categories as chip previews

### DIFF
--- a/astro/src/components/VibeCodingTerms.astro
+++ b/astro/src/components/VibeCodingTerms.astro
@@ -1,6 +1,20 @@
 ---
-import { vibeCodingTermCategories, type VibeCodingTerm } from '../data/vibeCodingTerms';
+import {
+	vibeCodingTermCategories,
+	type VibeCodingTerm,
+	type VibeCodingTermCategory,
+} from '../data/vibeCodingTerms';
 import '../styles/vibe-coding-terms.css';
+
+/**
+ * 超过该数量的分类在索引页只展示紧凑预览，
+ * 完整列表由分类详情页（/vibe-coding/terms/{categoryId}/）承接。
+ */
+const PREVIEW_TERM_LIMIT = 12;
+
+function isOversized(category: VibeCodingTermCategory): boolean {
+	return category.terms.length > PREVIEW_TERM_LIMIT;
+}
 
 function groupTerms(terms: VibeCodingTerm[]): { name: string | null; terms: VibeCodingTerm[] }[] {
 	const groups: { name: string | null; terms: VibeCodingTerm[] }[] = [];
@@ -37,41 +51,68 @@ function groupTerms(terms: VibeCodingTerm[]): { name: string | null; terms: Vibe
 
 	<div class="vibe-term-categories">
 		{
-			vibeCodingTermCategories.map((category, categoryIndex) => (
-				<section class="vibe-term-category" id={category.id}>
-					<header class="vibe-category-header">
-						<span class="vibe-category-index" aria-hidden="true">
-							{String(categoryIndex + 1).padStart(2, '0')}
-						</span>
-						<h2>{category.label}</h2>
-						<p>{category.description}</p>
-						<a href={`/vibe-coding/terms/${category.id}/`}>
-							查看图解
-							<i class="ph ph-arrow-up-right" aria-hidden="true" />
-						</a>
-					</header>
+			vibeCodingTermCategories.map((category, categoryIndex) => {
+				const oversized = isOversized(category);
+				return (
+					<section class="vibe-term-category" id={category.id}>
+						<header class="vibe-category-header">
+							<span class="vibe-category-index" aria-hidden="true">
+								{String(categoryIndex + 1).padStart(2, '0')}
+							</span>
+							<h2>{category.label}</h2>
+							<p>{category.description}</p>
+							<a href={`/vibe-coding/terms/${category.id}/`}>
+								{oversized ? `查看全部 ${category.terms.length} 个模式` : '查看图解'}
+								<i class="ph ph-arrow-up-right" aria-hidden="true" />
+							</a>
+						</header>
 
-					<div class="vibe-terms-groups">
-						{groupTerms(category.terms).map((group) => (
-							<div class="vibe-terms-group">
-								{group.name ? <h3 class="vibe-term-group-title">{group.name}</h3> : null}
-								<div class="vibe-terms-list">
-									{group.terms.map((term) => (
-										<a class="vibe-term" id={term.id} href={`/vibe-coding/terms/${term.id}/`}>
-											<h3>
-												{term.name}
-												<span>{term.chineseName}</span>
-												<i class="ph ph-arrow-up-right vibe-term-arrow" aria-hidden="true" />
-											</h3>
-											<p>{term.description}</p>
-										</a>
-									))}
+						<div class="vibe-terms-groups">
+							{groupTerms(category.terms).map((group) => (
+								<div class="vibe-terms-group">
+									{group.name ? (
+										<h3 class="vibe-term-group-title">{group.name}</h3>
+									) : null}
+									{oversized ? (
+										<div class="vibe-terms-chip-list">
+											{group.terms.map((term) => (
+												<a
+													class="vibe-term-chip"
+													id={term.id}
+													href={`/vibe-coding/terms/${term.id}/`}
+												>
+													<strong>{term.name}</strong>
+													<span>{term.chineseName}</span>
+												</a>
+											))}
+										</div>
+									) : (
+										<div class="vibe-terms-list">
+											{group.terms.map((term) => (
+												<a
+													class="vibe-term"
+													id={term.id}
+													href={`/vibe-coding/terms/${term.id}/`}
+												>
+													<h3>
+														{term.name}
+														<span>{term.chineseName}</span>
+														<i
+															class="ph ph-arrow-up-right vibe-term-arrow"
+															aria-hidden="true"
+														/>
+													</h3>
+													<p>{term.description}</p>
+												</a>
+											))}
+										</div>
+									)}
 								</div>
-							</div>
-						))}
-					</div>
-				</section>
-			))
+							))}
+						</div>
+					</section>
+				);
+			})
 		}
 	</div>
 </section>

--- a/astro/src/styles/vibe-coding-terms.css
+++ b/astro/src/styles/vibe-coding-terms.css
@@ -303,6 +303,52 @@
 	letter-spacing: 0.14em;
 }
 
+.vibe-terms-chip-list {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 10px;
+}
+
+.vibe-term-chip {
+	display: inline-flex;
+	align-items: baseline;
+	gap: 7px;
+	padding: 8px 14px;
+	border: 1px solid color-mix(in srgb, var(--ink) 12%, transparent);
+	border-radius: 999px;
+	scroll-margin-top: 96px;
+	text-decoration: none;
+	transition:
+		border-color 0.2s ease,
+		translate 0.2s ease;
+}
+
+.vibe-term-chip strong {
+	color: var(--ink);
+	font-family: var(--sans);
+	font-size: 0.82rem;
+	font-weight: 700;
+	letter-spacing: -0.01em;
+	transition: color 0.2s ease;
+}
+
+.vibe-term-chip span {
+	color: var(--ink-faint);
+	font-size: 0.68rem;
+	font-weight: 600;
+}
+
+.vibe-term-chip:hover,
+.vibe-term-chip:focus-visible {
+	border-color: var(--blue-strong);
+	translate: 0 -2px;
+}
+
+.vibe-term-chip:hover strong,
+.vibe-term-chip:focus-visible strong {
+	color: var(--blue-strong);
+}
+
 @media (prefers-reduced-motion: reduce) {
 	.vibe-term-category {
 		animation: none;


### PR DESCRIPTION
## Summary

- 术语索引页不再平铺全部 60 张描述卡片：超过 12 条的分类（当前即界面图鉴，20 条/5 组）自动切换为紧凑预览模式
- 预览模式保留分组标题，术语以「英文名+中文名」胶囊链接呈现，分类头部链接升级为「查看全部 N 个模式」
- 完整列表由已有的分类页（/vibe-coding/terms/ui-patterns/）承接，路由与搜索索引零变化；其他小分类维持原卡片布局

## Test plan

- [x] astro check / eslint / vitest（46 tests）通过
- [x] 构建产物核对：胶囊 20 个、描述卡片 40 个、查看图解 ×6、详情链接 67（60 术语 + 7 分类）
- [x] verify-csp 与 verify-site 通过（743 路由）