### PR TITLE
feat: expand design gallery with nine more brand systems

### DIFF
--- a/astro/src/data/design-md/coinbase.md
+++ b/astro/src/data/design-md/coinbase.md
@@ -1,0 +1,570 @@
+---
+version: alpha
+name: Coinbase-design-analysis
+description: An institutional-grade crypto exchange whose marketing surfaces read like a quietly-confident financial-services brand. The base canvas is pure white; Coinbase Blue (`#0052ff`) is the single brand voltage, used scarcely on primary CTAs, signature glyphs, and inline accent moments. Type runs Coinbase's licensed CoinbaseDisplay (display) and CoinbaseSans (body) at modest weights — display sits at weight 400 not 700, signaling editorial calm rather than fintech-bombastic. Page rhythm rotates between bright white sections, soft gray elevation bands, and full-bleed dark editorial heroes (`#0a0b0d`) carrying product-ui mockup cards. Iconography is geometric and minimal; depth comes from card-on-card layering, never decorative shadows.
+
+colors:
+  primary: "#0052ff"
+  primary-active: "#003ecc"
+  primary-disabled: "#a8b8cc"
+  ink: "#0a0b0d"
+  body: "#5b616e"
+  body-strong: "#0a0b0d"
+  muted: "#7c828a"
+  muted-soft: "#a8acb3"
+  hairline: "#dee1e6"
+  hairline-soft: "#eef0f3"
+  canvas: "#ffffff"
+  surface-soft: "#f7f7f7"
+  surface-card: "#ffffff"
+  surface-strong: "#eef0f3"
+  surface-dark: "#0a0b0d"
+  surface-dark-elevated: "#16181c"
+  on-primary: "#ffffff"
+  on-dark: "#ffffff"
+  on-dark-soft: "#a8acb3"
+  semantic-up: "#05b169"
+  semantic-down: "#cf202f"
+  accent-yellow: "#f4b000"
+
+typography:
+  display-mega:
+    fontFamily: "'Coinbase Display', -apple-system, system-ui, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
+    fontSize: 80px
+    fontWeight: 400
+    lineHeight: 1.0
+    letterSpacing: -2px
+  display-xl:
+    fontFamily: "'Coinbase Display', sans-serif"
+    fontSize: 64px
+    fontWeight: 400
+    lineHeight: 1.0
+    letterSpacing: -1.6px
+  display-lg:
+    fontFamily: "'Coinbase Display', sans-serif"
+    fontSize: 52px
+    fontWeight: 400
+    lineHeight: 1.0
+    letterSpacing: -1.3px
+  display-md:
+    fontFamily: "'Coinbase Display', sans-serif"
+    fontSize: 44px
+    fontWeight: 400
+    lineHeight: 1.09
+    letterSpacing: -1px
+  display-sm:
+    fontFamily: "'Coinbase Sans', sans-serif"
+    fontSize: 36px
+    fontWeight: 400
+    lineHeight: 1.11
+    letterSpacing: -0.5px
+  title-lg:
+    fontFamily: "'Coinbase Sans', sans-serif"
+    fontSize: 32px
+    fontWeight: 400
+    lineHeight: 1.13
+    letterSpacing: -0.4px
+  title-md:
+    fontFamily: "'Coinbase Sans', sans-serif"
+    fontSize: 18px
+    fontWeight: 600
+    lineHeight: 1.33
+    letterSpacing: 0
+  title-sm:
+    fontFamily: "'Coinbase Sans', sans-serif"
+    fontSize: 16px
+    fontWeight: 600
+    lineHeight: 1.25
+    letterSpacing: 0
+  body-md:
+    fontFamily: "'Coinbase Sans', sans-serif"
+    fontSize: 16px
+    fontWeight: 400
+    lineHeight: 1.5
+    letterSpacing: 0
+  body-strong:
+    fontFamily: "'Coinbase Sans', sans-serif"
+    fontSize: 16px
+    fontWeight: 700
+    lineHeight: 1.5
+    letterSpacing: 0
+  body-sm:
+    fontFamily: "'Coinbase Sans', sans-serif"
+    fontSize: 14px
+    fontWeight: 400
+    lineHeight: 1.5
+    letterSpacing: 0
+  caption:
+    fontFamily: "'Coinbase Sans', sans-serif"
+    fontSize: 13px
+    fontWeight: 400
+    lineHeight: 1.5
+    letterSpacing: 0
+  caption-strong:
+    fontFamily: "'Coinbase Sans', sans-serif"
+    fontSize: 12px
+    fontWeight: 600
+    lineHeight: 1.5
+    letterSpacing: 0
+  number-display:
+    fontFamily: "'Coinbase Mono', 'Coinbase Sans', monospace"
+    fontSize: 18px
+    fontWeight: 500
+    lineHeight: 1.4
+    letterSpacing: 0
+  button:
+    fontFamily: "'Coinbase Sans', sans-serif"
+    fontSize: 16px
+    fontWeight: 600
+    lineHeight: 1.15
+    letterSpacing: 0
+  nav-link:
+    fontFamily: "'Coinbase Sans', sans-serif"
+    fontSize: 14px
+    fontWeight: 500
+    lineHeight: 1.4
+    letterSpacing: 0
+
+rounded:
+  none: 0px
+  xs: 4px
+  sm: 8px
+  md: 12px
+  lg: 16px
+  xl: 24px
+  pill: 100px
+  full: 9999px
+
+spacing:
+  xxs: 4px
+  xs: 8px
+  sm: 12px
+  base: 16px
+  md: 20px
+  lg: 24px
+  xl: 32px
+  xxl: 48px
+  section: 96px
+
+components:
+  top-nav-light:
+    backgroundColor: "{colors.canvas}"
+    textColor: "{colors.ink}"
+    typography: "{typography.nav-link}"
+    height: 64px
+  top-nav-on-dark:
+    backgroundColor: "{colors.surface-dark}"
+    textColor: "{colors.on-dark}"
+    typography: "{typography.nav-link}"
+    height: 64px
+  button-primary:
+    backgroundColor: "{colors.primary}"
+    textColor: "{colors.on-primary}"
+    typography: "{typography.button}"
+    rounded: "{rounded.pill}"
+    padding: 12px 20px
+    height: 44px
+  button-primary-active:
+    backgroundColor: "{colors.primary-active}"
+    textColor: "{colors.on-primary}"
+    rounded: "{rounded.pill}"
+  button-primary-disabled:
+    backgroundColor: "{colors.primary-disabled}"
+    textColor: "{colors.on-primary}"
+    rounded: "{rounded.pill}"
+  button-secondary-light:
+    backgroundColor: "{colors.surface-strong}"
+    textColor: "{colors.ink}"
+    typography: "{typography.button}"
+    rounded: "{rounded.pill}"
+    padding: 12px 20px
+    height: 44px
+  button-secondary-dark:
+    backgroundColor: "{colors.surface-dark-elevated}"
+    textColor: "{colors.on-dark}"
+    typography: "{typography.button}"
+    rounded: "{rounded.pill}"
+    padding: 12px 20px
+    height: 44px
+  button-outline-on-dark:
+    backgroundColor: transparent
+    textColor: "{colors.on-dark}"
+    typography: "{typography.button}"
+    rounded: "{rounded.pill}"
+    padding: 11px 19px
+    height: 44px
+  button-tertiary-text:
+    backgroundColor: transparent
+    textColor: "{colors.primary}"
+    typography: "{typography.button}"
+  button-pill-cta:
+    backgroundColor: "{colors.primary}"
+    textColor: "{colors.on-primary}"
+    typography: "{typography.button}"
+    rounded: "{rounded.pill}"
+    padding: 16px 32px
+    height: 56px
+  hero-band-dark:
+    backgroundColor: "{colors.surface-dark}"
+    textColor: "{colors.on-dark}"
+    typography: "{typography.display-mega}"
+    padding: 96px
+  hero-band-light:
+    backgroundColor: "{colors.canvas}"
+    textColor: "{colors.ink}"
+    typography: "{typography.display-mega}"
+    padding: 96px
+  product-ui-card-dark:
+    backgroundColor: "{colors.surface-dark-elevated}"
+    textColor: "{colors.on-dark}"
+    rounded: "{rounded.xl}"
+    padding: 32px
+  product-ui-card-light:
+    backgroundColor: "{colors.canvas}"
+    textColor: "{colors.ink}"
+    rounded: "{rounded.xl}"
+    padding: 32px
+  feature-card:
+    backgroundColor: "{colors.canvas}"
+    textColor: "{colors.ink}"
+    typography: "{typography.title-md}"
+    rounded: "{rounded.xl}"
+    padding: 32px
+  asset-row:
+    backgroundColor: transparent
+    textColor: "{colors.ink}"
+    typography: "{typography.body-md}"
+    padding: 16px 0
+  price-up-cell:
+    backgroundColor: transparent
+    textColor: "{colors.semantic-up}"
+    typography: "{typography.number-display}"
+  price-down-cell:
+    backgroundColor: transparent
+    textColor: "{colors.semantic-down}"
+    typography: "{typography.number-display}"
+  pricing-tier-card:
+    backgroundColor: "{colors.canvas}"
+    textColor: "{colors.ink}"
+    typography: "{typography.body-md}"
+    rounded: "{rounded.xl}"
+    padding: 32px
+  pricing-tier-featured:
+    backgroundColor: "{colors.surface-dark}"
+    textColor: "{colors.on-dark}"
+    typography: "{typography.body-md}"
+    rounded: "{rounded.xl}"
+    padding: 32px
+  cta-band-dark:
+    backgroundColor: "{colors.surface-dark}"
+    textColor: "{colors.on-dark}"
+    typography: "{typography.display-lg}"
+    padding: 96px
+  text-input:
+    backgroundColor: "{colors.canvas}"
+    textColor: "{colors.ink}"
+    typography: "{typography.body-md}"
+    rounded: "{rounded.md}"
+    padding: 14px 16px
+    height: 48px
+  search-input-pill:
+    backgroundColor: "{colors.surface-strong}"
+    textColor: "{colors.ink}"
+    typography: "{typography.body-md}"
+    rounded: "{rounded.pill}"
+    padding: 12px 20px
+    height: 44px
+  badge-pill:
+    backgroundColor: "{colors.surface-strong}"
+    textColor: "{colors.ink}"
+    typography: "{typography.caption-strong}"
+    rounded: "{rounded.pill}"
+    padding: 4px 12px
+  asset-icon-circular:
+    backgroundColor: "{colors.surface-strong}"
+    rounded: "{rounded.full}"
+    size: 32px
+  footer-light:
+    backgroundColor: "{colors.canvas}"
+    textColor: "{colors.body}"
+    typography: "{typography.body-sm}"
+    padding: 64px 48px
+  footer-link:
+    backgroundColor: transparent
+    textColor: "{colors.body}"
+    typography: "{typography.body-sm}"
+  legal-band:
+    backgroundColor: "{colors.canvas}"
+    textColor: "{colors.muted}"
+    typography: "{typography.caption}"
+---
+
+## Overview
+
+Coinbase reads like an institutional financial brand that happens to trade crypto — the marketing surfaces are quiet, white-canvas, editorially-spaced, and almost monochromatic. The single brand voltage is **Coinbase Blue** (`{colors.primary}` — #0052ff), used scarcely: every primary CTA pill, the brand wordmark, and inline emphasis links. Beyond that one blue, the system is white canvas + ink + soft gray elevation bands + a deep near-black editorial canvas (`{colors.surface-dark}` — #0a0b0d) for full-bleed product-mockup heroes.
+
+Type pairs **CoinbaseDisplay** for hero headlines with **CoinbaseSans** for body, captions, and navigation. Display sits at **weight 400** — not the 700+ typical of trading platforms. The choice signals editorial calm and institutional trust rather than fintech urgency.
+
+The page rhythm rotates three modes: bright white editorial sections, soft-gray elevation bands, and **full-bleed dark editorial heroes** carrying layered product-UI mockup cards. The dark hero with floating dashboard mockups is the single most distinctive component.
+
+**Key Characteristics:**
+- Single accent color: `{colors.primary}` (#0052ff Coinbase Blue) carries every primary CTA, wordmark, and inline brand link. Used scarcely.
+- Modest display weights — CoinbaseDisplay at weight 400, never 700+.
+- Editorial pill geometry: every CTA is `{rounded.pill}` (100px), every asset glyph is `{rounded.full}`, every card is `{rounded.xl}` (24px). Sharp corners absent.
+- Full-bleed dark heroes with floating product-UI cards: `{component.hero-band-dark}` plus inline `{component.product-ui-card-dark}` mockups is the brand's strongest signature pattern.
+- Trading semantics: `{colors.semantic-up}` (#05b169) and `{colors.semantic-down}` (#cf202f) — text color only, never background fills.
+- 96px section rhythm — generous editorial pacing.
+
+## Colors
+
+### Brand & Accent
+- **Coinbase Blue** (`{colors.primary}` — #0052ff): The single brand color. Every primary CTA pill, the Coinbase wordmark, and inline brand links.
+- **Coinbase Blue Active** (`{colors.primary-active}` — #003ecc): Press-state darken on the primary pill.
+- **Coinbase Blue Disabled** (`{colors.primary-disabled}` — #a8b8cc): Faded-blue tint for disabled CTAs.
+- **Accent Yellow** (`{colors.accent-yellow}` — #f4b000): A small sub-brand accent used very sparingly on Bitcoin/asset glyph fills inside feature cards. Illustrative-only, not an action color.
+
+### Surface
+- **Canvas** (`{colors.canvas}` — #ffffff): The default page floor.
+- **Surface Soft** (`{colors.surface-soft}` — #f7f7f7): Subtle alternating band surface.
+- **Surface Strong** (`{colors.surface-strong}` — #eef0f3): The light-gray fill behind secondary buttons, search pills, asset-icon plates.
+- **Surface Dark** (`{colors.surface-dark}` — #0a0b0d): Deep near-black canvas for full-bleed dark heroes, CTA bands. Same hex as `{colors.ink}` — page-floor and text-color share the value.
+- **Surface Dark Elevated** (`{colors.surface-dark-elevated}` — #16181c): One step lighter, used for floating product-UI mockup cards inside dark heroes.
+
+### Hairlines
+- **Hairline** (`{colors.hairline}` — #dee1e6): Default 1px divider on white surfaces.
+- **Hairline Soft** (`{colors.hairline-soft}` — #eef0f3): Lighter divider — same hex as `{colors.surface-strong}`.
+
+### Text
+- **Ink** (`{colors.ink}` — #0a0b0d): Display headings, primary nav, body emphasis.
+- **Body** (`{colors.body}` — #5b616e): Default running-text — slightly cool gray.
+- **Body Strong** (`{colors.body-strong}` — #0a0b0d): Same as ink, used for stronger emphasis.
+- **Muted** (`{colors.muted}` — #7c828a): Sub-titles, breadcrumbs, footer secondary.
+- **Muted Soft** (`{colors.muted-soft}` — #a8acb3): Disabled link text.
+- **On Primary** (`{colors.on-primary}` — #ffffff): White text on Coinbase Blue CTAs.
+- **On Dark** (`{colors.on-dark}` — #ffffff): White text on dark heroes.
+- **On Dark Soft** (`{colors.on-dark-soft}` — #a8acb3): Muted off-white for secondary text on dark.
+
+### Trading Semantics
+- **Semantic Up** (`{colors.semantic-up}` — #05b169): "Price up" green, text color only.
+- **Semantic Down** (`{colors.semantic-down}` — #cf202f): "Price down" red, text color only.
+
+## Typography
+
+### Font Family
+The system runs **CoinbaseDisplay** (display headlines), **CoinbaseSans** (body, navigation, captions, buttons), **CoinbaseIcons** (icon font), and **CoinbaseMono** for tabular numerical data. Fallback stack: `-apple-system, system-ui, "Segoe UI", Roboto, Helvetica, Arial, sans-serif`.
+
+The display/body split is functional: CoinbaseDisplay carries hero headlines only; CoinbaseSans carries everything else.
+
+### Hierarchy
+
+| Token | Size | Weight | Line Height | Letter Spacing | Use |
+|---|---|---|---|---|---|
+| `{typography.display-mega}` | 80px | 400 | 1.0 | -2px | Homepage hero h1 |
+| `{typography.display-xl}` | 64px | 400 | 1.0 | -1.6px | Subsidiary heroes |
+| `{typography.display-lg}` | 52px | 400 | 1.0 | -1.3px | Section heads |
+| `{typography.display-md}` | 44px | 400 | 1.09 | -1px | CTA-band headlines |
+| `{typography.display-sm}` | 36px | 400 | 1.11 | -0.5px | Sub-section heads — CoinbaseSans |
+| `{typography.title-lg}` | 32px | 400 | 1.13 | -0.4px | Card group titles |
+| `{typography.title-md}` | 18px | 600 | 1.33 | 0 | Component titles, asset row primary |
+| `{typography.title-sm}` | 16px | 600 | 1.25 | 0 | List labels |
+| `{typography.body-md}` | 16px | 400 | 1.5 | 0 | Default body |
+| `{typography.body-strong}` | 16px | 700 | 1.5 | 0 | Emphasized body |
+| `{typography.body-sm}` | 14px | 400 | 1.5 | 0 | Footer body |
+| `{typography.caption}` | 13px | 400 | 1.5 | 0 | Photo captions |
+| `{typography.caption-strong}` | 12px | 600 | 1.5 | 0 | Badge pill labels |
+| `{typography.number-display}` | 18px | 500 | 1.4 | 0 | Asset prices, percent changes — CoinbaseMono |
+| `{typography.button}` | 16px | 600 | 1.15 | 0 | Standard CTA pill |
+| `{typography.nav-link}` | 14px | 500 | 1.4 | 0 | Top-nav menu items |
+
+### Principles
+- **Display weight stays at 400.** The single most distinctive typographic choice — signals "calm institutional brand" rather than "trading-platform urgency."
+- **Negative letter-spacing on display only.** Display uses -1px to -2px tracking; body stays at 0.
+- **CoinbaseMono on every number.** Asset prices, percent changes — anything tabular renders in CoinbaseMono.
+
+### Note on Font Substitutes
+CoinbaseDisplay, CoinbaseSans, and CoinbaseMono are licensed Coinbase typefaces.
+- **CoinbaseDisplay → Inter** at weight 400, letter-spacing -1.5%.
+- **CoinbaseSans → Inter** at weight 400/600.
+- **CoinbaseMono → JetBrains Mono** or **Geist Mono** at weight 500.
+
+## Layout
+
+### Spacing System
+- **Base unit:** 4px.
+- **Tokens:** `{spacing.xxs}` 4px · `{spacing.xs}` 8px · `{spacing.sm}` 12px · `{spacing.base}` 16px · `{spacing.md}` 20px · `{spacing.lg}` 24px · `{spacing.xl}` 32px · `{spacing.xxl}` 48px · `{spacing.section}` 96px.
+- **Section padding:** `{spacing.section}` (96px) for every major editorial band.
+- **Card internal padding:** `{spacing.xl}` (32px) for feature cards and product-UI mockups.
+
+### Grid & Container
+- **Max content width:** ~1200px centered. Hero photography full-bleed.
+- **Editorial body:** Single 12-column grid.
+- **Feature card grids:** 2-up at desktop for hero splits, 3-up for benefit grids.
+- **Footer:** 6-column link list at desktop.
+
+### Whitespace Philosophy
+Generous editorial pacing — closer to Bloomberg or the Financial Times than to a trading dashboard. 96px between bands; cards inside bands sit 24px apart. Density lives behind login walls, not on marketing.
+
+## Elevation & Depth
+
+| Level | Treatment | Use |
+|---|---|---|
+| Flat | No shadow, no border | 80% of surfaces |
+| Hairline border | 1px `{colors.hairline}` | Feature card outlines on white |
+| Soft drop | `0 4px 12px rgba(0, 0, 0, 0.04)` | Single shadow tier — hovered cards |
+| Photographic | Full-bleed product-UI mockups | Hero depth |
+
+### Decorative Depth
+- **Layered product-UI cards inside dark heroes** is the most distinctive decorative pattern — a `{component.product-ui-card-dark}` floats above a darker base canvas, often with a second smaller card overlapping at an angle.
+- **Geometric brand illustrations** carry illustrative depth where shadows would otherwise.
+
+## Shapes
+
+### Border Radius Scale
+
+| Token | Value | Use |
+|---|---|---|
+| `{rounded.none}` | 0px | Reserved (essentially unused) |
+| `{rounded.xs}` | 4px | Inline tags |
+| `{rounded.sm}` | 8px | Compact rows |
+| `{rounded.md}` | 12px | Form inputs |
+| `{rounded.lg}` | 16px | Mid-size cards |
+| `{rounded.xl}` | 24px | Feature cards, product-UI mockups, pricing tiers |
+| `{rounded.pill}` | 100px | All CTA buttons, search pills, badges |
+| `{rounded.full}` | 9999px | Asset icon circles, avatars |
+
+Pill for interactive, card-radius (24px) for containers, full circle for icons. Sharp corners absent.
+
+## Components
+
+### Top Navigation
+
+**`top-nav-light`** — Default top nav on white pages. Background `{colors.canvas}`, text `{colors.ink}`, height 64px. Layout: Coinbase wordmark left, primary horizontal menu (Cryptocurrencies / Individuals / Businesses / Institutions / Developers / Company), search-icon + globe + Sign In + Sign Up CTAs right.
+
+**`top-nav-on-dark`** — Top nav over a dark hero band. Background `{colors.surface-dark}`, text `{colors.on-dark}`. Same layout.
+
+### Buttons
+
+**`button-primary`** — The signature Coinbase Blue pill. Background `{colors.primary}`, text `{colors.on-primary}`, type `{typography.button}` (16px / 600), padding 12px × 20px, height 44px, rounded `{rounded.pill}` (100px).
+
+**`button-primary-active`** — Press state. Background `{colors.primary-active}`, deeper blue.
+
+**`button-primary-disabled`** — Faded blue tint. Background `{colors.primary-disabled}`. Cursor not-allowed.
+
+**`button-secondary-light`** — Soft-gray secondary on white surfaces. Background `{colors.surface-strong}`, text `{colors.ink}`, same pill geometry.
+
+**`button-secondary-dark`** — Used on dark heroes. Background `{colors.surface-dark-elevated}`, text `{colors.on-dark}`, same pill geometry.
+
+**`button-outline-on-dark`** — Transparent pill with white outline. Background transparent, text `{colors.on-dark}`, 1px white border.
+
+**`button-tertiary-text`** — Inline text link. Background transparent, text `{colors.primary}`, type `{typography.button}`.
+
+**`button-pill-cta`** — Larger pill CTA used on the homepage hero ("Get started"). Same Coinbase Blue palette but with 56px height and 16px × 32px padding for a prouder stance.
+
+### Hero Bands
+
+**`hero-band-dark`** — The signature full-bleed dark hero. Background `{colors.surface-dark}`, text `{colors.on-dark}`, full-bleed layered product-UI mockup cards. Display headline left in `{typography.display-mega}` (80px / 400), subhead in `{typography.body-md}`, two CTAs.
+
+**`hero-band-light`** — White-canvas variant used on Wealth and Explore. Background `{colors.canvas}`, text `{colors.ink}`. Same skeleton, light palette.
+
+### Cards
+
+**`product-ui-card-dark`** — The floating product-UI mockup. Background `{colors.surface-dark-elevated}`, text `{colors.on-dark}`, rounded `{rounded.xl}` (24px), padding 32px. Often shown as 2-3 stacked cards at slight rotation, mimicking a layered dashboard.
+
+**`product-ui-card-light`** — Light-canvas variant used on Explore for asset cards. Background `{colors.canvas}`, text `{colors.ink}`, same geometry, 1px hairline border.
+
+**`feature-card`** — Used in 3-up and 2-up grids. Background `{colors.canvas}`, text `{colors.ink}`, type `{typography.title-md}`, rounded `{rounded.xl}`, padding 32px.
+
+### Trading Surfaces
+
+**`asset-row`** — Horizontal row in asset lists (Explore, Wealth). Background transparent, 1px hairline divider. Layout: 32px circular asset icon left, asset name + ticker, price column in `{typography.number-display}`, 24h change column with `{component.price-up-cell}` or `{component.price-down-cell}`.
+
+**`price-up-cell`** + **`price-down-cell`** — Inline price-change cells. Color only — green or red text in `{typography.number-display}`, no background fill.
+
+**`asset-icon-circular`** — Circular plate behind asset glyphs. Background `{colors.surface-strong}`, rounded `{rounded.full}`, 32px diameter.
+
+### Pricing
+
+**`pricing-tier-card`** — Standard pricing tier on Developer Platform. Background `{colors.canvas}`, rounded `{rounded.xl}`, padding 32px, 1px hairline border. Layout: tier name + price + feature checklist + CTA pill.
+
+**`pricing-tier-featured`** — The featured tier. Background `{colors.surface-dark}`, text `{colors.on-dark}`. Same skeleton, dark palette — visual inversion signals "highlighted choice" without colored ribbons.
+
+### Forms
+
+**`text-input`** — Standard text input. Background `{colors.canvas}`, text `{colors.ink}`, rounded `{rounded.md}` (12px), padding 14px × 16px, height 48px, 1px hairline border. On focus, border thickens to 2px Coinbase Blue.
+
+**`search-input-pill`** — Pill-shaped search bar. Background `{colors.surface-strong}`, rounded `{rounded.pill}`, padding 12px × 20px, height 44px.
+
+### Tags & Badges
+
+**`badge-pill`** — Small uppercase pill used as section labels ("INSTITUTIONAL", "REGULATED"). Background `{colors.surface-strong}`, text `{colors.ink}`, type `{typography.caption-strong}`, rounded `{rounded.pill}`.
+
+### CTA / Footer
+
+**`cta-band-dark`** — Pre-footer "Take control of your money" band. Background `{colors.surface-dark}`, text `{colors.on-dark}`, vertical padding 96px. Centered headline + two CTAs.
+
+**`footer-light`** — Closing white-canvas footer. Background `{colors.canvas}`, text `{colors.body}`. 6-column link list.
+
+**`footer-link`** — Individual footer link. Background transparent, text `{colors.body}`.
+
+**`legal-band`** — Bottom strip beneath footer columns. All text `{colors.muted}` at `{typography.caption}`.
+
+## Do's and Don'ts
+
+### Do
+- Reserve `{colors.primary}` (Coinbase Blue) for primary CTAs, wordmark, brand-glyph illustrations, inline accent links.
+- Set every CTA as `{rounded.pill}` (100px); every asset glyph as `{rounded.full}`.
+- Keep CoinbaseDisplay headlines at weight 400.
+- Use the dark/light band rotation as page rhythm.
+- Render every numerical value in CoinbaseMono via `{typography.number-display}`.
+- Pair every dark hero with a layered product-UI mockup card stack.
+
+### Don't
+- Don't introduce a secondary brand color. Coinbase Blue is the only action color; trading green/red are semantic-only.
+- Don't bold display copy — display sits at weight 400; bolding shifts the brand voice.
+- Don't add drop shadow tiers — system has one shadow tier.
+- Don't use sharp `{rounded.none}` (0px) on CTAs.
+- Don't mix CoinbaseDisplay and CoinbaseSans inside the same headline.
+- Don't use trading green/red as a button background.
+- Don't extract a CTA color from a third-party widget (cookie consent, OneTrust). The brand's CTA color is what appears on actual product CTAs, not on injected modals.
+
+## Responsive Behavior
+
+### Breakpoints
+
+| Name | Width | Key Changes |
+|---|---|---|
+| Mobile | < 640px | Hero h1 80→40px; feature card grid 1-up; asset row stacks; nav collapses to hamburger; layered product-UI cards collapse to single card. |
+| Tablet | 640–1024px | Hero h1 64px; feature card grid 2-up; asset rows stay horizontal but compress columns. |
+| Desktop | 1024–1280px | Full hero h1 80px; feature card grid 3-up; full asset row layout. |
+| Wide | > 1280px | Content caps at 1200px; hero photography full-bleed. |
+
+### Touch Targets
+- Primary CTA pill at 44px height — at WCAG AAA.
+- Larger hero pill (`{component.button-pill-cta}`) at 56px — well above AAA.
+- Asset icon circles at 32px — borderline; padded 8px row creates effective 48px tap zone.
+- Search pill at 44px height — at AAA.
+
+### Collapsing Strategy
+- Top nav switches to hamburger sheet below 768px. Sign Up CTA stays visible.
+- Hero h1 steps down: 80 → 64 → 52 → 44 → 36px on smallest screens.
+- Layered product-UI mockup cards collapse from 2-3 stacked into a single card on mobile.
+- Pricing tier rows: 3-up → 2-up → 1-up.
+- Asset rows on mobile stack vertically: ticker line on top, price + change line beneath.
+
+## Iteration Guide
+
+1. Focus on a single component at a time. Reference YAML keys directly.
+2. New CTAs default to `{rounded.pill}` (100px); new icon plates default to `{rounded.full}`. Cards use `{rounded.xl}`.
+3. Variants live as separate entries inside the `components:` block.
+4. Use `{token.refs}` everywhere — never inline hex.
+5. Hover state never documented. Only Default and Active/Pressed.
+6. CoinbaseDisplay 400 for display, CoinbaseSans 400/600/700 for body. CoinbaseMono on every number.
+7. Coinbase Blue stays scarce — one or two blue moments per band.
+
+## Known Gaps
+
+- CoinbaseDisplay, CoinbaseSans, CoinbaseMono are licensed; Inter and JetBrains Mono are documented substitutes.
+- In-product trading surfaces (order book, charts, order forms) are behind login walls — this document covers marketing only.
+- Animation timings out of scope.
+- Form validation states beyond focus not visible on captured surfaces.
+- Accent yellow appears only inside Bitcoin asset glyph illustrations; documented as illustrative-only.

--- a/astro/src/data/design-md/cursor.md
+++ b/astro/src/data/design-md/cursor.md
@@ -1,0 +1,537 @@
+---
+version: alpha
+name: Cursor-design-analysis
+description: An AI-first code editor whose marketing site reads like a quietly-confident developer-tools brand with a warm-cream editorial canvas (`#f7f7f4`) instead of the typical dark IDE atmosphere. Near-black warm ink (`#26251e`) carries body and display alike — display sits at weight 400 with negative letter-spacing for a magazine feel rather than a bold tech voice. The single brand voltage is **Cursor Orange** (`#f54e00`) reserved for primary CTAs and the wordmark. A signature pastel timeline palette (peach, mint, blue, lavender, gold) marks AI-action stages (Thinking / Reading / Editing / Grepping / Done) — only inside in-product timeline visualizations. Cards use minimal hairlines, no shadows, generous 80px section rhythm. CursorGothic for display/body, JetBrains Mono on every code surface (which is roughly half the page).
+
+colors:
+  primary: "#f54e00"
+  primary-active: "#d04200"
+  ink: "#26251e"
+  body: "#5a5852"
+  body-strong: "#26251e"
+  muted: "#807d72"
+  muted-soft: "#a09c92"
+  hairline: "#e6e5e0"
+  hairline-soft: "#efeee8"
+  hairline-strong: "#cfcdc4"
+  canvas: "#f7f7f4"
+  canvas-soft: "#fafaf7"
+  surface-card: "#ffffff"
+  surface-strong: "#e6e5e0"
+  on-primary: "#ffffff"
+  timeline-thinking: "#dfa88f"
+  timeline-grep: "#9fc9a2"
+  timeline-read: "#9fbbe0"
+  timeline-edit: "#c0a8dd"
+  timeline-done: "#c08532"
+  semantic-error: "#cf2d56"
+  semantic-success: "#1f8a65"
+
+typography:
+  display-mega:
+    fontFamily: "'CursorGothic', system-ui, 'Helvetica Neue', Helvetica, Arial, sans-serif"
+    fontSize: 72px
+    fontWeight: 400
+    lineHeight: 1.1
+    letterSpacing: -2.16px
+  display-lg:
+    fontFamily: "'CursorGothic', sans-serif"
+    fontSize: 36px
+    fontWeight: 400
+    lineHeight: 1.2
+    letterSpacing: -0.72px
+  display-md:
+    fontFamily: "'CursorGothic', sans-serif"
+    fontSize: 26px
+    fontWeight: 400
+    lineHeight: 1.25
+    letterSpacing: -0.325px
+  display-sm:
+    fontFamily: "'CursorGothic', sans-serif"
+    fontSize: 22px
+    fontWeight: 400
+    lineHeight: 1.3
+    letterSpacing: -0.11px
+  title-md:
+    fontFamily: "'CursorGothic', sans-serif"
+    fontSize: 18px
+    fontWeight: 600
+    lineHeight: 1.4
+    letterSpacing: 0
+  title-sm:
+    fontFamily: "'CursorGothic', sans-serif"
+    fontSize: 16px
+    fontWeight: 600
+    lineHeight: 1.4
+    letterSpacing: 0
+  body-md:
+    fontFamily: "'CursorGothic', sans-serif"
+    fontSize: 16px
+    fontWeight: 400
+    lineHeight: 1.5
+    letterSpacing: 0
+  body-tracked:
+    fontFamily: "'CursorGothic', sans-serif"
+    fontSize: 16px
+    fontWeight: 400
+    lineHeight: 1.5
+    letterSpacing: 0.08px
+  body-sm:
+    fontFamily: "'CursorGothic', sans-serif"
+    fontSize: 14px
+    fontWeight: 400
+    lineHeight: 1.5
+    letterSpacing: 0
+  caption:
+    fontFamily: "'CursorGothic', sans-serif"
+    fontSize: 13px
+    fontWeight: 400
+    lineHeight: 1.4
+    letterSpacing: 0
+  caption-uppercase:
+    fontFamily: "'CursorGothic', sans-serif"
+    fontSize: 11px
+    fontWeight: 600
+    lineHeight: 1.4
+    letterSpacing: 0.88px
+    textTransform: uppercase
+  code:
+    fontFamily: "'JetBrains Mono', 'Fira Code', monospace"
+    fontSize: 13px
+    fontWeight: 400
+    lineHeight: 1.5
+    letterSpacing: 0
+  button:
+    fontFamily: "'CursorGothic', sans-serif"
+    fontSize: 14px
+    fontWeight: 500
+    lineHeight: 1.0
+    letterSpacing: 0
+  nav-link:
+    fontFamily: "'CursorGothic', sans-serif"
+    fontSize: 14px
+    fontWeight: 500
+    lineHeight: 1.4
+    letterSpacing: 0
+
+rounded:
+  none: 0px
+  xs: 4px
+  sm: 6px
+  md: 8px
+  lg: 12px
+  xl: 16px
+  pill: 9999px
+  full: 9999px
+
+spacing:
+  xxs: 4px
+  xs: 8px
+  sm: 12px
+  base: 16px
+  md: 20px
+  lg: 24px
+  xl: 32px
+  xxl: 48px
+  section: 80px
+
+components:
+  top-nav:
+    backgroundColor: "{colors.canvas}"
+    textColor: "{colors.ink}"
+    typography: "{typography.nav-link}"
+    height: 64px
+  button-primary:
+    backgroundColor: "{colors.primary}"
+    textColor: "{colors.on-primary}"
+    typography: "{typography.button}"
+    rounded: "{rounded.md}"
+    padding: 10px 18px
+    height: 40px
+  button-primary-active:
+    backgroundColor: "{colors.primary-active}"
+    textColor: "{colors.on-primary}"
+    rounded: "{rounded.md}"
+  button-secondary:
+    backgroundColor: "{colors.surface-card}"
+    textColor: "{colors.ink}"
+    typography: "{typography.button}"
+    rounded: "{rounded.md}"
+    padding: 9px 17px
+    height: 40px
+  button-tertiary-text:
+    backgroundColor: transparent
+    textColor: "{colors.ink}"
+    typography: "{typography.button}"
+  button-download:
+    backgroundColor: "{colors.ink}"
+    textColor: "{colors.canvas}"
+    typography: "{typography.button}"
+    rounded: "{rounded.md}"
+    padding: 12px 20px
+    height: 44px
+  hero-band:
+    backgroundColor: "{colors.canvas}"
+    textColor: "{colors.ink}"
+    typography: "{typography.display-mega}"
+    padding: 80px
+  ide-mockup-card:
+    backgroundColor: "{colors.surface-card}"
+    textColor: "{colors.ink}"
+    rounded: "{rounded.lg}"
+    padding: 0
+  ide-pane:
+    backgroundColor: "{colors.canvas-soft}"
+    textColor: "{colors.body}"
+    typography: "{typography.code}"
+    rounded: "{rounded.md}"
+    padding: 16px
+  feature-card:
+    backgroundColor: "{colors.surface-card}"
+    textColor: "{colors.ink}"
+    typography: "{typography.title-md}"
+    rounded: "{rounded.lg}"
+    padding: 24px
+  comparison-card:
+    backgroundColor: "{colors.surface-card}"
+    textColor: "{colors.ink}"
+    typography: "{typography.body-md}"
+    rounded: "{rounded.lg}"
+    padding: 24px
+  timeline-pill-thinking:
+    backgroundColor: "{colors.timeline-thinking}"
+    textColor: "{colors.ink}"
+    typography: "{typography.caption-uppercase}"
+    rounded: "{rounded.pill}"
+    padding: 4px 10px
+  timeline-pill-grep:
+    backgroundColor: "{colors.timeline-grep}"
+    textColor: "{colors.ink}"
+    typography: "{typography.caption-uppercase}"
+    rounded: "{rounded.pill}"
+    padding: 4px 10px
+  timeline-pill-read:
+    backgroundColor: "{colors.timeline-read}"
+    textColor: "{colors.ink}"
+    typography: "{typography.caption-uppercase}"
+    rounded: "{rounded.pill}"
+    padding: 4px 10px
+  timeline-pill-edit:
+    backgroundColor: "{colors.timeline-edit}"
+    textColor: "{colors.ink}"
+    typography: "{typography.caption-uppercase}"
+    rounded: "{rounded.pill}"
+    padding: 4px 10px
+  timeline-pill-done:
+    backgroundColor: "{colors.timeline-done}"
+    textColor: "{colors.on-primary}"
+    typography: "{typography.caption-uppercase}"
+    rounded: "{rounded.pill}"
+    padding: 4px 10px
+  code-block:
+    backgroundColor: "{colors.surface-card}"
+    textColor: "{colors.ink}"
+    typography: "{typography.code}"
+    rounded: "{rounded.lg}"
+    padding: 20px
+  pricing-tier-card:
+    backgroundColor: "{colors.surface-card}"
+    textColor: "{colors.ink}"
+    typography: "{typography.body-md}"
+    rounded: "{rounded.lg}"
+    padding: 32px
+  pricing-tier-featured:
+    backgroundColor: "{colors.ink}"
+    textColor: "{colors.canvas}"
+    typography: "{typography.body-md}"
+    rounded: "{rounded.lg}"
+    padding: 32px
+  text-input:
+    backgroundColor: "{colors.surface-card}"
+    textColor: "{colors.ink}"
+    typography: "{typography.body-md}"
+    rounded: "{rounded.md}"
+    padding: 12px 16px
+    height: 44px
+  badge-pill:
+    backgroundColor: "{colors.surface-strong}"
+    textColor: "{colors.ink}"
+    typography: "{typography.caption-uppercase}"
+    rounded: "{rounded.pill}"
+    padding: 4px 10px
+  cta-band:
+    backgroundColor: "{colors.canvas}"
+    textColor: "{colors.ink}"
+    typography: "{typography.display-lg}"
+    padding: 96px
+  testimonial-card:
+    backgroundColor: "{colors.surface-card}"
+    textColor: "{colors.body}"
+    typography: "{typography.body-md}"
+    rounded: "{rounded.lg}"
+    padding: 24px
+  footer:
+    backgroundColor: "{colors.canvas}"
+    textColor: "{colors.body}"
+    typography: "{typography.body-sm}"
+    padding: 64px 48px
+  footer-link:
+    backgroundColor: transparent
+    textColor: "{colors.body}"
+    typography: "{typography.body-sm}"
+---
+
+## Overview
+
+Cursor's marketing site reads as a quietly-confident developer brand that believes in editorial calm over IDE-darkness. The base canvas is **warm cream** (`{colors.canvas}` — #f7f7f4) holding warm near-black ink (`{colors.ink}` — #26251e) for body and display alike. The single brand voltage is **Cursor Orange** (`{colors.primary}` — #f54e00) reserved for primary CTAs and the wordmark — used scarcely.
+
+Type runs **CursorGothic** as the single sans family. Display sits at weight 400 with negative letter-spacing — a magazine-editorial voice rather than tech-bombastic. JetBrains Mono carries every code surface (and code surfaces are roughly half the page).
+
+The brand's strongest visual signature is the **AI-timeline pill palette**: five pastel pills (peach `{colors.timeline-thinking}`, mint `{colors.timeline-grep}`, blue `{colors.timeline-read}`, lavender `{colors.timeline-edit}`, gold `{colors.timeline-done}`) marking AI-action stages inside in-product timeline visualizations. Used only in product UI — never as system action colors.
+
+**Key Characteristics:**
+- Warm cream canvas, not white. Ink is warm (#26251e), not pure black.
+- Single CTA color: `{colors.primary}` (Cursor Orange #f54e00). Used scarcely.
+- Display weight stays at 400 — never bold. Magazine voice.
+- AI timeline pastels: 5 dedicated tokens for in-product agent action stages.
+- Compact 8px CTA radius — developer dialect.
+- Hairline-only depth; no drop shadows.
+- 80px section rhythm.
+
+## Colors
+
+### Brand & Accent
+- **Cursor Orange** (`{colors.primary}` — #f54e00): Primary CTA pills, wordmark, hero accent. Used scarcely.
+- **Cursor Orange Active** (`{colors.primary-active}` — #d04200): Press state.
+
+### Surface
+- **Canvas** (`{colors.canvas}` — #f7f7f4): Warm cream page floor.
+- **Canvas Soft** (`{colors.canvas-soft}` — #fafaf7): IDE-pane background inside mockups.
+- **Surface Card** (`{colors.surface-card}` — #ffffff): Pure white card surface — slight contrast against the cream canvas.
+- **Surface Strong** (`{colors.surface-strong}` — #e6e5e0): Badges, tag pills.
+
+### Hairlines
+- **Hairline** (`{colors.hairline}` — #e6e5e0): 1px divider.
+- **Hairline Soft** (`{colors.hairline-soft}` — #efeee8): Lighter divider.
+- **Hairline Strong** (`{colors.hairline-strong}` — #cfcdc4): Stronger panel outline.
+
+### Text
+- **Ink** (`{colors.ink}` — #26251e): Display, body emphasis. Warm near-black.
+- **Body** (`{colors.body}` — #5a5852): Default running-text.
+- **Body Strong** (`{colors.body-strong}` — #26251e): Same as ink.
+- **Muted** (`{colors.muted}` — #807d72): Sub-titles.
+- **Muted Soft** (`{colors.muted-soft}` — #a09c92): Disabled text.
+- **On Primary** (`{colors.on-primary}` — #ffffff): White text on Cursor Orange.
+
+### Timeline (AI-action signature)
+- **Thinking** (`{colors.timeline-thinking}` — #dfa88f): Peach. Used inside in-product agent timeline only.
+- **Grep** (`{colors.timeline-grep}` — #9fc9a2): Mint.
+- **Read** (`{colors.timeline-read}` — #9fbbe0): Pastel blue.
+- **Edit** (`{colors.timeline-edit}` — #c0a8dd): Lavender.
+- **Done** (`{colors.timeline-done}` — #c08532): Warm gold.
+
+### Semantic
+- **Success** (`{colors.semantic-success}` — #1f8a65): Confirmation indicators.
+- **Error** (`{colors.semantic-error}` — #cf2d56): Validation errors.
+
+## Typography
+
+### Font Family
+**CursorGothic** is the licensed display + body family. Fallback: `system-ui, "Helvetica Neue", Helvetica, Arial, sans-serif`. Code surfaces switch to **JetBrains Mono**.
+
+### Hierarchy
+
+| Token | Size | Weight | Line Height | Letter Spacing | Use |
+|---|---|---|---|---|---|
+| `{typography.display-mega}` | 72px | 400 | 1.1 | -2.16px | Homepage hero h1 |
+| `{typography.display-lg}` | 36px | 400 | 1.2 | -0.72px | Section heads |
+| `{typography.display-md}` | 26px | 400 | 1.25 | -0.325px | Sub-section heads |
+| `{typography.display-sm}` | 22px | 400 | 1.3 | -0.11px | Card group titles |
+| `{typography.title-md}` | 18px | 600 | 1.4 | 0 | Component titles |
+| `{typography.title-sm}` | 16px | 600 | 1.4 | 0 | List labels |
+| `{typography.body-md}` | 16px | 400 | 1.5 | 0 | Default body |
+| `{typography.body-tracked}` | 16px | 400 | 1.5 | 0.08px | Tracked editorial body |
+| `{typography.body-sm}` | 14px | 400 | 1.5 | 0 | Footer body |
+| `{typography.caption}` | 13px | 400 | 1.4 | 0 | Photo captions |
+| `{typography.caption-uppercase}` | 11px | 600 | 1.4 | 0.88px | Section labels, timeline pill labels |
+| `{typography.code}` | 13px | 400 | 1.5 | 0 | Code blocks — JetBrains Mono |
+| `{typography.button}` | 14px | 500 | 1.0 | 0 | CTA pill labels |
+| `{typography.nav-link}` | 14px | 500 | 1.4 | 0 | Top-nav menu |
+
+### Principles
+- **Display weight stays at 400.** Magazine voice, never bold.
+- **Negative letter-spacing on display only.** -0.11px to -2.16px tracking.
+- **JetBrains Mono on every code surface.**
+
+### Note on Font Substitutes
+CursorGothic is licensed. Open-source substitute: **Inter** at weight 400 with letter-spacing -1.5%. Or **GT Sectra** for a more editorial feel.
+
+## Layout
+
+### Spacing System
+- **Base unit:** 4px.
+- **Tokens:** `{spacing.xxs}` 4px · `{spacing.xs}` 8px · `{spacing.sm}` 12px · `{spacing.base}` 16px · `{spacing.md}` 20px · `{spacing.lg}` 24px · `{spacing.xl}` 32px · `{spacing.xxl}` 48px · `{spacing.section}` 80px.
+- **Section padding:** 80px.
+
+### Grid & Container
+- Max content width: ~1200px.
+- Editorial body: 12-column grid.
+- Feature card grids: 2-up at desktop for splits, 3-up for benefits.
+- Footer: 5-column at desktop.
+
+### Whitespace Philosophy
+Generous editorial pacing — closer to a print magazine than a tech site. The cream canvas has plenty of breathing room; cards within bands sit close (16-24px gap).
+
+## Elevation & Depth
+
+The system uses **hairline-only depth**. No drop shadows, no elevation tiers. Cards float above the canvas via 1px hairlines and the slight white-on-cream contrast.
+
+| Level | Treatment | Use |
+|---|---|---|
+| Flat (canvas) | `{colors.canvas}` (#f7f7f4) | Body bands, footer |
+| Card | `{colors.surface-card}` (#ffffff) | Content cards |
+| Hairline border | 1px `{colors.hairline}` | Card outlines, dividers |
+| IDE pane | `{colors.canvas-soft}` (#fafaf7) | Inside IDE mockup cards |
+
+### Decorative Depth
+- **IDE-mockup cards** are the only "elevated" element. White card on cream canvas with internal pane structure mimicking the actual Cursor editor.
+- **Timeline pastel pills** add chromatic depth without surface elevation.
+
+## Shapes
+
+### Border Radius Scale
+
+| Token | Value | Use |
+|---|---|---|
+| `{rounded.none}` | 0px | Reserved |
+| `{rounded.xs}` | 4px | Inline tags |
+| `{rounded.sm}` | 6px | Compact rows |
+| `{rounded.md}` | 8px | CTA buttons, form inputs |
+| `{rounded.lg}` | 12px | Cards, IDE panes |
+| `{rounded.xl}` | 16px | Larger feature cards (rare) |
+| `{rounded.pill}` | 9999px | Timeline pills, badges |
+| `{rounded.full}` | 9999px | Avatars (rare) |
+
+## Components
+
+### Top Navigation
+
+**`top-nav`** — Background `{colors.canvas}`, text `{colors.ink}`, height 64px. Layout: Cursor wordmark left, primary horizontal menu (Pricing / Features / Enterprise / Blog / Forum / Careers), Sign In + Download primary CTA right.
+
+### Buttons
+
+**`button-primary`** — The signature Cursor Orange CTA. Background `{colors.primary}`, text `{colors.on-primary}`, type `{typography.button}` (14px / 500), padding 10px × 18px, height 40px, rounded `{rounded.md}` (8px).
+
+**`button-primary-active`** — Press state. Background `{colors.primary-active}`.
+
+**`button-secondary`** — White card pill on cream canvas. Background `{colors.surface-card}`, text `{colors.ink}`, 1px `{colors.hairline-strong}` border.
+
+**`button-tertiary-text`** — Inline ink text link.
+
+**`button-download`** — Larger ink-canvas CTA. Background `{colors.ink}`, text `{colors.canvas}`, padding 12px × 20px, height 44px. Used for "Download for macOS" type CTAs.
+
+### Hero & IDE Mockups
+
+**`hero-band`** — Background `{colors.canvas}`, full-width display headline in `{typography.display-mega}` (72px / 400 / -2.16px), subhead in `{typography.body-md}`, two CTAs (`button-download` + `button-tertiary-text`), and a centered IDE-mockup card below the hero copy.
+
+**`ide-mockup-card`** — A white card containing a multi-pane IDE mockup (sidebar + main editor + chat panel + terminal). Background `{colors.surface-card}`, rounded `{rounded.lg}` (12px), 1px `{colors.hairline}` border, no padding (panes fill the card edge-to-edge).
+
+**`ide-pane`** — Individual IDE pane inside the mockup. Background `{colors.canvas-soft}`, text `{colors.body}` in `{typography.code}` (JetBrains Mono 13px), rounded `{rounded.md}` (8px), padding 16px.
+
+### Cards
+
+**`feature-card`** — Background `{colors.surface-card}`, text `{colors.ink}`, type `{typography.title-md}`, rounded `{rounded.lg}`, padding 24px. 1px `{colors.hairline}` border.
+
+**`comparison-card`** — Side-by-side "Cursor vs other tools" card. Same surface and rounding; internally split into 2 columns.
+
+**`testimonial-card`** — Quote card. Background `{colors.surface-card}`, text `{colors.body}`, rounded `{rounded.lg}`, padding 24px.
+
+### AI Timeline (signature)
+
+**`timeline-pill-thinking`** — Peach pill. Background `{colors.timeline-thinking}`, text `{colors.ink}`, type `{typography.caption-uppercase}` (11px / 600 / 0.88px tracking, uppercase), rounded `{rounded.pill}`, padding 4px × 10px. Marks "Thinking" stage in product timeline.
+
+**`timeline-pill-grep`** — Mint pill. Same shape, background `{colors.timeline-grep}`. Marks "Grepping" stage.
+
+**`timeline-pill-read`** — Pastel-blue pill. Background `{colors.timeline-read}`. Marks "Reading" stage.
+
+**`timeline-pill-edit`** — Lavender pill. Background `{colors.timeline-edit}`. Marks "Editing" stage.
+
+**`timeline-pill-done`** — Gold pill. Background `{colors.timeline-done}`, text `{colors.on-primary}` white. Marks "Done" stage.
+
+### Code
+
+**`code-block`** — Inline code block. Background `{colors.surface-card}`, text `{colors.ink}` in `{typography.code}`, rounded `{rounded.lg}`, padding 20px, 1px `{colors.hairline}` border.
+
+### Pricing
+
+**`pricing-tier-card`** — Background `{colors.surface-card}`, rounded `{rounded.lg}`, padding 32px, 1px `{colors.hairline}` border.
+
+**`pricing-tier-featured`** — Featured tier inverts to ink. Background `{colors.ink}`, text `{colors.canvas}`. Same shape, dark inversion signals "highlighted" without colored ribbon.
+
+### Forms & Tags
+
+**`text-input`** — Background `{colors.surface-card}`, text `{colors.ink}`, rounded `{rounded.md}` (8px), padding 12px × 16px, height 44px.
+
+**`badge-pill`** — Small uppercase pill. Background `{colors.surface-strong}`, text `{colors.ink}`, type `{typography.caption-uppercase}`, rounded `{rounded.pill}`, padding 4px × 10px.
+
+### CTA / Footer
+
+**`cta-band`** — Pre-footer "Try Cursor now" band. Background `{colors.canvas}`, centered display headline in `{typography.display-lg}`, single Cursor Orange CTA. 96px vertical padding.
+
+**`footer`** — Closing footer. Background `{colors.canvas}`, text `{colors.body}`. 5-column link list. 64×48px padding.
+
+**`footer-link`** — Background transparent, text `{colors.body}`, type `{typography.body-sm}`.
+
+## Do's and Don'ts
+
+### Do
+- Reserve `{colors.primary}` (Cursor Orange) for primary CTAs and brand wordmark.
+- Keep display weight at 400. The editorial voice depends on this.
+- Use the cream `{colors.canvas}` page floor — never pure white.
+- Render every code surface (inline, blocks, IDE panes) in JetBrains Mono.
+- Use timeline pastels only inside in-product agent visualizations — never as system action colors.
+
+### Don't
+- Don't introduce a secondary brand action color. Cursor Orange is the only one.
+- Don't drop display to bold weights (700+). Magazine voice depends on 400.
+- Don't add drop shadows. Hairlines + ink-on-cream contrast carry the depth.
+- Don't use timeline pastels on non-timeline UI. They're scoped to the agent timeline only.
+- Don't extract a CTA color from a third-party widget (cookie consent, OneTrust). The brand's CTA is what appears on actual product CTAs.
+
+## Responsive Behavior
+
+### Breakpoints
+
+| Name | Width | Key Changes |
+|---|---|---|
+| Mobile | < 640px | Hero h1 72→32px; IDE mockup collapses to single pane preview; feature grid 1-up; nav hamburger. |
+| Tablet | 640–1024px | Hero h1 56px; IDE mockup compresses; feature grid 2-up. |
+| Desktop | 1024–1280px | Full hero h1 72px; full multi-pane IDE mockup; feature grid 3-up. |
+| Wide | > 1280px | Content caps at 1200px. |
+
+### Touch Targets
+- Primary CTA at 40px height — at WCAG AA, padded for AAA.
+- Download CTA at 44px — at AAA.
+
+### Collapsing Strategy
+- Top nav switches to hamburger below 768px.
+- IDE mockup multi-pane collapses to a single primary pane preview on mobile.
+- Feature grid: 3-up → 2-up → 1-up.
+
+## Iteration Guide
+
+1. Focus on a single component at a time.
+2. CTAs default to `{rounded.md}` (8px). Cards use `{rounded.lg}` (12px).
+3. Variants live as separate entries inside `components:`.
+4. Use `{token.refs}` everywhere — never inline hex.
+5. Hover state never documented.
+6. CursorGothic 400 for display, 400/500/600 for body. JetBrains Mono on every code surface.
+7. Cursor Orange stays scarce.
+8. Timeline pastels stay scoped to in-product agent visualizations.
+
+## Known Gaps
+
+- CursorGothic is a licensed typeface; Inter is the substitute.
+- Animation timings (timeline pill entrance, IDE pane reveal) out of scope.
+- In-app surfaces (code editor, chat panel, agent timeline) only partially captured via marketing IDE mockups.
+- Form validation states beyond focus not visible on captured surfaces.

--- a/astro/src/data/design-md/framer.md
+++ b/astro/src/data/design-md/framer.md
@@ -1,0 +1,544 @@
+---
+version: alpha
+name: Framer-design-analysis
+description: "A confident dark-canvas builder marketing site that treats the page like a working artboard — pure black surfaces, white display type set in GT Walsheim Medium with aggressive negative tracking, and a single confident blue (#0099ff) reserved for hyperlinks and selection states. The page rhythm is broken by oversized vibrant gradient atmosphere panels — magenta, violet, orange spotlights — that act as living showcase tiles, not decoration. Every CTA is a white pill on dark; every card is a translucent or charcoal surface; every section title pulls letter-spacing tight enough to feel like a poster."
+
+colors:
+  primary: "#ffffff"
+  on-primary: "#000000"
+  accent-blue: "#0099ff"
+  ink: "#ffffff"
+  ink-muted: "#999999"
+  canvas: "#090909"
+  surface-1: "#141414"
+  surface-2: "#1c1c1c"
+  hairline: "#262626"
+  hairline-soft: "#1a1a1a"
+  inverse-canvas: "#ffffff"
+  inverse-ink: "#000000"
+  gradient-magenta: "#d44df0"
+  gradient-violet: "#6a4cf5"
+  gradient-orange: "#ff7a3d"
+  gradient-coral: "#ff5577"
+  semantic-success: "#22c55e"
+
+typography:
+  display-xxl:
+    fontFamily: GT Walsheim Framer Medium
+    fontSize: 110px
+    fontWeight: 500
+    lineHeight: 0.85
+    letterSpacing: -5.5px
+  display-xl:
+    fontFamily: GT Walsheim Medium
+    fontSize: 85px
+    fontWeight: 500
+    lineHeight: 0.95
+    letterSpacing: -4.25px
+    fontFeature: ss02
+  display-lg:
+    fontFamily: GT Walsheim Medium
+    fontSize: 62px
+    fontWeight: 500
+    lineHeight: 1.00
+    letterSpacing: -3.1px
+    fontFeature: ss02
+  display-md:
+    fontFamily: GT Walsheim Medium
+    fontSize: 32px
+    fontWeight: 500
+    lineHeight: 1.13
+    letterSpacing: -1.0px
+  headline:
+    fontFamily: Inter
+    fontSize: 22px
+    fontWeight: 700
+    lineHeight: 1.20
+    letterSpacing: -0.8px
+    fontFeature: cv05
+  subhead:
+    fontFamily: Inter Variable
+    fontSize: 24px
+    fontWeight: 400
+    lineHeight: 1.30
+    letterSpacing: -0.01px
+    fontFeature: cv11
+  body-lg:
+    fontFamily: Inter Variable
+    fontSize: 18px
+    fontWeight: 400
+    lineHeight: 1.30
+    letterSpacing: -0.18px
+    fontFeature: cv11
+  body:
+    fontFamily: Inter Variable
+    fontSize: 15px
+    fontWeight: 400
+    lineHeight: 1.30
+    letterSpacing: -0.15px
+    fontFeature: cv11
+  body-sm:
+    fontFamily: Inter Variable
+    fontSize: 14px
+    fontWeight: 500
+    lineHeight: 1.40
+    letterSpacing: -0.14px
+    fontFeature: cv11
+  caption:
+    fontFamily: Inter Variable
+    fontSize: 13px
+    fontWeight: 500
+    lineHeight: 1.20
+    letterSpacing: -0.13px
+    fontFeature: cv11
+  micro:
+    fontFamily: Inter Variable
+    fontSize: 12px
+    fontWeight: 400
+    lineHeight: 1.20
+    letterSpacing: -0.12px
+    fontFeature: cv11
+  button:
+    fontFamily: Inter Variable
+    fontSize: 14px
+    fontWeight: 500
+    lineHeight: 1.0
+    letterSpacing: -0.14px
+    fontFeature: cv11
+
+rounded:
+  xs: 4px
+  sm: 6px
+  md: 10px
+  lg: 15px
+  xl: 20px
+  xxl: 30px
+  pill: 100px
+  full: 9999px
+
+spacing:
+  hair: 1px
+  xxs: 4px
+  xs: 8px
+  sm: 12px
+  md: 15px
+  lg: 20px
+  xl: 30px
+  xxl: 40px
+  section: 96px
+
+components:
+  button-primary:
+    backgroundColor: "{colors.primary}"
+    textColor: "{colors.on-primary}"
+    typography: "{typography.button}"
+    rounded: "{rounded.pill}"
+    padding: 10px 15px
+  button-primary-pressed:
+    backgroundColor: "{colors.primary}"
+    textColor: "{colors.on-primary}"
+    typography: "{typography.button}"
+    rounded: "{rounded.pill}"
+  button-secondary:
+    backgroundColor: "{colors.surface-1}"
+    textColor: "{colors.ink}"
+    typography: "{typography.button}"
+    rounded: "{rounded.pill}"
+    padding: 10px 15px
+  button-translucent:
+    backgroundColor: "{colors.surface-2}"
+    textColor: "{colors.ink}"
+    typography: "{typography.button}"
+    rounded: "{rounded.xxl}"
+    padding: 8px 14px
+  button-icon-circular:
+    backgroundColor: "{colors.surface-1}"
+    textColor: "{colors.ink}"
+    typography: "{typography.button}"
+    rounded: "{rounded.full}"
+    size: 40px
+  pricing-tab-default:
+    backgroundColor: "{colors.canvas}"
+    textColor: "{colors.ink-muted}"
+    typography: "{typography.button}"
+    rounded: "{rounded.pill}"
+    padding: 8px 14px
+  pricing-tab-selected:
+    backgroundColor: "{colors.surface-2}"
+    textColor: "{colors.ink}"
+    typography: "{typography.button}"
+    rounded: "{rounded.pill}"
+    padding: 8px 14px
+  text-input:
+    backgroundColor: "{colors.surface-1}"
+    textColor: "{colors.ink}"
+    typography: "{typography.body}"
+    rounded: "{rounded.md}"
+    padding: 10px 14px
+  text-input-focused:
+    backgroundColor: "{colors.surface-1}"
+    textColor: "{colors.ink}"
+    typography: "{typography.body}"
+    rounded: "{rounded.md}"
+    padding: 10px 14px
+  pricing-card:
+    backgroundColor: "{colors.surface-1}"
+    textColor: "{colors.ink}"
+    typography: "{typography.body}"
+    rounded: "{rounded.xl}"
+    padding: 24px
+  pricing-card-featured:
+    backgroundColor: "{colors.surface-2}"
+    textColor: "{colors.ink}"
+    typography: "{typography.body}"
+    rounded: "{rounded.xl}"
+    padding: 24px
+  template-card:
+    backgroundColor: "{colors.surface-1}"
+    textColor: "{colors.ink}"
+    typography: "{typography.body-sm}"
+    rounded: "{rounded.lg}"
+    padding: 12px
+  gradient-spotlight-card:
+    backgroundColor: "{colors.gradient-violet}"
+    textColor: "{colors.ink}"
+    typography: "{typography.subhead}"
+    rounded: "{rounded.xl}"
+    padding: 32px
+  gradient-spotlight-card-magenta:
+    backgroundColor: "{colors.gradient-magenta}"
+    textColor: "{colors.ink}"
+    typography: "{typography.subhead}"
+    rounded: "{rounded.xl}"
+    padding: 32px
+  gradient-spotlight-card-orange:
+    backgroundColor: "{colors.gradient-orange}"
+    textColor: "{colors.ink}"
+    typography: "{typography.subhead}"
+    rounded: "{rounded.xl}"
+    padding: 32px
+  product-mockup-tile:
+    backgroundColor: "{colors.surface-1}"
+    textColor: "{colors.ink}"
+    typography: "{typography.body-sm}"
+    rounded: "{rounded.xl}"
+    padding: 16px
+  feature-row:
+    backgroundColor: "{colors.canvas}"
+    textColor: "{colors.ink}"
+    typography: "{typography.body}"
+    rounded: "{rounded.xs}"
+  comparison-row:
+    backgroundColor: "{colors.canvas}"
+    textColor: "{colors.ink-muted}"
+    typography: "{typography.body-sm}"
+    rounded: "{rounded.xs}"
+  top-nav:
+    backgroundColor: "{colors.canvas}"
+    textColor: "{colors.ink}"
+    typography: "{typography.body-sm}"
+    rounded: "{rounded.xs}"
+    height: 56px
+  faq-row:
+    backgroundColor: "{colors.canvas}"
+    textColor: "{colors.ink}"
+    typography: "{typography.body}"
+    rounded: "{rounded.md}"
+    padding: 24px
+  footer:
+    backgroundColor: "{colors.canvas}"
+    textColor: "{colors.ink-muted}"
+    typography: "{typography.caption}"
+    rounded: "{rounded.xs}"
+    padding: 64px 32px
+---
+
+## Overview
+
+Framer's marketing canvas is a near-pure black artboard. The dominant surface is `{colors.canvas}` — almost pure black with a faint warmth — and on top of it sits oversized white display type set in **GT Walsheim Medium** with letter-spacing pulled to extreme negative values (-5.5px on the 110px display, -4.25px on the 85px hero). The page reads like a poster: one assertive statement per band, generous breathing room above and below.
+
+The single accent is `{colors.accent-blue}` — used scarcely, mostly for hyperlinks, selection halos, and a subtle blue-tinted shadow ring on focused inputs. The brand chrome itself is monochrome: white pill buttons, charcoal cards, gray secondary text. What makes Framer distinctive is the rhythm break — every few sections the page drops in a **vibrant gradient atmosphere card**: a magenta-violet spotlight, a sunset-orange wash, a coral-pink panel. These aren't section backgrounds; they're individual cards arranged in a card grid, each one a small living poster that shows what Framer can produce.
+
+Body type is **Inter Variable**, with Framer leaning hard into Inter's character variants (`cv01`, `cv05`, `cv09`, `cv11`, `ss03`, `ss07`, `dlig`) — the result is a body voice that feels custom-tuned, with single-storey "a", straight-leg "l", and tabular figures. There's no light mode on the marketing site; the brand IS dark.
+
+**Key Characteristics:**
+- Black-canvas marketing system: `{colors.canvas}` is the surface for hero, body, pricing, FAQ, and footer alike — no light interludes.
+- Massive negative letter-spacing on display sizes (-5.5px / -4.25px / -3.1px) creates a poster-grade headline cadence.
+- White pill (`{components.button-primary}`) is the only primary CTA shape across the site; secondary actions live as charcoal pills (`{components.button-secondary}`) or text links.
+- Oversized **gradient spotlight cards** (violet, magenta, orange, coral) act as showcase tiles inside the dark grid; they are individual cards, not section backgrounds.
+- Inter Variable with bespoke OpenType character variants (`cv01/05/09/11`, `ss03/ss07`, `dlig`) used everywhere body type appears — the typographic voice is unmistakable.
+- Border radius scale runs from 4px utility chips up to 100px pills and full circles, with 15–20px the default for cards and 30px for atmospheric gradient cards.
+- A single chromatic accent `{colors.accent-blue}` reserved for hyperlinks, focus, and selection — never decorative.
+
+## Colors
+
+> Source pages: framer.com (home), /ai/, /startups/, /marketplace/templates/nudge/, /gallery/a16z-speedrun-×-tonik, /pricing.
+
+### Brand & Accent
+- **Pure White** ({colors.primary}): The brand primary surface. Every primary CTA pill, every display headline, every body line on canvas.
+- **Sky Blue** ({colors.accent-blue}): The single chromatic accent. Hyperlinks, focused-input rings, and a few selection states. Never used for backgrounds or as a brand fill.
+
+### Surface
+- **Canvas** ({colors.canvas}): Default page background — near-black with a faint warmth. Footer, pricing, hero, and FAQ all sit on it.
+- **Surface 1** ({colors.surface-1}): One step above canvas — pricing cards, secondary buttons, mockup tiles.
+- **Surface 2** ({colors.surface-2}): Two steps above — featured pricing card, hero pill backdrop, selected pricing tab.
+- **Hairline** ({colors.hairline}): 1px borders on input groups, comparison-table dividers.
+- **Hairline Soft** ({colors.hairline-soft}): Subtler dividers — between FAQ rows and footer column rules.
+- **Inverse Canvas** ({colors.inverse-canvas}): Pure white — used as the surface of light-on-dark pill CTAs and a small set of light-mode template thumbnails embedded in the showcase grid.
+
+### Text
+- **Ink** ({colors.ink}): All headline and emphasized body type — pure white.
+- **Ink Muted** ({colors.ink-muted}): Secondary type — gray (#999999) used for meta info, footer columns, comparison-row labels, deselected pricing tabs. Hierarchy on the dark canvas is carried by ink → ink-muted contrast, not by weight changes.
+
+### Semantic
+- **Success Green** ({colors.semantic-success}): Pricing comparison-table checkmarks. Glyph fill, not surface.
+
+### Brand Gradient (signature)
+- **Gradient Magenta** ({colors.gradient-magenta}): Spotlight card variant.
+- **Gradient Violet** ({colors.gradient-violet}): Spotlight card variant — most common.
+- **Gradient Orange** ({colors.gradient-orange}): Spotlight card variant — sunset wash.
+- **Gradient Coral** ({colors.gradient-coral}): Spotlight card variant — coral/pink.
+
+These four sit as oversized atmospheric tiles inside otherwise monochrome card grids — a dark canvas with one or two glowing spotlight cards is a recurring page signature.
+
+## Typography
+
+### Font Family
+
+- **GT Walsheim Framer Medium** / **GT Walsheim Medium** — Framer's display typeface. Geometric, slightly humanist, very confident at large sizes with extreme negative tracking. Fallbacks: `GT Walsheim Medium Placeholder` system font.
+- **Inter Variable** — System body typeface. Used with extensive OpenType character variants: `cv01` (alternate "1"), `cv05` (alternate "g"), `cv09` (alternate "i" / "l"), `cv11` (alternate "0"), `ss03` / `ss07` stylistic sets, `dlig` discretionary ligatures, and `tnum` for numerics in tabular contexts. The result is a body voice that feels bespoke without commissioning a custom face.
+- **Inter** — Used selectively for `{typography.headline}` (the 22px / 20px tier). The non-variable cut catches small tracking targets that the variable file rounds.
+
+### Hierarchy
+
+| Token | Size | Weight | Line Height | Letter Spacing | Use |
+|---|---|---|---|---|---|
+| `{typography.display-xxl}` | 110px | 500 | 0.85 | -5.5px | Largest hero headline (home, AI page) |
+| `{typography.display-xl}` | 85px | 500 | 0.95 | -4.25px | Section opener headlines |
+| `{typography.display-lg}` | 62px | 500 | 1.00 | -3.1px | Sub-section openers |
+| `{typography.display-md}` | 32px | 500 | 1.13 | -1.0px | Card titles, smaller display |
+| `{typography.headline}` | 22px | 700 | 1.20 | -0.8px | Pricing tier headlines, FAQ category titles |
+| `{typography.subhead}` | 24px | 400 | 1.30 | -0.01px | Lead body next to display headlines |
+| `{typography.body-lg}` | 18px | 400 | 1.30 | -0.18px | Hero subhead, lead paragraphs |
+| `{typography.body}` | 15px | 400 | 1.30 | -0.15px | Default body, card descriptions |
+| `{typography.body-sm}` | 14px | 500 | 1.40 | -0.14px | Pricing comparison rows, dense data |
+| `{typography.caption}` | 13px | 500 | 1.20 | -0.13px | Eyebrows, footer columns, meta |
+| `{typography.micro}` | 12px | 400 | 1.20 | -0.12px | Disclaimer, footnote |
+| `{typography.button}` | 14px | 500 | 1.0 | -0.14px | Pill buttons |
+
+### Principles
+
+- **Letter-spacing scales with size, hard.** Display-xxl pulls -5.5px (5% of size); body sticks to about -1% (-0.15px on 15px). The result: posters at the top, comfortable reading at body.
+- **OpenType character variants are the brand voice.** Switching off `cv11`, `ss03`, etc. visibly changes the body voice — the brand depends on them.
+- **Weight stays in a narrow band.** Display sits at 500, body at 400, body-sm/caption at 500. Hierarchy is carried by size + tracking, not by 700/900 ramps.
+- **Tight line-heights everywhere.** Even body runs at 1.30 — Framer's editorial tone is denser than typical SaaS marketing.
+
+### Note on Font Substitutes
+
+If implementing without GT Walsheim Medium, suitable open-source substitutes include **Mona Sans**, **Geist**, or **Inter** at weight 600–700 with manually tightened tracking. Mona Sans's hairline weights at 100–300 are particularly close to Framer's cleaner section openers. Inter Variable is open-source — keep it as-is and preserve the documented OpenType variants.
+
+## Layout
+
+### Spacing System
+
+- **Base unit**: 5px (Framer uses non-standard 5/10/15/20/30 increments rather than the more common 4/8/16/24).
+- **Tokens (front matter)**: `{spacing.hair}` 1px · `{spacing.xxs}` 4px · `{spacing.xs}` 8px · `{spacing.sm}` 12px · `{spacing.md}` 15px · `{spacing.lg}` 20px · `{spacing.xl}` 30px · `{spacing.xxl}` 40px · `{spacing.section}` 96px.
+- Card interior padding: `{spacing.lg}` 20px on pricing cards; `{spacing.xl}` 30px on gradient spotlight cards.
+- Pill button padding: 10px vertical · 15px horizontal — `{components.button-primary}`.
+- Section padding (vertical): roughly `{spacing.section}` 96px on home; tighter (~64px) on pricing comparison.
+
+### Grid & Container
+
+- Max content width sits around the 1199px breakpoint, with side gutters that scale toward `{spacing.xl}` on desktop.
+- Card grids on the home gallery use 2-up at desktop, collapsing to 1-up below 810px.
+- Pricing tier grid is 4-up across the documented breakpoints; comparison table beneath it uses fixed-width left column with horizontally scrolling tier columns at narrow widths.
+
+### Whitespace Philosophy
+
+The dark canvas IS the whitespace. Where lighter brands lean on white air to separate sections, Framer leans on long stretches of black with a single oversized statement floating in the middle. Sections separate by mode change: a band of charcoal cards, then a band of black with a gradient spotlight, then back to charcoal — like cuts in a dark film.
+
+## Elevation & Depth
+
+| Level | Treatment | Use |
+|---|---|---|
+| 0 (flat) | No shadow, no border | Default for canvas-mounted display type, FAQ rows, footer |
+| 1 (charcoal) | `{colors.surface-1}` lift on canvas | Pricing cards, mockup tiles, secondary buttons |
+| 2 (light-edge) | `rgba(255,255,255,0.10)` 0.5px top edge + `rgba(0,0,0,0.25)` 0px 10px 30px drop | Floating product cards, modal cards |
+| 3 (selected) | `rgba(0,153,255,0.15)` 0px 0px 0px 1px ring | Focused inputs, selected option |
+
+Four shadow signatures recur across the homepage: a 1px subtle drop, a translucent blue ring, a thick near-black 2px outline (used as the active-element marker on sub-nav), and the layered light-edge + drop-shadow used for floating cards.
+
+### Decorative Depth
+
+- **Gradient spotlight cards** are the dominant depth device — color saturation against black canvas substitutes for shadow-driven elevation.
+- **Layered product mockups** (browser frames containing live Framer-built sites) sit inside `{colors.surface-1}` cards with the level-2 light-edge treatment.
+- **Subtle blue ring (focus / selected)** is the only chromatic depth signal — used to mark the active state of input groups and pricing tier toggles without changing the underlying surface.
+
+## Shapes
+
+### Border Radius Scale
+
+Framer's extracted radius set is unusually granular (1px, 4px, 5px, 6px, 8px, 10px, 12px, 15px, 20px, 30px, 40px, 100px). The named scale below picks the levels the marketing surface actually consumes.
+
+| Token | Value | Use |
+|---|---|---|
+| `{rounded.xs}` | 4px | Small chip / utility radius |
+| `{rounded.sm}` | 6px | Inline tag, badge |
+| `{rounded.md}` | 10px | Form input, list item |
+| `{rounded.lg}` | 15px | Template card thumbnails |
+| `{rounded.xl}` | 20px | Pricing cards, mockup tiles |
+| `{rounded.xxl}` | 30px | Gradient spotlight cards, oversized panels |
+| `{rounded.pill}` | 100px | All primary text CTAs |
+| `{rounded.full}` | 9999px | Circular icon buttons, avatar circles |
+
+### Photography & Illustration Geometry
+
+- Embedded site mockups (browser-chromed previews of Framer-built sites) sit in `{rounded.xl}` 20px tiles with `{spacing.md}` 15px interior padding.
+- Gradient spotlight cards use `{rounded.xxl}` 30px corners — softer than the 20px content cards by design, to make them feel like atmospheric panels rather than tighter UI.
+- Icon glyphs and sub-nav glyphs render in `{rounded.full}` circles at 32–40px sizes.
+
+## Components
+
+### Buttons
+
+**`button-primary`** — White pill on dark canvas. The primary CTA across home, pricing, AI, and gallery pages.
+- Background `{colors.primary}`, text `{colors.on-primary}`, type `{typography.button}`, padding 10px 15px, rounded `{rounded.pill}`.
+- Pressed state lives in `button-primary-pressed` (the live site uses a transform-scale shrink rather than a darkened fill).
+
+**`button-secondary`** — Charcoal pill. Used for secondary navigation actions ("Sign in", "Talk to sales") and as the visual counterpart to the primary pill.
+- Background `{colors.surface-1}`, text `{colors.ink}`, type `{typography.button}`, padding 10px 15px, rounded `{rounded.pill}`.
+
+**`button-translucent`** — Translucent / lifted secondary used on top of busy backgrounds (gallery hero, gradient cards).
+- Background `{colors.surface-2}`, text `{colors.ink}`, type `{typography.button}`, rounded `{rounded.xxl}`, padding 8px 14px.
+
+**`button-icon-circular`** — 40px circle for inline icon actions (carousel arrows, social links).
+- Background `{colors.surface-1}`, text `{colors.ink}`, rounded `{rounded.full}`, size 40px.
+
+### Pricing Tabs
+
+**`pricing-tab-default`** + **`pricing-tab-selected`** — The pill-toggle that switches between Basic / Pro / Business / Enterprise on `/pricing`.
+- Default: `{colors.canvas}` background, `{colors.ink-muted}` text, rounded `{rounded.pill}`.
+- Selected: `{colors.surface-2}` background, `{colors.ink}` text — selected = lift, not color. Surface depth communicates "active" without needing a chromatic fill.
+
+### Inputs & Forms
+
+**`text-input`** + **`text-input-focused`** — Form fields on `/pricing` (seat-count, currency switcher) and the in-product preview surfaces.
+- Background `{colors.surface-1}`, text `{colors.ink}`, type `{typography.body}`, rounded `{rounded.md}`, padding 10px 14px.
+- Focused state retains the same surface; the focus ring is the level-3 blue-tinted shadow `rgba(0,153,255,0.15)` 0 0 0 1px.
+
+### Cards & Containers
+
+**`pricing-card`** — Each tier on `/pricing`.
+- Background `{colors.surface-1}`, text `{colors.ink}`, type `{typography.body}`, rounded `{rounded.xl}`, padding 24px.
+
+**`pricing-card-featured`** — The Pro tier (visually emphasized).
+- Background `{colors.surface-2}`, otherwise identical structure. The lift is one surface step up — no chromatic outline.
+
+**`template-card`** — Thumbnail tile in the home "Built with Framer" gallery and `/marketplace`.
+- Background `{colors.surface-1}`, text `{colors.ink}`, type `{typography.body-sm}`, rounded `{rounded.lg}`, padding 12px.
+
+**`product-mockup-tile`** — Larger tile that frames a live product UI mock (Framer canvas, Workshop video, AI translate panel).
+- Background `{colors.surface-1}`, text `{colors.ink}`, type `{typography.body-sm}`, rounded `{rounded.xl}`, padding 16px.
+
+### Gradient Spotlight Cards (signature)
+
+The defining decorative surface of Framer's marketing — oversized atmospheric tiles dropped into otherwise monochrome card grids. Variants:
+
+**`gradient-spotlight-card`** — violet ground (most common).
+- Background `{colors.gradient-violet}`, text `{colors.ink}`, type `{typography.subhead}`, rounded `{rounded.xl}`, padding 32px. (The on-site card often pushes to `{rounded.xxl}` 30px when it spans a wider tile.)
+
+**`gradient-spotlight-card-magenta`** — magenta-pink ground.
+- Background `{colors.gradient-magenta}`, otherwise identical.
+
+**`gradient-spotlight-card-orange`** — sunset-orange wash.
+- Background `{colors.gradient-orange}`, otherwise identical.
+
+(Coral pink follows the same shape with `{colors.gradient-coral}`.)
+
+### Comparison & FAQ
+
+**`feature-row`** + **`comparison-row`** — Single rows inside the pricing comparison table.
+- `feature-row`: `{colors.canvas}` background, `{colors.ink}` text. Header rows.
+- `comparison-row`: `{colors.canvas}` background, `{colors.ink-muted}` text. Data rows with `{typography.body-sm}` and 1px `{colors.hairline-soft}` underlines.
+
+**`faq-row`** — Each accordion line in the pricing-page FAQ.
+- Background `{colors.canvas}`, text `{colors.ink}`, type `{typography.body}`, rounded `{rounded.md}`, padding 24px.
+
+### Navigation
+
+**`top-nav`** — Sticky bar on `{colors.canvas}` with the Framer wordmark left, primary nav links centered, and a `button-secondary` ("Sign in") + `button-primary` ("Get started for free") pair right.
+- Background `{colors.canvas}`, text `{colors.ink}`, type `{typography.body-sm}`, height 56px.
+- Mobile: collapses primary links into a hamburger; the two pill CTAs collapse into a single primary pill on the bar.
+
+### Footer
+
+**`footer`** — Dense link grid on `{colors.canvas}` with the Framer wordmark left and 5–6 columns of caption-sized links.
+- Background `{colors.canvas}`, text `{colors.ink-muted}`, type `{typography.caption}`, padding 64px 32px.
+
+## Do's and Don'ts
+
+### Do
+
+- Reserve `{colors.primary}` (white) and `{colors.canvas}` (near-black) as the system's two anchor surfaces. Every band of the page chooses one or the other.
+- Push display-size letter-spacing aggressively negative — `{typography.display-xxl}` at -5.5px is the brand signature, not a stylistic accident.
+- Use `{colors.accent-blue}` only for hyperlinks, focus rings, and selected indicators. Never as a background or button fill.
+- Drop one or two `gradient-spotlight-card` variants into a card grid; they are the brand's atmosphere device. Don't overdo it — three or more in the same viewport reads as a moodboard, not a system.
+- Compose every CTA as a pill (`{rounded.pill}`); secondary actions live as charcoal pills, never as bordered ghost buttons.
+- Keep body type Inter Variable with character variants `cv01`, `cv05`, `cv09`, `cv11`, `ss03`, `ss07` enabled — the brand voice depends on them.
+- Use surface lift (canvas → surface-1 → surface-2) to mark hierarchy on dark, not opacity changes on white type.
+
+### Don't
+
+- Don't ship a light-mode marketing page. Framer's identity is dark.
+- Don't introduce mid-tone gray text outside `{colors.ink-muted}`. The hierarchy is binary: `ink` or `ink-muted`.
+- Don't use `{colors.accent-blue}` as a brand fill (e.g., a blue CTA pill). The blue is a signal color, not a surface.
+- Don't square off CTAs. Pill (`{rounded.pill}`) or full circle is the brand vocabulary.
+- Don't reduce the negative letter-spacing on display sizes "for accessibility". The compression is intrinsic to the brand voice; reduce the SIZE if needed, but keep the percentage.
+- Don't apply gradient backgrounds to whole sections. Gradients are CARDS, not section grounds.
+- Don't combine more than one chromatic accent. The palette is monochrome plus one blue plus the gradient family — not "blue, green, and red".
+
+## Responsive Behavior
+
+### Breakpoints
+
+| Name | Width | Key Changes |
+|---|---|---|
+| Desktop | 1199px | Default desktop layout |
+| Tablet | 810px | Card grids collapse 4-up → 2-up; nav becomes hamburger |
+| Mobile-Lg | 809px | Pricing comparison table becomes per-tier accordion |
+| Mobile-XS | 98px | Smallest documented breakpoint — single-column everything |
+
+### Touch Targets
+
+- Pill buttons (`button-primary`, `button-secondary`) maintain a minimum 44px tap height across all viewports — combine `{typography.button}` 14px line-height with the documented 10px vertical padding.
+- Circular icon buttons (`button-icon-circular`) are 40px on desktop and grow to 44px on touch viewports.
+- Pricing-tab pills hold ≥40px tap height; below 810px they may collapse into a horizontal-scroll row instead of stacking.
+
+### Collapsing Strategy
+
+- **Nav**: horizontal nav with a centered link group + right-anchored pill pair collapses to a hamburger overlay below 810px. The `button-primary` stays visible on the bar.
+- **Card grids**: the gallery and template-card grids go 2-up on desktop → 1-up on mobile. Gradient spotlight cards retain `{rounded.xxl}` corners at every viewport — they don't bleed.
+- **Pricing comparison table**: collapses into per-tier accordions below 810px to avoid horizontal scroll.
+- **Display type**: `{typography.display-xxl}` 110px scales down toward `{typography.display-lg}` 62px on tablet and `{typography.display-md}` 32px on mobile, preserving the percentage-negative letter-spacing.
+
+### Image Behavior
+
+- Embedded product mockups (browser frames containing live Framer-built sites) maintain their aspect ratio and never crop.
+- Gradient spotlight cards keep their gradient orientations across breakpoints — the gradient direction is part of the brand spec.
+
+## Iteration Guide
+
+1. Focus on ONE component at a time and reference it by its `components:` token name (e.g., `{components.button-primary}`, `{components.gradient-spotlight-card}`).
+2. When introducing a new section on the dark canvas, decide first which surface lift it lives on — `{colors.canvas}` for hero/FAQ, `{colors.surface-1}` for cards, `{colors.surface-2}` for featured cards. The depth choice is the most consequential decision.
+3. Default body to `{typography.body}` with all the documented OpenType variants; reach for `{typography.subhead}` only inside spotlight cards.
+4. Run `npx @google/design.md lint DESIGN.md` after edits — `broken-ref`, `contrast-ratio`, and `orphaned-tokens` warnings flag issues automatically.
+5. Add new variants as separate component entries (`-pressed`, `-featured`, `-selected`) — do not bury them in prose.
+6. Treat `{colors.accent-blue}` as a single-shot signal color: hyperlinks, focus, and selection — that's it. If you find yourself reaching for a second blue, the brand is drifting.
+7. Gradient spotlight cards are scarce by design. One or two per long page is the spec; three is a moodboard.
+
+## Known Gaps
+
+- The exact gradient stops for the spotlight cards are derived from screenshot pixels rather than from CSS variables — the production gradients are likely defined as `linear-gradient` strings on individual elements rather than as design tokens. Treat the documented `{colors.gradient-*}` hex values as base anchors, not as exact gradient specs.
+- Form-field validation / error styling is not visible on the inspected pages because no error states render in the static screenshots.
+- Dark mode is the only mode — no light-mode adaptation is documented because the marketing site does not ship one.
+- The marketplace template detail page returned sparser CSS variable data than the other pages; surface tokens for that page were inferred from the matching home / gallery treatment rather than extracted directly.

--- a/astro/src/data/design-md/minimax.md
+++ b/astro/src/data/design-md/minimax.md
@@ -1,0 +1,746 @@
+---
+version: alpha
+name: MiniMax-design-analysis
+description: MiniMax presents itself as a premium AI infrastructure brand through a striking duality — bold black-pill CTAs and stark white canvas for marketing, paired with vibrant gradient product cards (orange-red, magenta-pink, purple, blue) that turn each model release into a distinctive visual identity. The system uses DM Sans across all surfaces, employs an oversized 80px hero display, anchors major actions in deep near-black pills, and layers content density via a 3-column documentation grid with sidebar nav, prose body, and TOC. Coverage spans the marketing homepage, model showcase pages, developer documentation, and platform pricing surfaces.
+
+colors:
+  primary: "#0a0a0a"
+  on-primary: "#ffffff"
+  primary-soft: "#181e25"
+  brand-coral: "#ff5530"
+  brand-magenta: "#ea5ec1"
+  brand-blue: "#1456f0"
+  brand-blue-mid: "#3b82f6"
+  brand-blue-deep: "#1d4ed8"
+  brand-blue-700: "#17437d"
+  brand-cyan: "#3daeff"
+  brand-blue-200: "#bfdbfe"
+  brand-purple: "#a855f7"
+  canvas: "#ffffff"
+  surface: "#f7f8fa"
+  surface-soft: "#f2f3f5"
+  hairline: "#e5e7eb"
+  hairline-soft: "#eaecf0"
+  ink: "#0a0a0a"
+  ink-strong: "#000000"
+  charcoal: "#222222"
+  slate: "#45515e"
+  steel: "#5f5f5f"
+  stone: "#8e8e93"
+  muted: "#a8aab2"
+  success-bg: "#e8ffea"
+  success-text: "#1ba673"
+  on-dark: "#ffffff"
+  footer-bg: "#0a0a0a"
+
+typography:
+  hero-display:
+    fontFamily: DM Sans
+    fontSize: 80px
+    fontWeight: 600
+    lineHeight: 1.10
+    letterSpacing: -2px
+  display-lg:
+    fontFamily: DM Sans
+    fontSize: 56px
+    fontWeight: 600
+    lineHeight: 1.10
+    letterSpacing: -1.5px
+  heading-lg:
+    fontFamily: DM Sans
+    fontSize: 40px
+    fontWeight: 600
+    lineHeight: 1.20
+    letterSpacing: -1px
+  heading-md:
+    fontFamily: DM Sans
+    fontSize: 32px
+    fontWeight: 600
+    lineHeight: 1.25
+    letterSpacing: -0.5px
+  heading-sm:
+    fontFamily: DM Sans
+    fontSize: 24px
+    fontWeight: 600
+    lineHeight: 1.30
+  card-title:
+    fontFamily: DM Sans
+    fontSize: 20px
+    fontWeight: 600
+    lineHeight: 1.40
+  subtitle:
+    fontFamily: DM Sans
+    fontSize: 18px
+    fontWeight: 500
+    lineHeight: 1.50
+  body-md:
+    fontFamily: DM Sans
+    fontSize: 16px
+    fontWeight: 400
+    lineHeight: 1.50
+  body-md-bold:
+    fontFamily: DM Sans
+    fontSize: 16px
+    fontWeight: 700
+    lineHeight: 1.50
+  body-sm:
+    fontFamily: DM Sans
+    fontSize: 14px
+    fontWeight: 400
+    lineHeight: 1.50
+  body-sm-medium:
+    fontFamily: DM Sans
+    fontSize: 14px
+    fontWeight: 500
+    lineHeight: 1.50
+  caption:
+    fontFamily: DM Sans
+    fontSize: 13px
+    fontWeight: 400
+    lineHeight: 1.70
+  caption-bold:
+    fontFamily: DM Sans
+    fontSize: 13px
+    fontWeight: 600
+    lineHeight: 1.50
+  micro:
+    fontFamily: DM Sans
+    fontSize: 12px
+    fontWeight: 400
+    lineHeight: 1.50
+  button-md:
+    fontFamily: DM Sans
+    fontSize: 14px
+    fontWeight: 600
+    lineHeight: 1.40
+
+rounded:
+  xs: 4px
+  sm: 6px
+  md: 8px
+  lg: 12px
+  xl: 16px
+  xxl: 20px
+  xxxl: 24px
+  hero: 32px
+  full: 9999px
+
+spacing:
+  xxs: 4px
+  xs: 8px
+  sm: 12px
+  md: 16px
+  lg: 20px
+  xl: 24px
+  xxl: 32px
+  xxxl: 40px
+  section-sm: 48px
+  section: 64px
+  section-lg: 80px
+  hero: 96px
+
+components:
+  button-primary:
+    backgroundColor: "{colors.primary}"
+    textColor: "{colors.on-primary}"
+    typography: "{typography.button-md}"
+    rounded: "{rounded.full}"
+    padding: "11px 24px"
+  button-primary-pressed:
+    backgroundColor: "{colors.charcoal}"
+    textColor: "{colors.on-primary}"
+  button-primary-disabled:
+    backgroundColor: "{colors.hairline}"
+    textColor: "{colors.muted}"
+  button-secondary:
+    backgroundColor: "transparent"
+    textColor: "{colors.ink}"
+    typography: "{typography.button-md}"
+    rounded: "{rounded.full}"
+    padding: "11px 24px"
+    border: "1px solid {colors.ink}"
+  button-tertiary:
+    backgroundColor: "{colors.canvas}"
+    textColor: "{colors.ink}"
+    typography: "{typography.button-md}"
+    rounded: "{rounded.full}"
+    padding: "11px 24px"
+    border: "1px solid {colors.hairline}"
+  button-link:
+    backgroundColor: "transparent"
+    textColor: "{colors.ink}"
+    typography: "{typography.body-sm-medium}"
+    padding: "8px 0"
+  button-icon-circular:
+    backgroundColor: "{colors.canvas}"
+    textColor: "{colors.ink}"
+    rounded: "{rounded.full}"
+    size: 36px
+    border: "1px solid {colors.hairline}"
+  product-card-coral:
+    backgroundColor: "{colors.brand-coral}"
+    textColor: "{colors.on-dark}"
+    rounded: "{rounded.hero}"
+    padding: "{spacing.xxl}"
+  product-card-magenta:
+    backgroundColor: "{colors.brand-magenta}"
+    textColor: "{colors.on-dark}"
+    rounded: "{rounded.hero}"
+    padding: "{spacing.xxl}"
+  product-card-blue:
+    backgroundColor: "{colors.brand-blue}"
+    textColor: "{colors.on-dark}"
+    rounded: "{rounded.hero}"
+    padding: "{spacing.xxl}"
+  product-card-purple:
+    backgroundColor: "{colors.brand-purple}"
+    textColor: "{colors.on-dark}"
+    rounded: "{rounded.hero}"
+    padding: "{spacing.xxl}"
+  product-card-photo:
+    backgroundColor: "{colors.primary}"
+    textColor: "{colors.on-dark}"
+    rounded: "{rounded.hero}"
+    padding: "{spacing.xxl}"
+  card-base:
+    backgroundColor: "{colors.canvas}"
+    rounded: "{rounded.xl}"
+    padding: "{spacing.xl}"
+    border: "1px solid {colors.hairline}"
+  card-feature:
+    backgroundColor: "{colors.surface}"
+    rounded: "{rounded.xl}"
+    padding: "{spacing.xxl}"
+  card-recommendation:
+    backgroundColor: "{colors.canvas}"
+    rounded: "{rounded.lg}"
+    padding: "{spacing.lg}"
+    border: "1px solid {colors.hairline}"
+  promo-cta-card:
+    backgroundColor: "{colors.brand-coral}"
+    textColor: "{colors.on-dark}"
+    rounded: "{rounded.hero}"
+    padding: "{spacing.section}"
+  text-input:
+    backgroundColor: "{colors.canvas}"
+    textColor: "{colors.ink}"
+    typography: "{typography.body-md}"
+    rounded: "{rounded.md}"
+    padding: "{spacing.sm} {spacing.md}"
+    border: "1px solid {colors.hairline}"
+    height: 40px
+  text-input-focused:
+    backgroundColor: "{colors.canvas}"
+    textColor: "{colors.ink}"
+    border: "2px solid {colors.brand-blue-deep}"
+  text-input-error:
+    backgroundColor: "{colors.canvas}"
+    textColor: "{colors.ink}"
+    border: "1px solid #d45656"
+  search-pill:
+    backgroundColor: "{colors.surface}"
+    textColor: "{colors.steel}"
+    typography: "{typography.body-sm}"
+    rounded: "{rounded.md}"
+    padding: "{spacing.xs} {spacing.md}"
+    height: 36px
+    border: "1px solid {colors.hairline}"
+  segmented-tab:
+    backgroundColor: "transparent"
+    textColor: "{colors.steel}"
+    typography: "{typography.button-md}"
+    rounded: "0"
+    padding: "{spacing.md} {spacing.lg}"
+    border: "0 0 2px transparent solid"
+  segmented-tab-active:
+    backgroundColor: "transparent"
+    textColor: "{colors.ink}"
+    typography: "{typography.button-md}"
+    border: "0 0 2px {colors.ink} solid"
+  pill-tab:
+    backgroundColor: "{colors.canvas}"
+    textColor: "{colors.steel}"
+    typography: "{typography.body-sm-medium}"
+    rounded: "{rounded.full}"
+    padding: "{spacing.xs} {spacing.md}"
+    border: "1px solid {colors.hairline}"
+  pill-tab-active:
+    backgroundColor: "{colors.primary}"
+    textColor: "{colors.on-primary}"
+    rounded: "{rounded.full}"
+    border: "1px solid {colors.primary}"
+  badge-success:
+    backgroundColor: "{colors.success-bg}"
+    textColor: "{colors.success-text}"
+    typography: "{typography.caption-bold}"
+    rounded: "{rounded.full}"
+    padding: "4px 10px"
+  badge-new:
+    backgroundColor: "{colors.brand-coral}"
+    textColor: "{colors.on-dark}"
+    typography: "{typography.caption-bold}"
+    rounded: "{rounded.full}"
+    padding: "4px 10px"
+  badge-beta:
+    backgroundColor: "{colors.brand-blue-200}"
+    textColor: "{colors.brand-blue-deep}"
+    typography: "{typography.caption-bold}"
+    rounded: "{rounded.full}"
+    padding: "4px 10px"
+  badge-code:
+    backgroundColor: "{colors.brand-blue-200}"
+    textColor: "{colors.brand-blue-deep}"
+    typography: "{typography.caption-bold}"
+    rounded: "{rounded.sm}"
+    padding: "2px 6px"
+  promo-banner:
+    backgroundColor: "{colors.primary}"
+    textColor: "{colors.on-primary}"
+    typography: "{typography.body-sm-medium}"
+    padding: "{spacing.sm} {spacing.lg}"
+  data-table:
+    backgroundColor: "{colors.canvas}"
+    textColor: "{colors.ink}"
+    typography: "{typography.body-sm}"
+    rounded: "{rounded.md}"
+    border: "1px solid {colors.hairline}"
+  data-table-header:
+    backgroundColor: "{colors.surface}"
+    textColor: "{colors.steel}"
+    typography: "{typography.caption-bold}"
+    padding: "{spacing.sm} {spacing.md}"
+  data-table-row:
+    backgroundColor: "{colors.canvas}"
+    textColor: "{colors.ink}"
+    typography: "{typography.body-sm}"
+    padding: "{spacing.md}"
+    border: "0 0 1px {colors.hairline-soft} solid"
+  sidebar-nav-item:
+    backgroundColor: "transparent"
+    textColor: "{colors.charcoal}"
+    typography: "{typography.body-sm}"
+    rounded: "{rounded.sm}"
+    padding: "{spacing.xs} {spacing.md}"
+  sidebar-nav-item-active:
+    backgroundColor: "{colors.surface}"
+    textColor: "{colors.ink}"
+    typography: "{typography.body-sm-medium}"
+  doc-toc-item:
+    backgroundColor: "transparent"
+    textColor: "{colors.steel}"
+    typography: "{typography.body-sm}"
+    padding: "{spacing.xs} 0"
+  ai-product-tile:
+    backgroundColor: "{colors.canvas}"
+    rounded: "{rounded.xxxl}"
+    padding: "{spacing.xl}"
+    border: "1px solid {colors.hairline}"
+  footer-region:
+    backgroundColor: "{colors.footer-bg}"
+    textColor: "{colors.on-dark}"
+    typography: "{typography.body-sm}"
+    padding: "{spacing.section} {spacing.xxl}"
+  footer-link:
+    backgroundColor: "transparent"
+    textColor: "{colors.muted}"
+    typography: "{typography.body-sm}"
+    padding: "{spacing.xxs} 0"
+  hero-band-marketing:
+    backgroundColor: "{colors.canvas}"
+    textColor: "{colors.ink}"
+    typography: "{typography.hero-display}"
+    rounded: "{rounded.lg}"
+    padding: "{spacing.hero}"
+  product-matrix-grid:
+    backgroundColor: "{colors.canvas}"
+    rounded: "{rounded.hero}"
+    padding: "{spacing.xxl}"
+  ai-product-matrix:
+    backgroundColor: "{colors.canvas}"
+    rounded: "{rounded.xxxl}"
+    padding: "{spacing.xl}"
+    border: "1px solid {colors.hairline}"
+  docs-prose-block:
+    backgroundColor: "{colors.canvas}"
+    textColor: "{colors.charcoal}"
+    typography: "{typography.body-md}"
+    padding: "{spacing.xxl}"
+  models-comparison-table:
+    backgroundColor: "{colors.canvas}"
+    textColor: "{colors.ink}"
+    typography: "{typography.body-sm}"
+    rounded: "{rounded.md}"
+    border: "1px solid {colors.hairline}"
+  testimonial-stat-row:
+    backgroundColor: "{colors.canvas}"
+    textColor: "{colors.ink}"
+    typography: "{typography.heading-lg}"
+    padding: "{spacing.xl}"
+---
+
+## Overview
+
+MiniMax stages itself as a Chinese AI infrastructure brand with a sophisticated dual identity. Marketing surfaces and platform pages anchor in stark white canvas with deep-black typographic emphasis — the brand voice is confident, technical, almost editorial. But each model release gets its own vibrant gradient identity card: M2.7 in volcanic coral-red, Music 2.6 in magenta-pink, Hailuo in deep blue, Speech 2.8 in saturated orange-purple. Together these vibrant tiles read like album covers laid out on the homepage — each one declaring its own product personality.
+
+DM Sans anchors every surface from oversized 80px hero displays down to 12px micro labels. The geometric, slightly humanist character of the face suits both the dense documentation surfaces (where 14px body type carries 1.5 line-height for long-form prose) and the high-impact marketing displays (where -2px letter-spacing tightens 80px headlines). Buttons are universally pill-shaped (`rounded-full`) with a sharp two-tier system: black-pill primary (the dominant CTA) and outline-pill secondary. Cards split into two distinct families: vibrant gradient product showcases (32px corner softening) and quiet white documentation cards (16px corner softening).
+
+**Key Characteristics:**
+- Stark monochrome palette — black ({colors.primary}) and white ({colors.canvas}) — broken open by saturated brand-color gradient cards
+- Distinct product-color encoding: each model line has its own vibrant brand color (coral M2.7, magenta Music 2.6, blue Hailuo, orange Speech 2.8)
+- DM Sans across the entire system; Inter as fallback
+- Pill-shaped buttons ({rounded.full}) and pill-shaped tabs everywhere; rectangular forms only inside data tables and dense docs
+- Hero typography uses tight 1.10 line-height with -2px letter-spacing for impact
+- Documentation surfaces use a 3-column layout: left sidebar nav, center prose body, right table-of-contents
+- Black promo banners ({colors.primary}) above the nav for time-bound brand moments
+
+## Colors
+
+> Source pages: minimax.io/ (homepage), /models/text/m27 (product showcase), platform.minimax.io/docs/guides/models-intro (documentation), /subscribe/token-plan (pricing). Token coverage was identical across all four pages.
+
+### Brand & Accent
+- **Brand Coral** ({colors.brand-coral}): Signature high-impact accent. Used on M2.7 product card, "Token Plan" hero band, promo CTA strips, and "NEW" badges. Carries the brand's most attention-grabbing energy.
+- **Brand Magenta** ({colors.brand-magenta}): Secondary product-card identity (Music 2.6); used for music/audio product encoding.
+- **Brand Blue** ({colors.brand-blue}): Hailuo video product identity; primary blue accent across the system.
+- **Brand Blue Deep** ({colors.brand-blue-deep}): Form-control activation, link emphasis.
+- **Brand Blue 700** ({colors.brand-blue-700}): Documentation tag and reference text color.
+- **Brand Cyan** ({colors.brand-cyan}): Atmospheric blue for product gradients and decorative wash.
+- **Brand Blue 200** ({colors.brand-blue-200}): Code badges, info-tag backgrounds.
+- **Brand Purple** ({colors.brand-purple}): Speech 2.8 and minor purple-product identity; gradient mate for magenta cards.
+
+### Surface
+- **Canvas White** ({colors.canvas}): Primary page background and card surface.
+- **Surface** ({colors.surface}): Subtle section backgrounds, search-pill rest, sidebar-nav active state.
+- **Surface Soft** ({colors.surface-soft}): Quieter section divisions.
+- **Hairline** ({colors.hairline}): 1px input border and primary divider.
+- **Hairline Soft** ({colors.hairline-soft}): Quieter table-row divider and secondary section break.
+
+### Text
+- **Ink** ({colors.ink}): Primary headline and CTA text — the brand's near-black anchor.
+- **Ink Strong** ({colors.ink-strong}): Pure black used in promo banners and hero displays for maximum contrast.
+- **Charcoal** ({colors.charcoal}): Body text on light surfaces.
+- **Slate** ({colors.slate}): Secondary text, metadata.
+- **Steel** ({colors.steel}): Tertiary text, table headers, sidebar inactive items.
+- **Stone** ({colors.stone}): Muted captions and tab inactive labels.
+- **Muted** ({colors.muted}): Footer link text and de-emphasized labels.
+
+### Semantic
+- **Success Background** ({colors.success-bg}): Pale-green wash for success badges and confirmations.
+- **Success Text** ({colors.success-text}): Deep-green ink for success badge labels.
+- Error tones derive from a `#d45656` red used in input border error states (not extracted as a top-level system token).
+
+## Typography
+
+### Font Family
+**DM Sans** (primary): Geometric variable sans-serif. Used across every surface, every role. Fallbacks: Inter, Helvetica Neue, Helvetica, Arial.
+
+DM Sans was chosen for its dual fluency: it scales cleanly from 80px hero displays (where -2px letter-spacing creates magazine-grade tightness) down to 12px micro labels (where the slightly humanist counters maintain legibility). The face has no italic variant in the brand's deployment — emphasis comes from weight (500/600/700) instead.
+
+### Hierarchy
+
+| Token | Size | Weight | Line Height | Letter Spacing | Use |
+|---|---|---|---|---|---|
+| `{typography.hero-display}` | 80px | 600 | 1.10 | -2px | Homepage hero ("MiniMax Music 2.6") |
+| `{typography.display-lg}` | 56px | 600 | 1.10 | -1.5px | Section openers, major page heroes |
+| `{typography.heading-lg}` | 40px | 600 | 1.20 | -1px | Sub-page headlines ("Token Plan", "Models Overview") |
+| `{typography.heading-md}` | 32px | 600 | 1.25 | -0.5px | Subsection headers ("Full-Stack Model Matrix") |
+| `{typography.heading-sm}` | 24px | 600 | 1.30 | 0 | Card titles, feature headers |
+| `{typography.card-title}` | 20px | 600 | 1.40 | 0 | Product-card titles, feature-tile headers |
+| `{typography.subtitle}` | 18px | 500 | 1.50 | 0 | Section subtitles, lead body |
+| `{typography.body-md}` | 16px | 400 | 1.50 | 0 | Primary body text |
+| `{typography.body-md-bold}` | 16px | 700 | 1.50 | 0 | Body emphasis |
+| `{typography.body-sm}` | 14px | 400 | 1.50 | 0 | Secondary body, table cells, navigation |
+| `{typography.body-sm-medium}` | 14px | 500 | 1.50 | 0 | Active sidebar nav, button labels |
+| `{typography.caption}` | 13px | 400 | 1.70 | 0 | Documentation captions, fine print |
+| `{typography.caption-bold}` | 13px | 600 | 1.50 | 0 | Badge labels, table-header text |
+| `{typography.micro}` | 12px | 400 | 1.50 | 0 | Footer microcopy, chip labels |
+| `{typography.button-md}` | 14px | 600 | 1.40 | 0 | Pill button labels |
+
+### Principles
+- **Tight hero leading** (1.10) and aggressive negative letter-spacing on display sizes create a magazine-quality typographic display unique to MiniMax.
+- **Generous body leading** (1.50) keeps long-form documentation comfortable; captions push to 1.70 for scientific-paper-grade clarity.
+- **Weight discipline:** 400 (body), 500 (medium emphasis), 600 (headings/buttons), 700 (strong inline emphasis). Heavier weights are not used.
+- **Single typeface** strategy — never mix DM Sans with another sans-serif. Code samples (when shown) use a system monospace fallback, but no second typeface enters the brand canvas.
+
+## Layout
+
+### Spacing System
+- **Base unit**: 4px (8px primary increment).
+- **Tokens**: `{spacing.xxs}` (4px) · `{spacing.xs}` (8px) · `{spacing.sm}` (12px) · `{spacing.md}` (16px) · `{spacing.lg}` (20px) · `{spacing.xl}` (24px) · `{spacing.xxl}` (32px) · `{spacing.xxxl}` (40px) · `{spacing.section-sm}` (48px) · `{spacing.section}` (64px) · `{spacing.section-lg}` (80px) · `{spacing.hero}` (96px).
+- **Section rhythm**: Marketing pages separate at `{spacing.hero}` (96px) above-fold, then `{spacing.section-lg}` (80px) below; documentation tightens to `{spacing.section}` (64px); table rows compress to `{spacing.md}` (16px).
+- **Card internal padding**: Vibrant product cards use `{spacing.xxl}` (32px); documentation cards use `{spacing.lg}–{spacing.xl}` (20–24px); promo strips expand to `{spacing.section}` (64px).
+
+### Grid & Container
+- Marketing pages use a 1280px max-width with 32px gutters.
+- Homepage product matrix renders as a 4-column row of 32px-rounded gradient cards, each ~280–320px wide.
+- AI Product Matrix below uses a 4-column grid with 16px-rounded white cards.
+- Documentation surfaces use a 3-column layout: left sidebar nav (~220px), center prose body (~720px max-width), right TOC (~180px). Sidebar persists on desktop; collapses to drawer below 1024px.
+- Token Plan / pricing pages use 2-column tabs above a 3-column tier card grid.
+
+### Whitespace Philosophy
+Marketing pages give product photography and color cards generous breathing room — `{spacing.hero}` (96px) above-the-fold creates visual oxygen for the 80px hero display. Inside documentation, whitespace tightens dramatically: section gaps drop to `{spacing.xxl}` (32px), table rows pack down to `{spacing.md}` (16px), and the sidebar nav uses `{spacing.xs}` (8px) vertical rhythm.
+
+## Elevation & Depth
+
+The system runs predominantly flat. Elevation is reserved for sticky panels, dropdowns, and the rare floating CTA.
+
+| Level | Treatment | Use |
+|---|---|---|
+| 0 (flat) | No shadow; `{colors.hairline}` border | Default cards, table rows, form inputs |
+| 1 (subtle) | `rgba(0, 0, 0, 0.04) 0px 1px 2px 0px` | Card-recommendation, hover-elevated tiles |
+| 2 (card) | `rgba(0, 0, 0, 0.08) 0px 4px 6px 0px` | Standard feature cards, dropdowns |
+| 3 (atmospheric) | `rgba(0, 0, 0, 0.08) 0px 0px 22px 0px` | Diffuse glow on featured product cards |
+| 4 (modal) | `rgba(36, 36, 36, 0.08) 0px 12px 16px -4px` | Modals, confirmation dialogs, sticky panels |
+
+### Decorative Depth
+- The vibrant gradient product cards carry their own atmospheric depth via internal radial gradients and silhouette imagery — no shadow needed; the color does the work.
+- Brand-tinted shadows (`rgba(44, 30, 116, 0.16) 0px 0px 15px`) appear under purple-themed cards for subtle ambient lift.
+- Dotted/grain textures occasionally appear inside product cards as photographic-content decoration; these are not formalized as system tokens.
+
+## Shapes
+
+### Border Radius Scale
+
+| Token | Value | Use |
+|---|---|---|
+| `{rounded.xs}` | 4px | Code chips, micro-controls |
+| `{rounded.sm}` | 6px | Compact controls, table cells |
+| `{rounded.md}` | 8px | Inputs, secondary buttons, search pill |
+| `{rounded.lg}` | 12px | Documentation cards, recommendation tiles |
+| `{rounded.xl}` | 16px | Standard feature cards, AI product tiles |
+| `{rounded.xxl}` | 20px | Larger feature panels |
+| `{rounded.xxxl}` | 24px | AI product tile feature variants |
+| `{rounded.hero}` | 32px | Vibrant gradient product cards, promo CTA strip |
+| `{rounded.full}` | 9999px | All buttons, all pill tabs, badges |
+
+### Photography Geometry
+- Vibrant product cards use 32px corner softening — distinct from the 16px used on quiet white cards. The doubled radius is the visual signature of "this is a featured product moment."
+- Product imagery inside cards is treated as photographic content (silhouettes, dark portrait studio lighting) without rounded internal frames.
+- Avatar circles (rare, in testimonials) are `{rounded.full}` — perfect circles.
+
+## Components
+
+> Per the no-hover policy, hover states are NOT documented. Default and pressed/active states only.
+
+### Buttons
+
+**`button-primary`** — Black pill primary CTA, the dominant action across all surfaces.
+- Background `{colors.primary}`, text `{colors.on-primary}`, typography `{typography.button-md}`, padding `11px 24px`, rounded `{rounded.full}`.
+- Pressed state `button-primary-pressed` lifts to `{colors.charcoal}`.
+- Disabled state `button-primary-disabled` uses `{colors.hairline}` background and `{colors.muted}` text.
+
+**`button-secondary`** — Outlined pill secondary action, paired with primary in dual-CTA hero patterns.
+- Background transparent, text `{colors.ink}`, border `1px solid {colors.ink}`, typography `{typography.button-md}`, padding `11px 24px`, rounded `{rounded.full}`.
+
+**`button-tertiary`** — White-fill quieter pill, used for tertiary nav and informational CTAs.
+- Background `{colors.canvas}`, text `{colors.ink}`, border `1px solid {colors.hairline}`, typography `{typography.button-md}`, padding `11px 24px`, rounded `{rounded.full}`.
+
+**`button-link`** — Inline text link styled as a subtle button.
+- Background transparent, text `{colors.ink}`, typography `{typography.body-sm-medium}`, padding `8px 0`. Underline appears on activation.
+
+**`button-icon-circular`** — 36×36px circular utility button (carousel arrows, share, copy).
+- Background `{colors.canvas}`, text `{colors.ink}`, border `1px solid {colors.hairline}`, rounded `{rounded.full}`.
+
+### Vibrant Product Cards
+
+**`product-card-coral`** — M2.7 / Token Plan signature card.
+- Background `{colors.brand-coral}`, text `{colors.on-dark}`, rounded `{rounded.hero}` (32px), padding `{spacing.xxl}`.
+- Hosts the M2.7 wordmark in massive `{typography.display-lg}` with white tagline.
+
+**`product-card-magenta`** — Music 2.6 product showcase.
+- Background `{colors.brand-magenta}`, text `{colors.on-dark}`, rounded `{rounded.hero}`, padding `{spacing.xxl}`.
+
+**`product-card-blue`** — Hailuo Video product showcase.
+- Background `{colors.brand-blue}`, text `{colors.on-dark}`, rounded `{rounded.hero}`, padding `{spacing.xxl}`.
+
+**`product-card-purple`** — Speech 2.8 / variant product showcase.
+- Background `{colors.brand-purple}`, text `{colors.on-dark}`, rounded `{rounded.hero}`, padding `{spacing.xxl}`.
+
+**`product-card-photo`** — Dark portrait product card (homepage S2 placement, video-emotion product).
+- Background `{colors.primary}` (black with overlaid product photo), text `{colors.on-dark}`, rounded `{rounded.hero}`, padding `{spacing.xxl}`.
+
+### Cards & Containers
+
+**`card-base`** — Standard documentation/feature card.
+- Background `{colors.canvas}`, rounded `{rounded.xl}`, padding `{spacing.xl}`, border `1px solid {colors.hairline}`.
+
+**`card-feature`** — Quieter feature panel on light gray.
+- Background `{colors.surface}`, rounded `{rounded.xl}`, padding `{spacing.xxl}`.
+
+**`card-recommendation`** — "Recommended Reading" tile in documentation footer.
+- Background `{colors.canvas}`, rounded `{rounded.lg}`, padding `{spacing.lg}`, border `1px solid {colors.hairline}`.
+
+**`promo-cta-card`** — Bright orange "Refunds of 10%..." promo strip with embedded CTA pill.
+- Background `{colors.brand-coral}`, text `{colors.on-dark}`, rounded `{rounded.hero}`, padding `{spacing.section}`. Embedded button uses `button-tertiary` (white pill on coral) for the "Join Now" action.
+
+**`ai-product-tile`** — White card in the AI Product Matrix grid (Agent, Hailuo Video, MiniMax Audio).
+- Background `{colors.canvas}`, rounded `{rounded.xxxl}`, padding `{spacing.xl}`, border `1px solid {colors.hairline}`. Carries an icon/illustration top, title `{typography.card-title}`, description `{typography.body-sm}`.
+
+### Inputs & Forms
+
+**`text-input`** — Standard text field.
+- Background `{colors.canvas}`, text `{colors.ink}`, border `1px solid {colors.hairline}`, rounded `{rounded.md}`, padding `{spacing.sm} {spacing.md}`, height 40px.
+
+**`text-input-focused`** — Activated state.
+- Border switches to `2px solid {colors.brand-blue-deep}`.
+
+**`text-input-error`** — Validation error state.
+- Border switches to `1px solid #d45656`; error label below in matching red `{typography.body-sm}`.
+
+**`search-pill`** — Documentation top-bar search field.
+- Background `{colors.surface}`, text `{colors.steel}`, typography `{typography.body-sm}`, rounded `{rounded.md}`, height 36px, border `1px solid {colors.hairline}`.
+
+### Tabs
+
+**`segmented-tab`** + **`segmented-tab-active`** — Underline-style tab navigation (Benchmark / Self-Evaluation / Multi-Agent Collaboration on the M2.7 page).
+- Inactive: text `{colors.steel}`, transparent background, padding `{spacing.md} {spacing.lg}`. Active: text shifts to `{colors.ink}`, 2px bottom border in `{colors.ink}`.
+
+**`pill-tab`** + **`pill-tab-active`** — Pricing-page tab nav (Token Plan / Audio Subscription / Video Package).
+- Inactive: background `{colors.canvas}`, text `{colors.steel}`, border `1px solid {colors.hairline}`, padding `{spacing.xs} {spacing.md}`, rounded `{rounded.full}`.
+- Active: background `{colors.primary}`, text `{colors.on-primary}`, no border (or matching black border).
+
+### Badges & Status
+
+**`badge-success`** — Pale-green confirmation badge ("Available", "Active").
+- Background `{colors.success-bg}`, text `{colors.success-text}`, typography `{typography.caption-bold}`, rounded `{rounded.full}`, padding `4px 10px`.
+
+**`badge-new`** — Coral "NEW" / "Live" pill for fresh releases.
+- Background `{colors.brand-coral}`, text `{colors.on-dark}`, typography `{typography.caption-bold}`, rounded `{rounded.full}`, padding `4px 10px`.
+
+**`badge-beta`** — Pale-blue "BETA" / informational pill.
+- Background `{colors.brand-blue-200}`, text `{colors.brand-blue-deep}`, typography `{typography.caption-bold}`, rounded `{rounded.full}`, padding `4px 10px`.
+
+**`badge-code`** — Inline code-style chip ("Code", "API").
+- Background `{colors.brand-blue-200}`, text `{colors.brand-blue-deep}`, typography `{typography.caption-bold}`, rounded `{rounded.sm}`, padding `2px 6px`.
+
+**`promo-banner`** — Sticky black promotional strip ABOVE the top nav ("Invite & Earn — Rewards for Both!").
+- Background `{colors.primary}`, text `{colors.on-primary}`, typography `{typography.body-sm-medium}`, padding `{spacing.sm} {spacing.lg}`. Carries one-line copy with optional inline link.
+
+### Data Tables
+
+**`data-table`** — Documentation models comparison table.
+- Background `{colors.canvas}`, text `{colors.ink}`, typography `{typography.body-sm}`, rounded `{rounded.md}`, border `1px solid {colors.hairline}`.
+
+**`data-table-header`** — Top header row of the data table.
+- Background `{colors.surface}`, text `{colors.steel}`, typography `{typography.caption-bold}`, padding `{spacing.sm} {spacing.md}`.
+
+**`data-table-row`** — Body rows.
+- Background `{colors.canvas}`, text `{colors.ink}`, typography `{typography.body-sm}`, padding `{spacing.md}`, bottom border `1px solid {colors.hairline-soft}`.
+
+### Navigation
+
+**Top Navigation (Marketing)** — Sticky white bar with logo, link list, and right-side CTAs.
+- Background `{colors.canvas}`, height ~64px, bottom border `1px solid {colors.hairline-soft}`.
+- Left: MiniMax wordmark + horizontal link list (Models, Product, API, Company).
+- Right: black-pill "Contact Us" + outlined-pill "Login".
+
+**Top Navigation (Documentation/Platform)** — Compressed nav with center search-pill and right-side account/upgrade CTAs.
+- Background `{colors.canvas}`, height ~56px, with search-pill at center and "Documentation / Account / Subscribe" links + black-pill "Sign Up" right.
+
+**`sidebar-nav-item`** + **`sidebar-nav-item-active`** — Documentation left rail link entries.
+- Inactive: background transparent, text `{colors.charcoal}`, typography `{typography.body-sm}`, rounded `{rounded.sm}`, padding `{spacing.xs} {spacing.md}`.
+- Active: background `{colors.surface}`, text `{colors.ink}`, typography `{typography.body-sm-medium}`.
+
+**`doc-toc-item`** — Right-rail table-of-contents links.
+- Background transparent, text `{colors.steel}`, typography `{typography.body-sm}`, padding `{spacing.xs} 0`. Active item color shifts to `{colors.ink}`.
+
+### Signature Components
+
+**`hero-band-marketing`** — Centered hero with massive 80px display + dual-CTA pair.
+- Layout: centered headline in `{typography.hero-display}` ({colors.ink}), centered subtitle in `{typography.subtitle}` ({colors.steel}), centered button row (`button-primary` + `button-secondary`).
+
+**`product-matrix-grid`** — 4-column horizontal scroll of vibrant gradient product cards (homepage "Full-Stack Model Matrix").
+- Each tile uses one of the `product-card-*` variants (coral, magenta, blue, purple, photo).
+- Card title in `{typography.display-lg}` (M2.7 wordmark) or `{typography.heading-lg}` (Music 2.6).
+- Below the wordmark: thin tagline in `{typography.body-sm}` 80% white opacity.
+- Optional badge top-right: `badge-new`.
+- Card heights are uniform (~360–400px); the row scrolls horizontally on mobile.
+
+**`ai-product-matrix`** — 4-column grid of white product tiles below the vibrant matrix (Agent / Hailuo Video / Audio / Video).
+- Each tile is `ai-product-tile` chrome.
+- Top: 100px-tall illustration zone (often line-art icon or 3D mark).
+- Below: title in `{typography.card-title}`, description in `{typography.body-sm}` `{colors.steel}`.
+
+**`docs-prose-block`** — Documentation main content area.
+- Max-width ~720px, centered. Body in `{typography.body-md}` `{colors.charcoal}` line-height 1.6.
+- Inline code in `{typography.body-md}` monospace fallback with `{colors.surface}` background and `{rounded.xs}` corners.
+
+**`models-comparison-table`** — Documentation table comparing model sizes and features.
+- Uses `data-table` chrome. Each row carries a model name (linkified, in `{colors.ink}` body-sm-medium), a description column (`{colors.charcoal}`), and a features bullet list column.
+
+**`testimonial-stat-row`** — Stats strip ("214,000+ Enterprise Clients & Developers", "0+ Countries Served").
+- Horizontal row of 4 stat cells, each cell with a large number in `{typography.heading-lg}` `{colors.ink}` and a label below in `{typography.body-sm}` `{colors.steel}`.
+
+**`footer-region`** — Dense black-canvas multi-column footer.
+- Background `{colors.footer-bg}`, padding `{spacing.section} {spacing.xxl}`.
+- Top row: MiniMax wordmark ("intelligence with everyone" tagline) and social icons (X, Twitter, GitHub, etc.).
+- Body: 4-column link grid (Research / Product / API / Company / News).
+- Section headers in `{typography.body-sm-medium}` `{colors.on-dark}`.
+
+**`footer-link`** — Individual link entry inside the footer column.
+- Background transparent, text `{colors.muted}`, typography `{typography.body-sm}`, padding `{spacing.xxs} 0`. Active/visited states do not change color — only opacity shifts on activation.
+
+## Do's and Don'ts
+
+### Do
+- Use `{colors.primary}` (black) as the dominant CTA — it's the brand's most recognizable interactive element.
+- Reserve product brand colors (`{colors.brand-coral}`, `{colors.brand-magenta}`, `{colors.brand-blue}`, `{colors.brand-purple}`) ONLY for product-identity moments — never for general buttons or text.
+- Pair `{rounded.hero}` (32px) gradient cards with `{rounded.xl}` (16px) white cards in the same viewport — the radius contrast is the visual signature.
+- Apply `{rounded.full}` to every button, every pill tab, every badge.
+- Use `{typography.hero-display}` (80px) with -2px letter-spacing for hero displays — never compromise the leading or letter-spacing.
+- Treat each model/product line as a distinct color identity. M2.7 is coral, Music is magenta, Hailuo is blue. These are brand assignments, not free choices.
+
+### Don't
+- Don't use brand-coral or brand-magenta on body text or large surfaces — they lose meaning when overused.
+- Don't soften corners on buttons (anything less than `{rounded.full}`); the pill is a brand signature.
+- Don't introduce a second display typeface; DM Sans handles every role.
+- Don't reduce hero leading below 1.10 — the brand needs that breathing room on the 80px display.
+- Don't apply heavy shadows on white cards; flat-with-borders is the documentation default.
+- Don't put gradient backgrounds on standard buttons; gradients are reserved for product-card identity moments.
+
+## Responsive Behavior
+
+### Breakpoints
+| Name | Width | Key Changes |
+|---|---|---|
+| Mobile (small) | < 480px | Single column. Hero drops to 40px. Pill nav collapses to hamburger. Product matrix horizontal-scroll. Footer 1-column accordion. |
+| Mobile (large) | 480 – 767px | Same as small but AI product matrix renders 2-up. |
+| Tablet | 768 – 1023px | 2-column AI product matrix. Pill-tab nav returns. Documentation sidebar collapses to drawer. |
+| Desktop | 1024 – 1279px | Full 4-column product matrix; 3-column docs grid (sidebar / body / TOC). |
+| Wide Desktop | ≥ 1280px | Wider hero gutters, larger product photography, fixed 220px sidebar. |
+
+### Touch Targets
+- Pill buttons render at 38–40px effective height — bumps to 44px on mobile via padding override.
+- Circular icon buttons: 36×36px desktop → 44×44px on mobile.
+- Form inputs render at 40px height; bumps to 44px on mobile.
+- Sidebar nav items render at ~32px tall — bumps to 44px on mobile drawers.
+
+### Collapsing Strategy
+- **Promo banner** stays full-width; collapses to single line at < 480px with truncation.
+- **Top nav** below 1024px collapses to hamburger; horizontal links move into drawer.
+- **Documentation grid**: 3-column desktop → sidebar-drawer at < 1024px → single-column with collapsible sidebar at < 768px.
+- **Product matrix**: 4-column desktop → horizontal-scroll at < 1024px (carousel-style with snap points).
+- **AI Product Matrix**: 4-column → 2-column at tablet → 1-column at mobile.
+- **Hero typography**: `{typography.hero-display}` (80px) → 56px at < 1024px → 40px at < 768px → 32px at < 480px.
+- **Stats strip**: 4-column → 2×2 at < 768px → 1-column at < 480px.
+
+### Image Behavior
+- Product card imagery uses photographic content with internal gradient overlays; lazy-loaded below the fold.
+- AI product tile illustrations are SVG-based; remain crisp at all breakpoints.
+- Avatar imagery in testimonials uses 1:1 aspect ratio with `{rounded.full}` masking.
+
+## Iteration Guide
+
+1. Focus on ONE component at a time. The system has high internal consistency.
+2. Reference component names and tokens directly (`{colors.primary}`, `{component-name}-pressed`, `{rounded.full}`) — do not paraphrase.
+3. Run `npx @google/design.md lint DESIGN.md` after edits to catch broken refs and contrast issues.
+4. Add new variants as separate `components:` entries (`-pressed`, `-disabled`, `-active`).
+5. Default to `{typography.body-md}` for body and `{typography.subtitle}` for emphasis. Headlines step down `hero-display → display-lg → heading-lg → heading-md → heading-sm`.
+6. Keep brand colors (coral, magenta, blue, purple) confined to product-card identity. If a brand color appears on a standard button or generic surface, ask whether it earned that surface.
+7. Pill-shaped buttons (`{rounded.full}`) always; squared buttons signal "third-party widget" in this language.
+
+## Known Gaps
+
+- Specific dark-mode token values (canvas, surface, ink, hairline) are not surfaced on these pages; the brand has not yet shipped a published dark-mode palette.
+- Animation/transition timings are not extracted; recommend 150–200ms ease for hover/focus state transitions.
+- Form validation success state is not explicitly captured beyond defaults — implement following standard green-border + success badge patterns.
+- Code syntax highlighting palette inside docs is not formalized; documentation samples appear with system-default monospace and minimal coloring.

--- a/astro/src/data/design-md/mistral.md
+++ b/astro/src/data/design-md/mistral.md
@@ -1,0 +1,773 @@
+---
+version: alpha
+name: Mistral-AI-design-analysis
+description: Mistral AI brands itself with a singular signature — atmospheric sunset gradients (mustard, orange, deep red) layered over photography of mountains, plus a horizontal "sunset stripe" bar that closes every page. The system pairs warm cream-yellow surfaces ({colors.cream}) with a saturated orange primary CTA ({colors.primary}) and uses an elegant near-serif voice for hero displays. Coverage spans homepage (Frontier AI hero), Le Studio product page, Coding solutions, news article surfaces, contact form, and services tier page — all anchored by the signature gradient closing band.
+
+colors:
+  primary: "#fa520f"
+  primary-deep: "#cc3a05"
+  on-primary: "#ffffff"
+  sunshine-300: "#ffd06a"
+  sunshine-500: "#ffb83e"
+  sunshine-700: "#ffa110"
+  sunshine-800: "#ff8105"
+  sunshine-900: "#ff8a00"
+  yellow-saturated: "#ffd900"
+  cream: "#fff8e0"
+  cream-light: "#fffaeb"
+  cream-deeper: "#fff0c2"
+  beige-deep: "#e6d5a8"
+  block-5: "#ffe295"
+  block-6: "#ffd900"
+  block-7: "#ff8105"
+  ink: "#1f1f1f"
+  ink-tint: "#3d3d3d"
+  charcoal: "#2c2c2c"
+  slate: "#4a4a4a"
+  steel: "#6a6a6a"
+  stone: "#8a8a8a"
+  muted: "#a8a8a8"
+  hairline: "#e5e5e5"
+  hairline-soft: "#ededed"
+  hairline-strong: "#c7c7c7"
+  canvas: "#ffffff"
+  surface: "#fafafa"
+  surface-cream: "#fff8e0"
+  surface-cream-soft: "#fffaeb"
+  surface-code: "#1c1c1e"
+  on-dark: "#ffffff"
+  on-dark-muted: "#a8a8a8"
+  on-cream: "#1f1f1f"
+  footer-cream: "#fff8e0"
+  link: "#fa520f"
+
+typography:
+  hero-display:
+    fontFamily: PP Editorial Old
+    fontSize: 84px
+    fontWeight: 400
+    lineHeight: 1.05
+    letterSpacing: -1.5px
+  display-lg:
+    fontFamily: PP Editorial Old
+    fontSize: 64px
+    fontWeight: 400
+    lineHeight: 1.10
+    letterSpacing: -1px
+  heading-1:
+    fontFamily: PP Editorial Old
+    fontSize: 52px
+    fontWeight: 400
+    lineHeight: 1.15
+    letterSpacing: -0.5px
+  heading-2:
+    fontFamily: Inter
+    fontSize: 36px
+    fontWeight: 500
+    lineHeight: 1.20
+    letterSpacing: -0.5px
+  heading-3:
+    fontFamily: Inter
+    fontSize: 28px
+    fontWeight: 500
+    lineHeight: 1.25
+  heading-4:
+    fontFamily: Inter
+    fontSize: 22px
+    fontWeight: 500
+    lineHeight: 1.30
+  heading-5:
+    fontFamily: Inter
+    fontSize: 18px
+    fontWeight: 500
+    lineHeight: 1.40
+  subtitle:
+    fontFamily: Inter
+    fontSize: 18px
+    fontWeight: 400
+    lineHeight: 1.50
+  body-md:
+    fontFamily: Inter
+    fontSize: 16px
+    fontWeight: 400
+    lineHeight: 1.55
+  body-md-medium:
+    fontFamily: Inter
+    fontSize: 16px
+    fontWeight: 500
+    lineHeight: 1.55
+  body-sm:
+    fontFamily: Inter
+    fontSize: 14px
+    fontWeight: 400
+    lineHeight: 1.50
+  body-sm-medium:
+    fontFamily: Inter
+    fontSize: 14px
+    fontWeight: 500
+    lineHeight: 1.50
+  caption:
+    fontFamily: Inter
+    fontSize: 13px
+    fontWeight: 400
+    lineHeight: 1.40
+  caption-bold:
+    fontFamily: Inter
+    fontSize: 13px
+    fontWeight: 600
+    lineHeight: 1.40
+  micro:
+    fontFamily: Inter
+    fontSize: 12px
+    fontWeight: 500
+    lineHeight: 1.40
+  micro-uppercase:
+    fontFamily: Inter
+    fontSize: 11px
+    fontWeight: 600
+    lineHeight: 1.40
+    letterSpacing: 1px
+  button-md:
+    fontFamily: Inter
+    fontSize: 14px
+    fontWeight: 500
+    lineHeight: 1.30
+  stat-display:
+    fontFamily: PP Editorial Old
+    fontSize: 56px
+    fontWeight: 400
+    lineHeight: 1.10
+    letterSpacing: -1px
+  code-md:
+    fontFamily: JetBrains Mono
+    fontSize: 14px
+    fontWeight: 400
+    lineHeight: 1.50
+
+rounded:
+  xs: 4px
+  sm: 6px
+  md: 8px
+  lg: 12px
+  xl: 16px
+  xxl: 20px
+  full: 9999px
+
+spacing:
+  xxs: 4px
+  xs: 8px
+  sm: 12px
+  md: 16px
+  lg: 20px
+  xl: 24px
+  xxl: 32px
+  xxxl: 40px
+  section-sm: 48px
+  section: 64px
+  section-lg: 96px
+  hero: 120px
+
+components:
+  button-primary:
+    backgroundColor: "{colors.primary}"
+    textColor: "{colors.on-primary}"
+    typography: "{typography.button-md}"
+    rounded: "{rounded.md}"
+    padding: "10px 20px"
+  button-primary-pressed:
+    backgroundColor: "{colors.primary-deep}"
+    textColor: "{colors.on-primary}"
+  button-primary-disabled:
+    backgroundColor: "{colors.hairline}"
+    textColor: "{colors.muted}"
+  button-cream:
+    backgroundColor: "{colors.cream}"
+    textColor: "{colors.ink}"
+    typography: "{typography.button-md}"
+    rounded: "{rounded.md}"
+    padding: "10px 20px"
+    border: "1px solid {colors.beige-deep}"
+  button-dark:
+    backgroundColor: "{colors.ink}"
+    textColor: "{colors.on-dark}"
+    typography: "{typography.button-md}"
+    rounded: "{rounded.md}"
+    padding: "10px 20px"
+  button-secondary:
+    backgroundColor: "transparent"
+    textColor: "{colors.ink}"
+    typography: "{typography.button-md}"
+    rounded: "{rounded.md}"
+    padding: "10px 20px"
+    border: "1px solid {colors.hairline-strong}"
+  button-on-cream:
+    backgroundColor: "{colors.canvas}"
+    textColor: "{colors.ink}"
+    typography: "{typography.button-md}"
+    rounded: "{rounded.md}"
+    padding: "10px 20px"
+    border: "1px solid {colors.beige-deep}"
+  button-link:
+    backgroundColor: "transparent"
+    textColor: "{colors.primary}"
+    typography: "{typography.body-sm-medium}"
+    padding: "0"
+  card-base:
+    backgroundColor: "{colors.canvas}"
+    rounded: "{rounded.lg}"
+    padding: "{spacing.xl}"
+    border: "1px solid {colors.hairline-soft}"
+  card-feature:
+    backgroundColor: "{colors.canvas}"
+    rounded: "{rounded.lg}"
+    padding: "{spacing.xxl}"
+    border: "1px solid {colors.hairline-soft}"
+  card-cream:
+    backgroundColor: "{colors.cream}"
+    textColor: "{colors.ink}"
+    rounded: "{rounded.lg}"
+    padding: "{spacing.xxl}"
+    border: "1px solid {colors.beige-deep}"
+  card-cream-soft:
+    backgroundColor: "{colors.surface-cream-soft}"
+    textColor: "{colors.ink}"
+    rounded: "{rounded.lg}"
+    padding: "{spacing.xxl}"
+  card-feature-product:
+    backgroundColor: "{colors.canvas}"
+    rounded: "{rounded.lg}"
+    padding: "{spacing.xxl}"
+    border: "1px solid {colors.hairline-soft}"
+    shadow: "rgba(0, 0, 0, 0.04) 0px 4px 12px"
+  card-photographic:
+    backgroundColor: "{colors.surface-code}"
+    textColor: "{colors.on-dark}"
+    rounded: "{rounded.lg}"
+    padding: "0"
+  pricing-card:
+    backgroundColor: "{colors.canvas}"
+    rounded: "{rounded.lg}"
+    padding: "{spacing.xxl}"
+    border: "1px solid {colors.hairline-soft}"
+  pricing-card-featured:
+    backgroundColor: "{colors.cream}"
+    rounded: "{rounded.lg}"
+    padding: "{spacing.xxl}"
+    border: "2px solid {colors.primary}"
+  text-input:
+    backgroundColor: "{colors.canvas}"
+    textColor: "{colors.ink}"
+    typography: "{typography.body-md}"
+    rounded: "{rounded.md}"
+    padding: "{spacing.sm} {spacing.md}"
+    border: "1px solid {colors.hairline-strong}"
+    height: 44px
+  text-input-focused:
+    backgroundColor: "{colors.canvas}"
+    textColor: "{colors.ink}"
+    border: "2px solid {colors.primary}"
+  text-area:
+    backgroundColor: "{colors.canvas}"
+    textColor: "{colors.ink}"
+    typography: "{typography.body-md}"
+    rounded: "{rounded.md}"
+    padding: "{spacing.md}"
+    border: "1px solid {colors.hairline-strong}"
+  contact-form-panel:
+    backgroundColor: "{colors.cream}"
+    rounded: "{rounded.lg}"
+    padding: "{spacing.xxl}"
+    border: "1px solid {colors.beige-deep}"
+  pill-tab:
+    backgroundColor: "{colors.canvas}"
+    textColor: "{colors.steel}"
+    typography: "{typography.body-sm-medium}"
+    rounded: "{rounded.full}"
+    padding: "{spacing.xs} {spacing.md}"
+    border: "1px solid {colors.hairline}"
+  pill-tab-active:
+    backgroundColor: "{colors.ink}"
+    textColor: "{colors.on-dark}"
+    rounded: "{rounded.full}"
+    border: "1px solid {colors.ink}"
+  segmented-tab:
+    backgroundColor: "transparent"
+    textColor: "{colors.steel}"
+    typography: "{typography.body-sm-medium}"
+    padding: "{spacing.sm} {spacing.md}"
+    border: "0 0 2px transparent solid"
+  segmented-tab-active:
+    backgroundColor: "transparent"
+    textColor: "{colors.primary}"
+    typography: "{typography.body-sm-medium}"
+    border: "0 0 2px {colors.primary} solid"
+  badge-orange:
+    backgroundColor: "{colors.primary}"
+    textColor: "{colors.on-primary}"
+    typography: "{typography.caption-bold}"
+    rounded: "{rounded.full}"
+    padding: "4px 10px"
+  badge-cream:
+    backgroundColor: "{colors.cream-deeper}"
+    textColor: "{colors.ink}"
+    typography: "{typography.caption-bold}"
+    rounded: "{rounded.full}"
+    padding: "4px 10px"
+  badge-dark:
+    backgroundColor: "{colors.ink}"
+    textColor: "{colors.on-dark}"
+    typography: "{typography.caption-bold}"
+    rounded: "{rounded.full}"
+    padding: "4px 10px"
+  promo-banner:
+    backgroundColor: "{colors.ink}"
+    textColor: "{colors.on-dark}"
+    typography: "{typography.body-sm-medium}"
+    padding: "{spacing.sm} {spacing.md}"
+  hero-band-sunset:
+    backgroundColor: "{colors.sunshine-700}"
+    textColor: "{colors.ink}"
+    rounded: "0"
+    padding: "{spacing.hero}"
+  sunset-stripe-band:
+    backgroundColor: "{colors.primary}"
+    textColor: "{colors.on-primary}"
+    rounded: "0"
+    padding: "{spacing.lg} 0"
+  cta-banner-cream:
+    backgroundColor: "{colors.cream}"
+    textColor: "{colors.ink}"
+    rounded: "{rounded.lg}"
+    padding: "{spacing.section}"
+  code-block:
+    backgroundColor: "{colors.surface-code}"
+    textColor: "{colors.on-dark}"
+    typography: "{typography.code-md}"
+    rounded: "{rounded.md}"
+    padding: "{spacing.md}"
+  code-block-header:
+    backgroundColor: "{colors.surface-code}"
+    textColor: "{colors.on-dark-muted}"
+    typography: "{typography.caption}"
+    padding: "{spacing.xs} {spacing.md}"
+    border: "0 0 1px rgba(255,255,255,0.08) solid"
+  feature-icon-tile:
+    backgroundColor: "{colors.cream}"
+    rounded: "{rounded.md}"
+    padding: "{spacing.md}"
+    border: "1px solid {colors.beige-deep}"
+  industry-tile:
+    backgroundColor: "{colors.canvas}"
+    rounded: "{rounded.lg}"
+    padding: "{spacing.xl}"
+    border: "1px solid {colors.hairline-soft}"
+  stat-cell:
+    backgroundColor: "transparent"
+    textColor: "{colors.ink}"
+    typography: "{typography.stat-display}"
+    padding: "{spacing.lg}"
+  customer-testimonial-card:
+    backgroundColor: "{colors.canvas}"
+    rounded: "{rounded.lg}"
+    padding: "{spacing.xxl}"
+    border: "1px solid {colors.hairline-soft}"
+  logo-wall-item:
+    backgroundColor: "transparent"
+    textColor: "{colors.steel}"
+    typography: "{typography.body-md-medium}"
+    padding: "{spacing.lg}"
+  faq-accordion-item:
+    backgroundColor: "{colors.canvas}"
+    rounded: "{rounded.md}"
+    padding: "{spacing.xl}"
+    border: "0 0 1px {colors.hairline} solid"
+  footer-region:
+    backgroundColor: "{colors.footer-cream}"
+    textColor: "{colors.ink}"
+    typography: "{typography.body-sm}"
+    padding: "{spacing.section} {spacing.xxl}"
+  footer-link:
+    backgroundColor: "transparent"
+    textColor: "{colors.primary}"
+    typography: "{typography.body-sm}"
+    padding: "{spacing.xxs} 0"
+  app-store-badge:
+    backgroundColor: "{colors.ink}"
+    textColor: "{colors.on-dark}"
+    typography: "{typography.caption-bold}"
+    rounded: "{rounded.md}"
+    padding: "{spacing.sm} {spacing.md}"
+---
+
+## Overview
+
+Mistral AI carries itself with a singular, almost cinematographic visual signature — the homepage opens with "Frontier AI. In your hands." rendered in elegant near-serif display type over a photographic mountain landscape bathed in mustard-orange sunset light. Below the hero, every page closes with the same recognizable element: a horizontal "sunset stripe" gradient band running red→orange→yellow→cream that wraps the foot of the page just above the footer. This stripe is THE brand recognizer — it appears on the homepage, products/studio, solutions/coding, news articles, contact form, and services tier page without exception.
+
+The system pairs PP Editorial Old (a near-serif elegant display face) for hero displays with Inter for everything else (body, headings, UI). Cream-yellow surfaces ({colors.cream}, {colors.surface-cream-soft}) anchor form panels and feature cards; saturated orange ({colors.primary}) carries primary CTAs; the deep mountain photography on the homepage and the dark code mockups inside Le Studio create photographic depth. Cards are rectangular with `{rounded.lg}` (12px) corners — distinctly less playful than Miro's or Mintlify's pill-buttons-everywhere approach. Buttons are also `{rounded.md}` (8px), not pills — Mistral's geometry is more sober and editorial than its peers.
+
+**Key Characteristics:**
+- Atmospheric mountain-sunset hero photography (orange-red-yellow gradient sky)
+- Horizontal "sunset stripe" band ({colors.primary} → {colors.sunshine-700} → {colors.yellow-saturated} → {colors.cream}) at every page bottom
+- Cream-yellow surfaces ({colors.cream}, {colors.cream-soft}) for form panels and feature cards
+- PP Editorial Old (or similar near-serif) for hero displays; Inter for everything else
+- `{rounded.md}` (8px) buttons and `{rounded.lg}` (12px) cards — less playful, more editorial geometry
+- Saturated orange primary CTA ({colors.primary}) carries every action call
+
+## Colors
+
+> Source pages: mistral.ai/ (homepage), /products/studio (Le Studio product), /solutions/coding (coding solution), /news/vibe-remote-agents-mistral-medium-3-5 (news), /contact (contact form), /services (services tiers). Token coverage was identical across all six pages.
+
+### Brand & Accent
+- **Mistral Orange** ({colors.primary}): Primary CTA color, brand orange
+- **Orange Deep** ({colors.primary-deep}): Pressed-state and emphasis variant
+- **Sunshine 300** ({colors.sunshine-300}): Atmospheric light orange-yellow
+- **Sunshine 500** ({colors.sunshine-500}): Mid-spectrum sunset orange
+- **Sunshine 700** ({colors.sunshine-700}): Saturated mid sunset gradient stop
+- **Sunshine 800** ({colors.sunshine-800}): Deep sunset gradient stop
+- **Sunshine 900** ({colors.sunshine-900}): Deepest sunset orange
+- **Yellow Saturated** ({colors.yellow-saturated}): Pure brand yellow used in the sunset stripe gradient
+- **Block 5/6/7** ({colors.block-5}, {colors.block-6}, {colors.block-7}): Spectrum stops along the sunset gradient (light-yellow → mid-yellow → deep-orange)
+
+### Cream / Neutral Warm
+- **Cream** ({colors.cream}): Warm yellow-cream surface for form panels, feature cards, footer
+- **Cream Soft** ({colors.cream-soft}): Lighter cream variant
+- **Cream Deeper** ({colors.cream-deeper}): More-saturated cream for badge/tag chips
+- **Beige Deep** ({colors.beige-deep}): Cream surface 1px border color
+
+### Surface
+- **Canvas White** ({colors.canvas}): Page background and card surface
+- **Surface** ({colors.surface}): Subtle quieter background
+- **Surface Cream** ({colors.surface-cream}): Cream-yellow tinted surface
+- **Surface Code** ({colors.surface-code}): Dark code-block / IDE mockup surface
+- **Hairline** ({colors.hairline}): 1px borders
+- **Hairline Soft** ({colors.hairline-soft}): Quieter dividers
+- **Hairline Strong** ({colors.hairline-strong}): Stronger 1px border for inputs
+
+### Text
+- **Ink** ({colors.ink}): Primary headlines and body text
+- **Ink Tint** ({colors.ink-tint}): Slightly softer black for hero overlay text
+- **Charcoal** ({colors.charcoal}): Body emphasis
+- **Slate** ({colors.slate}): Secondary text
+- **Steel** ({colors.steel}): Tertiary text, captions
+- **Stone** ({colors.stone}): Muted labels
+- **Muted** ({colors.muted}): Disabled, placeholders
+- **On Dark** ({colors.on-dark}): White text on dark surfaces
+- **On Dark Muted** ({colors.on-dark-muted}): Reduced-opacity white
+- **On Cream** ({colors.on-cream}): Ink text on cream surfaces
+
+### Semantic
+- **Link** ({colors.link}): Inline link color (matches primary orange)
+
+## Typography
+
+### Font Family
+**PP Editorial Old** (display): Mistral's signature near-serif elegant display typeface used for hero displays, large numbers, and editorial section openers. Carries a slightly classical, intelligent character that contrasts the contemporary product positioning. Fallbacks: 'Times New Roman', Georgia, serif.
+
+**Inter** (UI prose): Variable typeface for body, navigation, buttons, labels, captions. Fallbacks: ui-sans-serif, system-ui, -apple-system, sans-serif.
+
+**JetBrains Mono** (code): Monospace for code blocks and IDE mockups. Fallbacks: 'SF Mono', Menlo, Consolas, monospace.
+
+### Hierarchy
+
+| Token | Size | Weight | Line Height | Letter Spacing | Family | Use |
+|---|---|---|---|---|---|---|
+| `{typography.hero-display}` | 84px | 400 | 1.05 | -1.5px | PP Editorial Old | Hero ("Frontier AI. In your hands.") |
+| `{typography.display-lg}` | 64px | 400 | 1.10 | -1px | PP Editorial Old | Section openers |
+| `{typography.heading-1}` | 52px | 400 | 1.15 | -0.5px | PP Editorial Old | Page headlines ("Get in touch with the team.") |
+| `{typography.stat-display}` | 56px | 400 | 1.10 | -1px | PP Editorial Old | Stat callouts ("75%") |
+| `{typography.heading-2}` | 36px | 500 | 1.20 | -0.5px | Inter | Subsection headlines |
+| `{typography.heading-3}` | 28px | 500 | 1.25 | 0 | Inter | Card titles |
+| `{typography.heading-4}` | 22px | 500 | 1.30 | 0 | Inter | Feature tile titles |
+| `{typography.heading-5}` | 18px | 500 | 1.40 | 0 | Inter | Smaller card titles |
+| `{typography.subtitle}` | 18px | 400 | 1.50 | 0 | Inter | Hero subtitle, lead body |
+| `{typography.body-md}` | 16px | 400 | 1.55 | 0 | Inter | Primary body text |
+| `{typography.body-md-medium}` | 16px | 500 | 1.55 | 0 | Inter | Body emphasis |
+| `{typography.body-sm}` | 14px | 400 | 1.50 | 0 | Inter | Secondary body |
+| `{typography.body-sm-medium}` | 14px | 500 | 1.50 | 0 | Inter | Active sidebar, button labels |
+| `{typography.caption}` | 13px | 400 | 1.40 | 0 | Inter | Helper text |
+| `{typography.caption-bold}` | 13px | 600 | 1.40 | 0 | Inter | Badge labels |
+| `{typography.micro}` | 12px | 500 | 1.40 | 0 | Inter | Footer microcopy |
+| `{typography.micro-uppercase}` | 11px | 600 | 1.40 | 1px | Inter | Section eyebrows |
+| `{typography.button-md}` | 14px | 500 | 1.30 | 0 | Inter | Button labels |
+| `{typography.code-md}` | 14px | 400 | 1.50 | 0 | JetBrains Mono | Code blocks |
+
+### Principles
+- **Editorial / sans pairing** — PP Editorial Old (near-serif, classical) anchors hero displays; Inter (geometric sans) carries everything else. The contrast IS the brand voice.
+- **Generous body leading** (1.55 on body-md) for editorial readability across long-form pages
+- **Tight hero leading** (1.05 on 84px display) creates magazine-grade typographic display
+- **Negative letter-spacing** progresses with size — display sizes use -1.5px to -0.5px; smaller heads relax to 0
+- **Stat-display token** (56px Editorial) for marketing stat callouts ("75% / 80% / 100%")
+
+## Layout
+
+### Spacing System
+- **Base unit**: 4px (8px primary increment)
+- **Tokens**: `{spacing.xxs}` (4px) · `{spacing.xs}` (8px) · `{spacing.sm}` (12px) · `{spacing.md}` (16px) · `{spacing.lg}` (20px) · `{spacing.xl}` (24px) · `{spacing.xxl}` (32px) · `{spacing.xxxl}` (40px) · `{spacing.section-sm}` (48px) · `{spacing.section}` (64px) · `{spacing.section-lg}` (96px) · `{spacing.hero}` (120px)
+- **Section rhythm**: Marketing pages use `{spacing.section-lg}` (96px); content pages tighten to `{spacing.section}` (64px)
+- **Card internal padding**: `{spacing.xl}` (24px) for compact cards; `{spacing.xxl}` (32px) for feature panels and form panels
+
+### Grid & Container
+- Marketing pages use 1280px max-width with 32px gutters
+- Hero band uses 2-column split (text left, sunset photography right) on desktop
+- Le Studio product page uses 3-up feature grid below the hero
+- Contact page uses 1-column layout with cream form panel centered (~520px max-width)
+- Services page uses 4-tier card layout with cream feature panel separator strip
+
+### Whitespace Philosophy
+Marketing surfaces give content generous breathing room — `{spacing.hero}` (120px) hero padding lets the mountain-sunset photography fill the frame. Form pages tighten dramatically: contact form panel uses `{spacing.xxl}` (32px) internal padding, fields stack on `{spacing.md}` (16px) gap.
+
+## Elevation & Depth
+
+The system runs predominantly flat with strategic atmospheric depth from photography.
+
+| Level | Treatment | Use |
+|---|---|---|
+| 0 (flat) | No shadow; `{colors.hairline-soft}` border | Default cards, table rows, form inputs |
+| 1 (subtle) | `rgba(0, 0, 0, 0.04) 0px 1px 2px 0px` | Hover-elevated tiles |
+| 2 (card) | `rgba(0, 0, 0, 0.04) 0px 4px 12px 0px` | Standard feature cards |
+| 3 (mockup) | `rgba(0, 0, 0, 0.08) 0px 12px 24px -4px` | IDE mockup, code editor frames |
+| 4 (modal) | `rgba(0, 0, 0, 0.12) 0px 16px 48px -8px` | Modals, dropdowns |
+
+### Decorative Depth
+- The atmospheric depth on Mistral's hero comes from the photographic mountain-sunset imagery — natural light gradient does the work
+- The "sunset stripe" closing band carries depth via its multi-stop gradient (red → orange → yellow → cream)
+- IDE / code mockups use dark-canvas backgrounds with subtle drop shadow
+
+## Shapes
+
+### Border Radius Scale
+
+| Token | Value | Use |
+|---|---|---|
+| `{rounded.xs}` | 4px | Small chips, micro-controls |
+| `{rounded.sm}` | 6px | Discount badges, compact UI |
+| `{rounded.md}` | 8px | Buttons, inputs, search-pill, code blocks |
+| `{rounded.lg}` | 12px | Cards, modals, panels (the dominant card radius) |
+| `{rounded.xl}` | 16px | Larger feature panels |
+| `{rounded.xxl}` | 20px | Featured emphasis cards |
+| `{rounded.full}` | 9999px | Status badges, pill tabs (used sparingly — most buttons are NOT pills) |
+
+The radius scale is sober and editorial — Mistral does NOT use pill buttons. `{rounded.md}` (8px) for buttons, `{rounded.lg}` (12px) for cards, `{rounded.full}` reserved for badges and the rare pill tab.
+
+### Photography Geometry
+- Hero photography is full-bleed atmospheric mountain-sunset imagery with no internal framing
+- IDE/code mockups render with `{rounded.lg}` (12px) corners on dark canvas
+- Customer logos wall presents wordmarks inline at consistent 60–80px height
+- Product imagery (Le Studio mockup, agent UI mockups) sits in `{rounded.lg}` panels with subtle border
+
+## Components
+
+> Per the no-hover policy, hover states are NOT documented. Default and pressed/active states only.
+
+### Buttons
+
+**`button-primary`** — Saturated-orange primary CTA, the dominant action.
+- Background `{colors.primary}`, text `{colors.on-primary}`, typography `{typography.button-md}`, padding `10px 20px`, rounded `{rounded.md}`.
+- Pressed state `button-primary-pressed` deepens to `{colors.primary-deep}`.
+- Disabled state `button-primary-disabled` uses `{colors.hairline}` background and `{colors.muted}` text.
+
+**`button-cream`** — Warm cream-yellow secondary action, common on cream-surface sections.
+- Background `{colors.cream}`, text `{colors.ink}`, border `1px solid {colors.beige-deep}`, typography `{typography.button-md}`, padding `10px 20px`, rounded `{rounded.md}`.
+
+**`button-dark`** — Dark/black primary CTA on cream surfaces.
+- Background `{colors.ink}`, text `{colors.on-dark}`, typography `{typography.button-md}`, padding `10px 20px`, rounded `{rounded.md}`.
+
+**`button-secondary`** — Outlined secondary action.
+- Background transparent, text `{colors.ink}`, border `1px solid {colors.hairline-strong}`, typography `{typography.button-md}`, padding `10px 20px`, rounded `{rounded.md}`.
+
+**`button-on-cream`** — White button on cream-tinted backgrounds.
+- Background `{colors.canvas}`, text `{colors.ink}`, border `1px solid {colors.beige-deep}`, typography `{typography.button-md}`, padding `10px 20px`, rounded `{rounded.md}`.
+
+**`button-link`** — Inline orange text link.
+- Background transparent, text `{colors.primary}`, typography `{typography.body-sm-medium}`, padding `0`. Underline on activation.
+
+### Cards & Containers
+
+**`card-base`** — Standard content card.
+- Background `{colors.canvas}`, rounded `{rounded.lg}`, padding `{spacing.xl}`, border `1px solid {colors.hairline-soft}`.
+
+**`card-feature`** — White feature card with larger padding.
+- Background `{colors.canvas}`, rounded `{rounded.lg}`, padding `{spacing.xxl}`, border `1px solid `{colors.hairline-soft}`.
+
+**`card-cream`** — Warm cream-yellow feature card (services tiers, perk callouts).
+- Background `{colors.cream}`, text `{colors.ink}`, rounded `{rounded.lg}`, padding `{spacing.xxl}`, border `1px solid {colors.beige-deep}`.
+
+**`card-cream-soft`** — Lighter cream variant.
+- Background `{colors.surface-cream-soft}`, text `{colors.ink}`, rounded `{rounded.lg}`, padding `{spacing.xxl}`.
+
+**`card-feature-product`** — Product showcase card with subtle elevation.
+- Background `{colors.canvas}`, rounded `{rounded.lg}`, padding `{spacing.xxl}`, border `1px solid {colors.hairline-soft}`, shadow `rgba(0, 0, 0, 0.04) 0px 4px 12px`.
+
+**`card-photographic`** — Photographic product card with dark background.
+- Background `{colors.surface-code}`, text `{colors.on-dark}`, rounded `{rounded.lg}`, padding `0` (image fills the card).
+
+**`pricing-card`** — Standard pricing tier card.
+- Background `{colors.canvas}`, rounded `{rounded.lg}`, padding `{spacing.xxl}`, border `1px solid {colors.hairline-soft}`.
+
+**`pricing-card-featured`** — Featured pricing tier (cream background + orange border).
+- Background `{colors.cream}`, rounded `{rounded.lg}`, padding `{spacing.xxl}`, border `2px solid {colors.primary}`.
+
+### Inputs & Forms
+
+**`text-input`** — Standard text field.
+- Background `{colors.canvas}`, text `{colors.ink}`, border `1px solid {colors.hairline-strong}`, rounded `{rounded.md}`, padding `{spacing.sm} {spacing.md}`, height 44px.
+
+**`text-input-focused`** — Activated state.
+- Border switches to `2px solid {colors.primary}`.
+
+**`text-area`** — Multi-line text area for contact form.
+- Background `{colors.canvas}`, text `{colors.ink}`, border `1px solid {colors.hairline-strong}`, rounded `{rounded.md}`, padding `{spacing.md}`.
+
+**`contact-form-panel`** — Cream-tinted form container on the contact page.
+- Background `{colors.cream}`, rounded `{rounded.lg}`, padding `{spacing.xxl}`, border `1px solid {colors.beige-deep}`. Hosts text-inputs, text-area, submit `button-dark`.
+
+### Tabs
+
+**`pill-tab`** + **`pill-tab-active`** — Pill-style tab nav (used sparingly on product pages).
+- Inactive: background `{colors.canvas}`, text `{colors.steel}`, border `1px solid {colors.hairline}`, padding `{spacing.xs} {spacing.md}`, rounded `{rounded.full}`.
+- Active: background `{colors.ink}`, text `{colors.on-dark}`.
+
+**`segmented-tab`** + **`segmented-tab-active`** — Underline-style tab navigation.
+- Inactive: text `{colors.steel}`, transparent background, padding `{spacing.sm} {spacing.md}`, no bottom border.
+- Active: text `{colors.primary}`, 2px bottom border in `{colors.primary}`.
+
+### Badges & Status
+
+**`badge-orange`** — Saturated orange badge.
+- Background `{colors.primary}`, text `{colors.on-primary}`, typography `{typography.caption-bold}`, rounded `{rounded.full}`, padding `4px 10px`.
+
+**`badge-cream`** — Cream-tinted tag chip.
+- Background `{colors.cream-deeper}`, text `{colors.ink}`, typography `{typography.caption-bold}`, rounded `{rounded.full}`, padding `4px 10px`.
+
+**`badge-dark`** — Dark/black status badge.
+- Background `{colors.ink}`, text `{colors.on-dark}`, typography `{typography.caption-bold}`, rounded `{rounded.full}`, padding `4px 10px`.
+
+**`promo-banner`** — Sticky black promo strip ABOVE the top nav.
+- Background `{colors.ink}`, text `{colors.on-dark}`, typography `{typography.body-sm-medium}`, padding `{spacing.sm} {spacing.md}`. Carries one-line copy + inline CTA.
+
+### Code
+
+**`code-block`** — Syntax-highlighted IDE-style code block (Le Studio page mockup, agent demos).
+- Background `{colors.surface-code}`, text `{colors.on-dark}`, typography `{typography.code-md}`, rounded `{rounded.md}`, padding `{spacing.md}`.
+
+**`code-block-header`** — Header bar above the code block.
+- Background `{colors.surface-code}`, text `{colors.on-dark-muted}`, typography `{typography.caption}`, padding `{spacing.xs} {spacing.md}`, bottom border `1px solid rgba(255,255,255,0.08)`.
+
+### Documentation Components
+
+**`feature-icon-tile`** — Cream-yellow feature icon callout.
+- Background `{colors.cream}`, rounded `{rounded.md}`, padding `{spacing.md}`, border `1px solid {colors.beige-deep}`.
+
+**`industry-tile`** — Industry-vertical tile in solutions page grid.
+- Background `{colors.canvas}`, rounded `{rounded.lg}`, padding `{spacing.xl}`, border `1px solid {colors.hairline-soft}`.
+
+**`stat-cell`** — Stat-row cell ("75% more / 80% better").
+- Background transparent, text `{colors.ink}`, typography `{typography.stat-display}`, padding `{spacing.lg}`.
+
+**`customer-testimonial-card`** — Customer quote card (used inside Le Studio and Solutions pages).
+- Background `{colors.canvas}`, rounded `{rounded.lg}`, padding `{spacing.xxl}`, border `1px solid {colors.hairline-soft}`. Quote in `{typography.body-md}`, attribution in `{typography.body-sm}` `{colors.steel}`.
+
+**`logo-wall-item`** — Customer logo wordmark cell.
+- Background transparent, text `{colors.steel}`, typography `{typography.body-md-medium}`, padding `{spacing.lg}`.
+
+**`faq-accordion-item`** — FAQ panel.
+- Background `{colors.canvas}`, rounded `{rounded.md}`, padding `{spacing.xl}`, bottom border `1px solid {colors.hairline}`.
+
+**`app-store-badge`** — App Store / Google Play download badge.
+- Background `{colors.ink}`, text `{colors.on-dark}`, typography `{typography.caption-bold}`, rounded `{rounded.md}`, padding `{spacing.sm} {spacing.md}`.
+
+### Navigation
+
+**Top Navigation (Marketing)** — Sticky white bar.
+- Background `{colors.canvas}`, height ~64px, bottom border `1px solid {colors.hairline-soft}`.
+- Left: Mistral M-mark logo + "MISTRAL AI_" wordmark + horizontal link list (Products, Solutions, Research, Blog, Customers, Company).
+- Right: "Contact Sales" link + black-pill "Try Studio" CTA.
+
+### Signature Components
+
+**`hero-band-sunset`** — Atmospheric sunset hero band.
+- Background gradient `linear-gradient(135deg, {colors.sunshine-700} 0%, {colors.sunshine-900} 60%, {colors.primary} 100%)` overlaid on photographic mountain landscape.
+- Layout: hero headline left in `{typography.hero-display}` ({colors.ink}), subtitle in `{typography.subtitle}` ({colors.ink-tint}), button row (`button-dark` + `button-secondary`), atmospheric mountain photography right.
+
+**`sunset-stripe-band`** — Horizontal closing band at the foot of every page.
+- Multi-stop gradient: `{colors.primary}` → `{colors.sunshine-700}` → `{colors.sunshine-500}` → `{colors.yellow-saturated}` → `{colors.cream}`.
+- Padding `{spacing.lg} 0`. Spans full width, sits above the footer. THIS IS THE BRAND'S MOST RECOGNIZABLE SIGNATURE ELEMENT.
+
+**`cta-banner-cream`** — Page-bottom CTA band on cream surface.
+- Background `{colors.cream}`, text `{colors.ink}`, rounded `{rounded.lg}`, padding `{spacing.section}`. "The next chapter of AI is yours." headline in `{typography.heading-1}` (PP Editorial Old), button row below.
+
+**`footer-region`** — Cream-tinted multi-column footer.
+- Background `{colors.footer-cream}`, padding `{spacing.section} {spacing.xxl}`.
+- 5-column link grid (Why Mistral / Explore / Build / Legal + brand mark column).
+- Bottom: language picker + social icons.
+
+**`footer-link`** — Individual footer link.
+- Background transparent, text `{colors.primary}`, typography `{typography.body-sm}`, padding `{spacing.xxs} 0`.
+
+## Do's and Don'ts
+
+### Do
+- Reserve `{colors.primary}` (saturated orange) for primary CTAs and active states only
+- Use the **sunset stripe band** at the foot of every page — it's the brand's most recognizable signature
+- Pair PP Editorial Old (display) with Inter (UI) — never substitute either with a generic alternative
+- Apply `{rounded.md}` (8px) to buttons and `{rounded.lg}` (12px) to cards consistently
+- Use cream-yellow surfaces ({colors.cream}) for form panels, feature cards, and footer
+- Anchor heroes with photographic mountain-sunset imagery (or its visual equivalent — atmospheric gradient sky)
+- Use stat-display token (PP Editorial 56px) for stat callouts to maintain editorial character
+
+### Don't
+- Don't use pill-shaped buttons (`{rounded.full}`) — Mistral's geometry is sober and editorial, not playful
+- Don't introduce additional accent colors beyond the orange/yellow/cream sunset palette
+- Don't reduce hero leading below 1.05 — the editorial display needs that magazine-grade tightness
+- Don't replace PP Editorial Old hero displays with Inter — the editorial / sans contrast IS the brand
+- Don't apply heavy shadows on flat documentation cards; reserve elevation for IDE mockups
+- Don't drop the sunset stripe band from any page bottom — it's the brand's continuity element
+
+## Responsive Behavior
+
+### Breakpoints
+| Name | Width | Key Changes |
+|---|---|---|
+| Mobile (small) | < 480px | Single column. Hero scales to 40px (PP Editorial). Pill nav collapses to hamburger. Pricing tiers stack 1-up. |
+| Mobile (large) | 480 – 767px | Feature tiles 2-up. Hero scales to 52px. |
+| Tablet | 768 – 1023px | 2-column feature grids. Pill-tab nav returns. Hero 64px. |
+| Desktop | 1024 – 1279px | Multi-column layouts. Hero 76px. Stat row at full width. |
+| Wide Desktop | ≥ 1280px | Full 84px hero presentation. |
+
+### Touch Targets
+- Buttons render at 40–44px effective height — at WCAG AAA floor with `10px 20px` padding
+- Form inputs render at 44px height
+- Pill tabs render at ~32px tall — bumps to 44px on mobile
+
+### Collapsing Strategy
+- **Promo banner** stays full-width; truncates at < 480px
+- **Top nav** below 1024px collapses to hamburger
+- **Hero band**: 2-column hero (text + photography) collapses to stacked at < 1024px
+- **Pricing tiers**: 4-column desktop → 2-column tablet → 1-column mobile
+- **Stat row**: 3-column → stacked at < 768px
+- **Hero typography**: 84px → 64px → 52px → 40px
+- **Footer**: 5-column desktop → 3-column tablet → 1-column accordion mobile
+- **Sunset stripe band** stays full-width on all breakpoints
+
+### Image Behavior
+- Mountain-sunset photography uses 16:9 ratio with full-bleed scaling
+- IDE mockup images maintain aspect ratio across breakpoints
+- Customer logo wall presents wordmarks at consistent 60–80px height
+
+## Iteration Guide
+
+1. Focus on ONE component at a time
+2. Reference component names and tokens directly (`{colors.primary}`, `{component-name}-pressed`)
+3. Run `npx @google/design.md lint DESIGN.md` after edits
+4. Add new variants as separate `components:` entries
+5. Default to `{typography.body-md}` for body and `{typography.subtitle}` for emphasis. Hero displays use `{typography.hero-display}` (PP Editorial Old).
+6. Keep `{colors.primary}` confined to primary CTAs, active states, and the sunset stripe band
+7. Cards use `{rounded.lg}` (12px), buttons use `{rounded.md}` (8px). Pills (`{rounded.full}`) reserved for badges only.
+8. Always include the sunset-stripe-band component at the foot of every page mockup.
+
+## Known Gaps
+
+- Specific dark-mode token values not surfaced; the brand has not shipped a published dark-mode palette
+- Animation/transition timings not extracted; recommend 150–200ms ease for hover/focus state transitions
+- Form validation success state not explicitly captured beyond defaults
+- Sunset stripe band gradient stops are approximations — the actual values may vary slightly across pages but the visual rhythm is consistent

--- a/astro/src/data/design-md/nvidia.md
+++ b/astro/src/data/design-md/nvidia.md
@@ -1,0 +1,640 @@
+---
+version: alpha
+name: NVIDIA-design-analysis
+description: |
+  An engineering-grade marketing system organized around two surface modes — a deep black canvas for hero and footer chapters and a flat paper-white canvas for body content — connected by a single, almost violently saturated NVIDIA Green accent that carries every CTA, every active tab, and the small decorative corner squares that mark out cards. The system is unapologetically angular: 2px radius across every surface, tight bold sans-serif typography in NVIDIA's proprietary EMEA cut, and a hairline gray rule that separates dense multi-column technical content. There is no decorative gradient, no atmospheric mesh, no soft drop shadow — just black, white, gray, and green stacked into a structured editorial grid that scales from product cards to massive industry landing pages without bending its rules.
+
+colors:
+  primary: "#76b900"
+  on-primary: "#000000"
+  primary-dark: "#5a8d00"
+  ink: "#000000"
+  canvas: "#ffffff"
+  surface-dark: "#000000"
+  surface-soft: "#f7f7f7"
+  surface-elevated: "#1a1a1a"
+  hairline: "#cccccc"
+  hairline-strong: "#5e5e5e"
+  body: "#1a1a1a"
+  mute: "#757575"
+  stone: "#898989"
+  ash: "#a7a7a7"
+  on-dark: "#ffffff"
+  on-dark-mute: "rgba(255,255,255,0.7)"
+  link-blue: "#0046a4"
+  blue-700: "#0046a4"
+  error: "#e52020"
+  error-deep: "#650b0b"
+  warning: "#df6500"
+  warning-bright: "#ef9100"
+  success-deep: "#3f8500"
+  accent-yellow-pale: "#feeeb2"
+  accent-purple: "#952fc6"
+  accent-purple-deep: "#4d1368"
+  accent-purple-pale: "#f9d4ff"
+  accent-green-pale: "#bff230"
+
+typography:
+  display-xl:
+    fontFamily: NVIDIA-EMEA
+    fontSize: 48px
+    fontWeight: 700
+    lineHeight: 1.25
+    letterSpacing: 0
+  display-lg:
+    fontFamily: NVIDIA-EMEA
+    fontSize: 36px
+    fontWeight: 700
+    lineHeight: 1.25
+    letterSpacing: 0
+  heading-xl:
+    fontFamily: NVIDIA-EMEA
+    fontSize: 24px
+    fontWeight: 700
+    lineHeight: 1.25
+    letterSpacing: 0
+  heading-lg:
+    fontFamily: NVIDIA-EMEA
+    fontSize: 22px
+    fontWeight: 400
+    lineHeight: 1.75
+    letterSpacing: 0
+  heading-md:
+    fontFamily: NVIDIA-EMEA
+    fontSize: 20px
+    fontWeight: 700
+    lineHeight: 1.25
+    letterSpacing: 0
+  heading-sm:
+    fontFamily: NVIDIA-EMEA
+    fontSize: 18px
+    fontWeight: 700
+    lineHeight: 1.4
+    letterSpacing: 0
+  card-title:
+    fontFamily: NVIDIA-EMEA
+    fontSize: 17px
+    fontWeight: 700
+    lineHeight: 1.47
+    letterSpacing: 0
+  body-md:
+    fontFamily: NVIDIA-EMEA
+    fontSize: 16px
+    fontWeight: 400
+    lineHeight: 1.5
+    letterSpacing: 0
+  body-strong:
+    fontFamily: NVIDIA-EMEA
+    fontSize: 16px
+    fontWeight: 700
+    lineHeight: 1.5
+    letterSpacing: 0
+  body-sm:
+    fontFamily: NVIDIA-EMEA
+    fontSize: 15px
+    fontWeight: 400
+    lineHeight: 1.67
+    letterSpacing: 0
+  button-lg:
+    fontFamily: NVIDIA-EMEA
+    fontSize: 18px
+    fontWeight: 700
+    lineHeight: 1.25
+    letterSpacing: 0
+  button-md:
+    fontFamily: NVIDIA-EMEA
+    fontSize: 16px
+    fontWeight: 700
+    lineHeight: 1.25
+    letterSpacing: 0
+  button-sm:
+    fontFamily: NVIDIA-EMEA
+    fontSize: 14.4px
+    fontWeight: 700
+    lineHeight: 1
+    letterSpacing: 0.144px
+  link-md:
+    fontFamily: NVIDIA-EMEA
+    fontSize: 15px
+    fontWeight: 400
+    lineHeight: 1.5
+    letterSpacing: 0
+  caption-md:
+    fontFamily: NVIDIA-EMEA
+    fontSize: 14px
+    fontWeight: 700
+    lineHeight: 1.43
+    letterSpacing: 0
+    textTransform: uppercase
+  caption-sm:
+    fontFamily: NVIDIA-EMEA
+    fontSize: 12px
+    fontWeight: 400
+    lineHeight: 1.25
+    letterSpacing: 0
+  caption-xs:
+    fontFamily: NVIDIA-EMEA
+    fontSize: 11px
+    fontWeight: 700
+    lineHeight: 1
+    letterSpacing: 0
+  utility-xs:
+    fontFamily: NVIDIA-EMEA
+    fontSize: 10px
+    fontWeight: 700
+    lineHeight: 1.5
+    letterSpacing: 0
+    textTransform: uppercase
+
+rounded:
+  none: 0px
+  xs: 1px
+  sm: 2px
+  full: 9999px
+
+spacing:
+  xxs: 2px
+  xs: 4px
+  sm: 8px
+  md: 12px
+  lg: 16px
+  xl: 24px
+  xxl: 32px
+  section: 64px
+
+components:
+  button-primary:
+    backgroundColor: "{colors.primary}"
+    textColor: "{colors.on-primary}"
+    typography: "{typography.button-md}"
+    rounded: "{rounded.sm}"
+    padding: 11px 24px
+    height: 44px
+  button-primary-active:
+    backgroundColor: "{colors.primary-dark}"
+    textColor: "{colors.on-primary}"
+    typography: "{typography.button-md}"
+    rounded: "{rounded.sm}"
+  button-outline:
+    backgroundColor: "transparent"
+    textColor: "{colors.ink}"
+    typography: "{typography.button-md}"
+    rounded: "{rounded.sm}"
+    padding: 11px 13px
+  button-outline-on-dark:
+    backgroundColor: "transparent"
+    textColor: "{colors.on-dark}"
+    typography: "{typography.button-md}"
+    rounded: "{rounded.sm}"
+  button-ghost-link:
+    textColor: "{colors.primary}"
+    typography: "{typography.button-md}"
+    rounded: "{rounded.none}"
+  button-disabled:
+    backgroundColor: "{colors.surface-soft}"
+    textColor: "{colors.ash}"
+    rounded: "{rounded.sm}"
+  pill-tab:
+    backgroundColor: "transparent"
+    textColor: "{colors.ink}"
+    typography: "{typography.button-sm}"
+    rounded: "{rounded.sm}"
+    padding: 10px 18px
+  pill-tab-active:
+    backgroundColor: "{colors.ink}"
+    textColor: "{colors.on-dark}"
+    typography: "{typography.button-sm}"
+    rounded: "{rounded.sm}"
+  text-input:
+    backgroundColor: "{colors.canvas}"
+    textColor: "{colors.ink}"
+    typography: "{typography.body-md}"
+    rounded: "{rounded.sm}"
+    padding: 12px 16px
+    height: 44px
+  text-input-focused:
+    backgroundColor: "{colors.canvas}"
+    textColor: "{colors.ink}"
+    rounded: "{rounded.sm}"
+  search-input:
+    backgroundColor: "{colors.canvas}"
+    textColor: "{colors.ink}"
+    typography: "{typography.body-md}"
+    rounded: "{rounded.sm}"
+    padding: 10px 16px
+    height: 40px
+  product-card:
+    backgroundColor: "{colors.canvas}"
+    textColor: "{colors.ink}"
+    typography: "{typography.card-title}"
+    rounded: "{rounded.sm}"
+    padding: 24px
+  feature-card:
+    backgroundColor: "{colors.canvas}"
+    textColor: "{colors.ink}"
+    typography: "{typography.body-md}"
+    rounded: "{rounded.sm}"
+    padding: 32px
+  resource-card:
+    backgroundColor: "{colors.canvas}"
+    textColor: "{colors.ink}"
+    typography: "{typography.card-title}"
+    rounded: "{rounded.sm}"
+    padding: 24px
+  hero-card-dark:
+    backgroundColor: "{colors.surface-dark}"
+    textColor: "{colors.on-dark}"
+    typography: "{typography.display-xl}"
+    rounded: "{rounded.none}"
+    padding: 80px 48px
+  cta-strip-dark:
+    backgroundColor: "{colors.surface-dark}"
+    textColor: "{colors.on-dark}"
+    typography: "{typography.heading-xl}"
+    rounded: "{rounded.none}"
+    padding: 64px 48px
+  callout-stat:
+    backgroundColor: "{colors.canvas}"
+    textColor: "{colors.ink}"
+    typography: "{typography.display-lg}"
+    rounded: "{rounded.sm}"
+    padding: 32px
+  corner-square:
+    backgroundColor: "{colors.primary}"
+    rounded: "{rounded.none}"
+    size: 12px
+  utility-bar:
+    backgroundColor: "{colors.surface-dark}"
+    textColor: "{colors.on-dark}"
+    typography: "{typography.caption-sm}"
+    rounded: "{rounded.none}"
+    height: 32px
+  primary-nav:
+    backgroundColor: "{colors.surface-dark}"
+    textColor: "{colors.on-dark}"
+    typography: "{typography.body-strong}"
+    rounded: "{rounded.none}"
+    height: 64px
+  breadcrumb-bar:
+    backgroundColor: "{colors.surface-soft}"
+    textColor: "{colors.body}"
+    typography: "{typography.caption-md}"
+    rounded: "{rounded.none}"
+    height: 48px
+  sub-nav-strip:
+    backgroundColor: "{colors.surface-soft}"
+    textColor: "{colors.ink}"
+    typography: "{typography.button-md}"
+    rounded: "{rounded.none}"
+    height: 56px
+  footer-section:
+    backgroundColor: "{colors.surface-dark}"
+    textColor: "{colors.on-dark-mute}"
+    typography: "{typography.body-sm}"
+    rounded: "{rounded.none}"
+    padding: 64px 48px
+  link-inline:
+    textColor: "{colors.link-blue}"
+    typography: "{typography.link-md}"
+  badge-tag:
+    backgroundColor: "{colors.surface-soft}"
+    textColor: "{colors.body}"
+    typography: "{typography.caption-md}"
+    rounded: "{rounded.sm}"
+    padding: 4px 10px
+---
+
+## Overview
+
+NVIDIA's marketing system is built like a piece of engineering documentation that learned graphic design — every page is a structured cascade of dense, factual information arranged on a paper-white grid, framed top and bottom by deep black hero/footer chapters. There is exactly one accent color in the entire system, and it is doing all the work: NVIDIA Green (`{colors.primary}` — `#76b900`), used for every primary CTA, every active tab, every link affordance on dark surfaces, and the small decorative corner squares that mark out card containers. Nothing else competes for attention.
+
+The system's character comes from extreme typographic restraint and an almost punishingly angular geometry. Every container, button, and image uses `{rounded.sm}` (2px) — a token that's barely-there but never zero, giving the system the precise, technical feel of CAD output rather than warm consumer software. Cards sit on plain `{colors.canvas}` with a hairline `{colors.hairline}` border (no shadow, no elevation), separated by tight 8px-base spacing rhythm. Long-form pages stack 6–10 of these cards into multi-column technical grids without ever introducing decorative breaks.
+
+The black-canvas hero and footer chapters are the system's "headline moments" — a single full-bleed photographic or 3D-rendered image with `{typography.display-xl}` headline copy laid in white, a single green CTA button, and a small green corner square as the only ornamentation. Everything else is subordinate.
+
+**Key Characteristics:**
+- Single-accent system: `{colors.primary}` carries every CTA, active state, and decorative motif. The rest is monochrome black/white/gray.
+- Two-mode surface architecture: `{colors.surface-dark}` for hero/footer chapters; `{colors.canvas}` for body — alternating in a predictable rhythm down the page
+- Hyper-angular geometry: `{rounded.sm}` (2px) on every interactive element. There are no pill buttons, no rounded cards, no soft chrome.
+- NVIDIA-EMEA proprietary sans-serif at weights 400 and 700, scaled across a 12-tier hierarchy from `{typography.utility-xs}` (10px) up to `{typography.display-xl}` (48px)
+- Card library leans on hairline `{colors.hairline}` borders and `{colors.surface-soft}` backgrounds rather than shadows for separation
+- Signature decorative element: the small `{component.corner-square}` (~12px green square) anchored to one corner of resource and feature cards
+- Dense multi-column footer with 4–6 link columns on `{colors.surface-dark}` — every page closes with the same structured global navigation
+
+## Colors
+
+> **Source pages:** `/tr-tr/` (primary homepage), `/en-eu/industries/healthcare-life-sciences/`, `/en-eu/solutions/ai/`, `/en-eu/ai/foundry/`. The chrome palette is identical across all four — only photography and copy vary.
+
+### Brand & Accent
+- **NVIDIA Green** (`{colors.primary}` — `#76b900`): the brand. Every primary CTA, every active state, every link affordance on dark surfaces, every corner square, and the brand wordmark itself.
+- **NVIDIA Green Dark** (`{colors.primary-dark}` — `#5a8d00`): pressed state for the primary button — a single notch deeper than the brand green.
+- **Accent Green Pale** (`{colors.accent-green-pale}` — `#bff230`): rare highlight tint used in editorial callouts and decorative micro-blocks; never on chrome.
+
+### Surface
+- **Page Canvas** (`{colors.canvas}` — `#ffffff`): the body of every page. Cards sit directly on it with hairline rules.
+- **Soft Surface** (`{colors.surface-soft}` — `#f7f7f7`): breadcrumb strip, sub-nav, side-by-side comparison panels, alternating row backgrounds.
+- **Black Canvas** (`{colors.surface-dark}` — `#000000`): hero chapter, dark CTA strips, footer, primary nav. The system's "frame" color.
+- **Surface Elevated** (`{colors.surface-elevated}` — `#1a1a1a`): nested dark panels inside the footer (column dividers, fine-print bar).
+- **Hairline** (`{colors.hairline}` — `#cccccc`): 1px card border, table rule, divider between footer link sections.
+- **Hairline Strong** (`{colors.hairline-strong}` — `#5e5e5e`): 1px divider on dark surfaces (footer column rules, dark-mode card edges).
+
+### Text
+- **Ink** (`{colors.ink}` — `#000000`): headlines and body text on `{colors.canvas}`.
+- **Body** (`{colors.body}` — `#1a1a1a`): long-form paragraph text where pure black is too heavy.
+- **Mute** (`{colors.mute}` — `#757575`): metadata, breadcrumb separators, footer copyright.
+- **Stone** (`{colors.stone}` — `#898989`): least-emphasis text and disabled state.
+- **Ash** (`{colors.ash}` — `#a7a7a7`): disabled icon color and faint utility text.
+- **On Dark** (`{colors.on-dark}` — `#ffffff`): primary text on `{colors.surface-dark}`.
+- **On Dark Mute** (`{colors.on-dark-mute}` — `rgba(255,255,255,0.7)`): secondary footer link text and dark-canvas body copy.
+
+### Semantic
+- **Error** (`{colors.error}` — `#e52020`): validation messages, destructive confirmation.
+- **Error Deep** (`{colors.error-deep}` — `#650b0b`): pressed state for error buttons; hover-pressed validation icons.
+- **Warning** (`{colors.warning}` — `#df6500`): caution callouts, deprecated documentation banners.
+- **Warning Bright** (`{colors.warning-bright}` — `#ef9100`): inverse warning on dark canvas.
+- **Success Deep** (`{colors.success-deep}` — `#3f8500`): positive confirmation where NVIDIA Green's saturation would clash.
+- **Link Blue** (`{colors.link-blue}` — `#0046a4`): inline anchor link color on light canvas — the only blue in the system, reserved for prose-embedded hyperlinks.
+
+### Editorial Accents (used sparingly inside long-form content)
+- **Accent Purple** (`{colors.accent-purple}` — `#952fc6`): research / scientific computing editorial accent.
+- **Accent Purple Deep** (`{colors.accent-purple-deep}` — `#4d1368`): paired dark for purple lockups.
+- **Accent Purple Pale** (`{colors.accent-purple-pale}` — `#f9d4ff`): wash background for editorial callouts.
+- **Accent Yellow Pale** (`{colors.accent-yellow-pale}` — `#feeeb2`): documentation tip / soft callout fill.
+
+## Typography
+
+### Font Family
+- **NVIDIA-EMEA** is the proprietary brand sans-serif used across every text role on the site. It carries weights 400 (regular) and 700 (bold) and falls back to Arial → Helvetica.
+- **Font Awesome 6 Pro** and **Font Awesome 6 Sharp** are used exclusively for iconography (chevrons, social glyphs, breadcrumb separators, search/menu icons) at sizes 14–22px.
+
+NVIDIA's type system is unusually flat: most chrome and body roles render at the same line-height (1.25–1.5) with the only meaningful variation coming from weight (400 vs 700) and size. The system relies on weight contrast — not size jumps and not color tinting — to establish hierarchy, which gives marketing copy and technical documentation an editorial newspaper feel.
+
+### Hierarchy
+
+| Token | Size | Weight | Line Height | Letter Spacing | Use |
+|---|---|---|---|---|---|
+| `{typography.display-xl}` | 48px | 700 | 1.25 | 0 | Hero headline on `{component.hero-card-dark}` |
+| `{typography.display-lg}` | 36px | 700 | 1.25 | 0 | Section headline ("Explore Our AI Solutions"), large stat callouts |
+| `{typography.heading-xl}` | 24px | 700 | 1.25 | 0 | Sub-section title, dark CTA-strip headline |
+| `{typography.heading-lg}` | 22px | 400 | 1.75 | 0 | Long-form intro paragraph that doubles as a heading |
+| `{typography.heading-md}` | 20px | 700 | 1.25 | 0 | Card group title, sub-nav anchor heading |
+| `{typography.heading-sm}` | 18px | 700 | 1.4 | 0 | Side-rail filter group, small section label |
+| `{typography.card-title}` | 17px | 700 | 1.47 | 0 | Resource card title, product card title |
+| `{typography.body-md}` | 16px | 400 | 1.5 | 0 | Body copy, default paragraph |
+| `{typography.body-strong}` | 16px | 700 | 1.5 | 0 | Inline emphasis, primary nav link, label |
+| `{typography.body-sm}` | 15px | 400 | 1.67 | 0 | Card description, secondary copy |
+| `{typography.button-lg}` | 18px | 700 | 1.25 | 0 | Hero primary CTA |
+| `{typography.button-md}` | 16px | 700 | 1.25 | 0 | Standard primary/secondary buttons |
+| `{typography.button-sm}` | 14.4px | 700 | 1 | 0.144px | Compact pill tab, in-card secondary CTA |
+| `{typography.link-md}` | 15px | 400 | 1.5 | 0 | Inline anchor link in body prose |
+| `{typography.caption-md}` | 14px | 700 | 1.43 | 0 | Eyebrow over section heading, breadcrumb (uppercase) |
+| `{typography.caption-sm}` | 12px | 400 | 1.25 | 0 | Footnote copy, metadata, table caption |
+| `{typography.caption-xs}` | 11px | 700 | 1 | 0 | Pill chip label, utility-bar text |
+| `{typography.utility-xs}` | 10px | 700 | 1.5 | 0 | Legal fine-print bar at the very bottom (uppercase) |
+
+### Principles
+The typography is brand-locked: NVIDIA-EMEA is used at every level, no serif, no display variant, no monospace, no italic. Hierarchy is built almost entirely from size and weight — color is reserved for emphasis (`{colors.primary}` on links over dark, `{colors.link-blue}` on light) and never used to separate type tiers.
+
+### Note on Font Substitutes
+NVIDIA-EMEA is proprietary. The closest open-source pairing is **Inter** (weights 400/700) — its x-height and stroke contrast match NVIDIA-EMEA's optical metrics within ~2% at body sizes. **Arial** is the official documented fallback and is acceptable for any system where Inter is unavailable. Avoid Helvetica Now or Helvetica Neue substitutes; their slightly tighter cap heights drift away from the brand's geometry.
+
+## Layout
+
+### Spacing System
+- **Base unit:** 8px
+- **Tokens (front matter):** `{spacing.xxs}` (2px) · `{spacing.xs}` (4px) · `{spacing.sm}` (8px) · `{spacing.md}` (12px) · `{spacing.lg}` (16px) · `{spacing.xl}` (24px) · `{spacing.xxl}` (32px) · `{spacing.section}` (64px)
+- **Universal section rhythm:** every page in the set uses `{spacing.section}` (64px) as the vertical gap between major content blocks. Card grids use `{spacing.xl}` (24px) gutters; in-card padding sits at `{spacing.xl}` to `{spacing.xxl}` depending on density.
+- **Hero chapter padding:** 80px vertical / 48px horizontal — the largest spacing in the system, reserved for `{component.hero-card-dark}`.
+
+### Grid & Container
+- **Max width:** ~1280px content area at desktop, with 24px gutters that grow to ~48px at ultrawide.
+- **Column patterns:**
+  - Card grids: 4-up at desktop, 3-up at 1024px, 2-up at 768px, 1-up at 480px.
+  - Long-form text: 2-column 60/40 split (body + sidebar) at desktop, single-column at < 960px.
+  - Footer: 6-up link columns at desktop, collapsing to 2-up on tablet, full accordion on mobile.
+- **Card aspect:** product cards lean to 1:1 or 4:3 with 16:9 imagery on top + 1–2 lines of metadata below. Resource cards are 3:2 imagery with a longer description block.
+
+### Whitespace Philosophy
+Whitespace is structural, not atmospheric. Sections butt against each other with `{spacing.section}` rhythm — there are no decorative dividers, no empty "breathing room" bands, no gradient transitions between sections. The sense of air comes from `{colors.canvas}` body sections sandwiched between `{colors.surface-dark}` chapter blocks, not from generous padding inside any one component.
+
+## Elevation & Depth
+
+| Level | Treatment | Use |
+|---|---|---|
+| 0 — Flat | No border, no shadow | Canvas-on-canvas blocks, hero chapter content, footer column body |
+| 1 — Hairline border | 1px solid `{colors.hairline}` | All cards on `{colors.canvas}`, table cells, comparison panels |
+| 2 — Hairline strong | 1px solid `{colors.hairline-strong}` | Dividers on `{colors.surface-dark}` (footer column rules, dark-card edges) |
+| 3 — Soft shadow | `0 0 5px 0 rgba(0,0,0,0.3)` | Sticky nav bottom edge when scrolled, sticky CTA bar — used very sparingly |
+
+NVIDIA's system has effectively no drop-shadow elevation in card or content surfaces. The only "shadow" in the extracted tokens is a subtle 5px ambient on sticky chrome bars. Cards do not lift; cards are flat rectangles with hairline borders.
+
+### Decorative Depth
+Depth in NVIDIA's system comes from photography and 3D-rendered hero imagery rather than from CSS effects:
+- **Hero imagery:** full-bleed photographic or rendered scenes (data-center hardware, neural-net visualizations, life-sciences microscopy) sit behind hero copy with a dark gradient overlay for legibility.
+- **Decorative corner squares:** the small `{component.corner-square}` (~12px solid `{colors.primary}` square) anchored to the top-left or bottom-right corner of resource and feature cards — the system's only consistent ornamental device.
+- **Editorial 3D accents:** isometric or wireframe 3D renderings appear as illustration-style fills inside long-form articles, never as chrome.
+
+## Shapes
+
+### Border Radius Scale
+
+| Token | Value | Use |
+|---|---|---|
+| `{rounded.none}` | 0px | Hero chapter, footer, dark CTA strips, primary nav |
+| `{rounded.xs}` | 1px | Decorative micro-rules and inset accent strips |
+| `{rounded.sm}` | 2px | Every interactive element — buttons, cards, inputs, pill tabs, badges |
+| `{rounded.full}` | 9999px / 50% | Avatar circles, social-icon dots, brand wordmark icon |
+
+The system is aggressively angular. Outside of avatar/icon circles, no element exceeds 2px radius. The 2px is enough to soften the optical aliasing on a sharp edge but small enough that the system reads as engineering-grade rather than consumer-friendly.
+
+### Photography Geometry
+- **Hero imagery:** full-bleed 16:9 (desktop) cropping to 4:5 portrait on mobile.
+- **Card imagery:** 16:9 thumbnail at the top of resource cards; 1:1 square for product/SKU cards; 3:2 for editorial article cards.
+- **Decorative corner squares:** 12×12px on standard cards, scaled to 16×16 on hero callouts.
+- **Avatar/social icons:** 32–40px circles with 1px hairline.
+
+## Components
+
+> **No hover states documented** per system policy. Each spec covers Default and Active/Pressed only; variants live as separate `components:` entries in the front matter.
+
+### Buttons
+
+**`button-primary`** — the universal NVIDIA CTA
+- Background `{colors.primary}`, text `{colors.on-primary}`, type `{typography.button-md}`, padding `11px 24px`, height `44px`, rounded `{rounded.sm}`.
+- The single most-repeated component in the system: hero CTA, dark CTA strip, "Learn More" on every card group, "Sign Up" / "Get Started" on every long-form page bottom.
+- Pressed state lives in `button-primary-active` — background drops to `{colors.primary-dark}` (`#5a8d00`) with the same text color.
+
+**`button-outline`** — secondary on light canvas
+- Background transparent, text `{colors.ink}`, 2px solid `{colors.primary}` border, type `{typography.button-md}`, padding `11px 13px`, rounded `{rounded.sm}`.
+- The system's most distinctive secondary CTA: a clear pane bordered in NVIDIA Green. Used for "Read the Documentation", "Watch the Video", "Compare Products" — second-tier actions that still earn the brand color.
+
+**`button-outline-on-dark`** — outline on `{colors.surface-dark}`
+- Background transparent, text `{colors.on-dark}`, 1px solid `{colors.on-dark}`, type `{typography.button-md}`, rounded `{rounded.sm}`.
+- White-on-black variant used in dark hero/footer CTA strips paired with a primary green button.
+
+**`button-ghost-link`** — inline arrow link
+- Text `{colors.primary}` with a small right-arrow icon, type `{typography.button-md}`, no background, no border, rounded `{rounded.none}`.
+- "Learn More →" affordance sitting at the bottom of resource cards and long-form section blocks. The arrow is uppercase and bold per `{typography.caption-md}`-equivalent treatment.
+
+**`button-disabled`**
+- Background `{colors.surface-soft}`, text `{colors.ash}`, rounded `{rounded.sm}` — flat gray.
+
+### Tabs & Chips
+
+**`pill-tab`** + **`pill-tab-active`**
+- Default: transparent background, text `{colors.ink}`, type `{typography.button-sm}`, padding `10px 18px`, rounded `{rounded.sm}`.
+- Active: background `{colors.ink}`, text `{colors.on-dark}` — the tab flips inverted on selection. Used in the "Latest in AI Resources" filter strip and similar segmented controls.
+
+**`badge-tag`**
+- Background `{colors.surface-soft}`, text `{colors.body}`, type `{typography.caption-md}`, padding `4px 10px`, rounded `{rounded.sm}` (uppercase).
+- Document type / category labels at the top of resource cards ("WHITE PAPER", "WEBINAR", "BLOG").
+
+### Inputs & Forms
+
+**`text-input`** + **`text-input-focused`**
+- Default: background `{colors.canvas}`, text `{colors.ink}`, 1px solid `{colors.hairline}`, type `{typography.body-md}`, padding `12px 16px`, height `44px`, rounded `{rounded.sm}`.
+- Focused: same surface, border becomes 2px solid `{colors.primary}` — the green border is the only focus signal in the system.
+
+**`search-input`**
+- Used in the global search overlay — same treatment as `text-input` but at 40px height with a magnifier glyph at left.
+
+### Cards
+
+**`product-card`**
+- Container: background `{colors.canvas}`, 1px solid `{colors.hairline}`, padding `{spacing.xl}` (24px), rounded `{rounded.sm}`.
+- Layout: 16:9 product image at top, `{typography.card-title}` title, `{typography.body-sm}` description, `{component.button-ghost-link}` "Learn More →" affordance at bottom.
+- The `{component.corner-square}` sits at the top-left corner.
+
+**`feature-card`**
+- Container: background `{colors.canvas}`, 1px solid `{colors.hairline}`, padding `{spacing.xxl}` (32px), rounded `{rounded.sm}`.
+- Layout: icon (Font Awesome at 22–24px) at top in `{colors.primary}` followed by `{typography.heading-md}` title and `{typography.body-md}` body.
+- Used in 3-up or 4-up grids that explain product capabilities ("Agentic AI", "Data Science", "Inference", "Conversational AI").
+
+**`resource-card`**
+- Container: background `{colors.canvas}`, 1px solid `{colors.hairline}`, padding `{spacing.xl}`, rounded `{rounded.sm}`.
+- Header strip: `{component.badge-tag}` document-type label.
+- Body: 3:2 thumbnail, `{typography.card-title}` title, `{typography.body-sm}` description.
+- Footer: ghost-link "Read More →" with right-pointing chevron in `{colors.primary}`.
+
+**`callout-stat`**
+- Background `{colors.canvas}` with 1px hairline `{colors.hairline}`, padding `{spacing.xxl}`, rounded `{rounded.sm}`.
+- Massive `{typography.display-lg}` (36px) numeric in `{colors.primary}` followed by `{typography.body-md}` caption underneath ("4× faster training", "60% lower cost", etc.). Used inside long-form industry pages.
+
+### Hero & CTA Strips
+
+**`hero-card-dark`**
+- Background `{colors.surface-dark}` with full-bleed 16:9 photographic/3D image and dark gradient overlay; copy slot at left.
+- `{typography.display-xl}` headline `{colors.on-dark}`, `{typography.heading-lg}` subhead, single `{component.button-primary}` CTA (sometimes paired with `{component.button-outline-on-dark}`).
+- Anchors the top of every primary landing page.
+
+**`cta-strip-dark`**
+- Same surface as hero but compressed to a 1-row band with `{typography.heading-xl}` headline + single CTA.
+- Sits between content sections as a "Ready to get started?" bridge.
+
+### Decorative
+
+**`corner-square`**
+- 12×12px solid `{colors.primary}` square anchored to a card corner. The brand's signature ornamental motif.
+- Used on resource cards, feature cards, and editorial callouts. Position varies (top-left, bottom-right) but the size and color are constant.
+
+### Navigation
+
+**`utility-bar`**
+- Background `{colors.surface-dark}`, text `{colors.on-dark}`, height 32px, type `{typography.caption-sm}`, rounded `{rounded.none}`.
+- Right-aligned cluster: locale selector / "Login" / "Account". Always present at the very top of the page.
+
+**`primary-nav`**
+- Background `{colors.surface-dark}`, text `{colors.on-dark}`, height 64px, type `{typography.body-strong}`, rounded `{rounded.none}`.
+- Layout: NVIDIA wordmark at left, centered nav row ("Products / Solutions / Industries / Resources / Support / Company"), right cluster (search-glyph + "Login" button + green CTA "Get Started").
+
+**`breadcrumb-bar`**
+- Background `{colors.surface-soft}`, text `{colors.body}`, height 48px, type `{typography.caption-md}` (uppercase).
+- Sits directly under the primary nav on every interior page; chevron separators in `{colors.mute}`.
+
+**`sub-nav-strip`**
+- Background `{colors.surface-soft}`, text `{colors.ink}`, height 56px, type `{typography.button-md}`, rounded `{rounded.none}`.
+- Section-specific nav anchored above content (e.g., "Healthcare → Drug Discovery / Medical Imaging / Genomics / Patient Care").
+
+**Top Nav (Mobile)**
+- Hamburger menu icon (left), NVIDIA wordmark (center), search + locale icons (right). Primary nav collapses into a full-screen drawer that slides in from the right.
+
+### Footer
+
+**`footer-section`**
+- Background `{colors.surface-dark}`, text `{colors.on-dark-mute}`, padding `{spacing.section}` (64px) vertical / 48px horizontal, rounded `{rounded.none}`.
+- Layout: 6-column link grid (Products / Software / Resources / Company Info / Solutions / Support) with column headers in `{typography.body-strong}` `{colors.on-dark}` and link lists in `{typography.body-sm}` `{colors.on-dark-mute}`.
+- Below the columns: social-icon strip + locale selector + legal/privacy fine-print row in `{typography.utility-xs}` (uppercase) `{colors.mute}`.
+
+### Inline
+
+**`link-inline`**
+- Body-prose anchor link: `{colors.link-blue}` text with underline. The ONLY blue in the system — appears nowhere except inline links inside `{typography.body-md}` paragraphs.
+
+## Do's and Don'ts
+
+### Do
+- Reserve `{colors.primary}` for primary CTAs, active states, decorative corner squares, and the NVIDIA wordmark itself. Treat it as a precious resource.
+- Stack hero/footer chapters in `{colors.surface-dark}` and body sections in `{colors.canvas}` — alternate them in a predictable rhythm down the page.
+- Anchor a `{component.corner-square}` to one corner of every reusable card. It is the system's identity tag.
+- Use `{rounded.sm}` (2px) on every interactive element. Never go to 0, never go past 4.
+- Build hierarchy from font weight (400 vs 700) and size, not from color tinting. Body text stays `{colors.ink}` or `{colors.body}` regardless of context.
+- Stack content sections at `{spacing.section}` (64px) rhythm with no decorative dividers between them.
+- Pair `{component.button-primary}` (green fill) with `{component.button-outline}` (green border) for primary + secondary action pairs.
+
+### Don't
+- Don't introduce drop shadows on cards or content surfaces. The only allowed shadow is the 5px ambient on sticky chrome.
+- Don't substitute `{colors.success-deep}`, `{colors.accent-green-pale}`, or any other green for `{colors.primary}` in CTAs. The brand green is precise.
+- Don't use `{colors.link-blue}` outside of inline body-prose links. It is not a button color, not a chrome color.
+- Don't soften the geometry. No pill buttons, no rounded cards, no `{rounded.lg}` or higher anywhere except avatars and social icons.
+- Don't pad the hero `{component.hero-card-dark}` symmetrically. Copy hugs the left third; imagery fills the right.
+- Don't add a second accent color for variety. The system is intentionally one-color.
+- Don't put `{component.button-primary}` on a `{colors.canvas}` background where green-on-white would clash with photo content — use `{component.button-outline}` instead and reserve fill for dark surfaces.
+
+## Responsive Behavior
+
+### Breakpoints
+
+| Name | Width | Key Changes |
+|---|---|---|
+| ultrawide | 1920px+ | Content max-width holds at 1280px; outer gutters grow to ~80px |
+| desktop-large | 1440px | Default desktop layout — 4-up card grid, 6-col footer |
+| desktop | 1280px | Same as large with slightly narrower outer gutters |
+| desktop-small | 1024px | 4-up cards collapse to 3-up; sub-nav remains horizontal |
+| tablet | 768px | 3-up cards collapse to 2-up; primary nav becomes hamburger drawer |
+| mobile | 480px | Single-column everything; footer columns collapse to accordion |
+| mobile-narrow | 320px | Hero `{typography.display-xl}` scales from 48px → 32px |
+
+### Touch Targets
+All interactive elements meet WCAG AA (≥ 44×44px). `{component.button-primary}` sits at 44px height with 24px horizontal padding. `{component.text-input}` sits at 44px. `{component.pill-tab}` sits at ~40px height with extended hit-target padding to 44px. `{component.button-outline}` matches the 44px standard. Footer links are 18–20px line-height with 8–12px vertical padding to keep tap targets at ~36–44px depending on link length.
+
+### Collapsing Strategy
+- **Primary nav:** desktop center cluster → tablet hamburger drawer at 768px.
+- **Card grid:** 4-up → 3-up → 2-up → 1-up at 1024, 768, and 480px; gutters drop from 24px to 16px on mobile.
+- **Footer:** 6-up link columns → 2-up at tablet → full accordion at mobile (each column header becomes a tap-to-expand row).
+- **Hero copy:** desktop `{typography.display-xl}` (48px) → tablet 36px → mobile 32px; line-height holds at 1.25.
+- **Sub-nav strip:** desktop horizontal anchor row → tablet horizontal scroll → mobile collapses into a select dropdown.
+- **Section padding:** `{spacing.section}` (64px) desktop → 48px tablet → 32px mobile.
+- **Long-form text:** desktop 60/40 body+sidebar → tablet/mobile single-column with sidebar pushed to the bottom.
+
+### Image Behavior
+- Hero imagery uses art-direction crops: 16:9 wide hero on desktop swaps to 4:5 portrait on mobile so the subject stays centered and headline text still has overlay space.
+- Card imagery is a fixed aspect (16:9 for resource, 1:1 for product) that scales rather than re-crops between breakpoints.
+- All non-critical imagery is lazy-loaded as the user scrolls into the next grid row.
+
+## Iteration Guide
+
+1. Focus on ONE component at a time. Pull its YAML entry from the front matter and verify every property resolves.
+2. Reference component names and tokens directly (`{colors.primary}`, `{component.button-primary-active}`, `{rounded.sm}`) — do not paraphrase.
+3. Run `npx @google/design.md lint DESIGN.md` after edits — `broken-ref`, `contrast-ratio`, and `orphaned-tokens` warnings flag issues automatically.
+4. Add new variants as separate component entries (`-active`, `-disabled`, `-focused`) — do not bury them inside prose.
+5. Default body to `{typography.body-md}`; reach for `{typography.body-strong}` for emphasis; reserve `{typography.display-xl}` strictly for hero chapter headlines.
+6. Keep `{colors.primary}` scarce per viewport — if more than one solid-green CTA appears in the same fold, neutralize one to `{component.button-outline}`.
+7. When introducing a new component, ask whether it can be expressed with the existing card + 2px-radius + corner-square + green-CTA vocabulary before adding new tokens. The system's strength is that it almost never needs new ones.
+
+## Known Gaps
+
+- **Mobile screenshots not captured** — responsive behavior synthesizes NVIDIA's known mobile pattern (hamburger drawer, accordion footer, 1-up card grid, hero downscale) from desktop evidence and the documented breakpoint stack.
+- **Hover states not documented** by system policy.
+- **Dialog / modal styling** beyond the locale-selector overlay not visible in the captured surfaces.
+- **Form field styling** for full sign-up / contact forms is not present in the captured surfaces — only inline search and basic text inputs are documented.
+- **Login / authenticated chrome** not in the captured pages.

--- a/astro/src/data/design-md/raycast.md
+++ b/astro/src/data/design-md/raycast.md
@@ -1,0 +1,669 @@
+---
+version: alpha
+name: Raycast-design-analysis
+属于: A dark-canvas developer-tools system that treats the marketing page like an extended product screenshot — pure-near-black background, command-palette mockups as the hero, Inter typography with the ss03 stylistic set turned on, and a single white CTA pill that doesn't break the inky atmosphere. The chrome reads like Raycast's own command-palette UI scaled up to a marketing page: monochrome dark surfaces with a faint surface ladder (#07080a → #0d0d0d → #101111), tight 6–10px radius on cards, hairline 1px borders in #242728, and rare splashes of saturated accent (Hacker News yellow, Slack red, Mac green, info blue) reserved for product-tile category illustrations. The signature visual moment is a red gradient hero wordmark — three diagonal red stripes laid across the very top of the home page like a launch-banner — paired with full-bleed product UI screenshots that show Raycast's actual command palette, store, and AI chat surfaces.
+description: |
+  Raycast's marketing system reads like an extended product screenshot. The chrome IS the in-product chrome at marketing scale: pure-near-black canvas, hairline 1px borders, command-palette-style cards, Inter typography with the ss03 stylistic set enabled site-wide, white CTA pill, and a small set of saturated category accent colors (yellow / red / green / blue) reserved for extension and feature illustrations. Section rhythm is generous (~96px) but the page never breaks tonal continuity — the whole site sits in one continuous dark mode.
+
+colors:
+  primary: "#ffffff"
+  primary-pressed: "#e8e8e8"
+  on-primary: "#000000"
+  ink: "#f4f4f6"
+  body: "#cdcdcd"
+  charcoal: "#d3d3d4"
+  mute: "#9c9c9d"
+  ash: "#6a6b6c"
+  stone: "#434345"
+  on-dark: "#ffffff"
+  on-dark-mute: "rgba(255,255,255,0.72)"
+  canvas: "#07080a"
+  surface: "#0d0d0d"
+  surface-elevated: "#101111"
+  surface-card: "#121212"
+  button-fg: "#18191a"
+  hairline: "#242728"
+  hairline-soft: "rgba(255,255,255,0.08)"
+  hairline-strong: "rgba(255,255,255,0.16)"
+  accent-blue: "#57c1ff"
+  accent-blue-soft: "rgba(87,193,255,0.15)"
+  accent-red: "#ff6161"
+  accent-red-soft: "rgba(255,97,97,0.15)"
+  accent-green: "#59d499"
+  accent-green-soft: "rgba(89,212,153,0.15)"
+  accent-yellow: "#ffc533"
+  accent-yellow-soft: "rgba(255,197,51,0.15)"
+  hero-stripe-start: "#ff5757"
+  hero-stripe-end: "#a1131a"
+  key-bg-start: "#121212"
+  key-bg-end: "#0d0d0d"
+
+typography:
+  display-xl:
+    fontFamily: Inter
+    fontSize: 64px
+    fontWeight: 600
+    lineHeight: 1.1
+    letterSpacing: 0
+    fontFeature: '"calt", "kern", "liga", "ss03"'
+  display-lg:
+    fontFamily: Inter
+    fontSize: 56px
+    fontWeight: 500
+    lineHeight: 1.17
+    letterSpacing: 0.2px
+    fontFeature: '"calt", "kern", "liga", "ss03"'
+  heading-xl:
+    fontFamily: Inter
+    fontSize: 24px
+    fontWeight: 500
+    lineHeight: 1.6
+    letterSpacing: 0.2px
+    fontFeature: '"calt", "kern", "liga", "ss03"'
+  heading-lg:
+    fontFamily: Inter
+    fontSize: 22px
+    fontWeight: 500
+    lineHeight: 1.15
+    letterSpacing: 0
+    fontFeature: '"calt", "kern", "liga", "ss03"'
+  heading-md:
+    fontFamily: Inter
+    fontSize: 20px
+    fontWeight: 500
+    lineHeight: 1.4
+    letterSpacing: 0.2px
+    fontFeature: '"calt", "kern", "liga", "ss03"'
+  heading-sm:
+    fontFamily: Inter
+    fontSize: 18px
+    fontWeight: 500
+    lineHeight: 1.4
+    letterSpacing: 0.2px
+    fontFeature: '"calt", "kern", "liga", "ss03"'
+  body-lg:
+    fontFamily: Inter
+    fontSize: 18px
+    fontWeight: 400
+    lineHeight: 1.6
+    letterSpacing: 0
+    fontFeature: '"calt", "kern", "liga", "ss03"'
+  body-md:
+    fontFamily: Inter
+    fontSize: 16px
+    fontWeight: 400
+    lineHeight: 1.6
+    letterSpacing: 0
+    fontFeature: '"calt", "kern", "liga", "ss03"'
+  body-strong:
+    fontFamily: Inter
+    fontSize: 16px
+    fontWeight: 500
+    lineHeight: 1.4
+    letterSpacing: 0.2px
+    fontFeature: '"calt", "kern", "liga", "ss03"'
+  body-sm:
+    fontFamily: Inter
+    fontSize: 14px
+    fontWeight: 400
+    lineHeight: 1.6
+    letterSpacing: 0
+    fontFeature: '"calt", "kern", "liga", "ss03"'
+  body-sm-strong:
+    fontFamily: Inter
+    fontSize: 14px
+    fontWeight: 500
+    lineHeight: 1.6
+    letterSpacing: 0.2px
+    fontFeature: '"calt", "kern", "liga", "ss03"'
+  caption-md:
+    fontFamily: Inter
+    fontSize: 13px
+    fontWeight: 400
+    lineHeight: 1.4
+    letterSpacing: 0.1px
+    fontFeature: '"calt", "kern", "liga", "ss03"'
+  caption-sm:
+    fontFamily: Inter
+    fontSize: 12px
+    fontWeight: 400
+    lineHeight: 1.5
+    letterSpacing: 0.4px
+    fontFeature: '"calt", "kern", "liga", "ss03"'
+  link-md:
+    fontFamily: Inter
+    fontSize: 16px
+    fontWeight: 500
+    lineHeight: 1.4
+    letterSpacing: 0.3px
+    fontFeature: '"calt", "kern", "liga", "ss03"'
+  button-md:
+    fontFamily: Inter
+    fontSize: 14px
+    fontWeight: 500
+    lineHeight: 1.6
+    letterSpacing: 0.2px
+    fontFeature: '"calt", "kern", "liga", "ss03"'
+
+rounded:
+  none: 0px
+  xs: 4px
+  sm: 6px
+  md: 8px
+  lg: 10px
+  xl: 16px
+  full: 9999px
+
+spacing:
+  xxs: 2px
+  xs: 4px
+  sm: 8px
+  md: 12px
+  lg: 16px
+  xl: 24px
+  xxl: 32px
+  section: 96px
+
+components:
+  button-primary:
+    backgroundColor: "{colors.primary}"
+    textColor: "{colors.on-primary}"
+    typography: "{typography.button-md}"
+    rounded: "{rounded.md}"
+    padding: 8px 16px
+    height: 36px
+  button-primary-pressed:
+    backgroundColor: "{colors.primary-pressed}"
+    textColor: "{colors.on-primary}"
+    typography: "{typography.button-md}"
+    rounded: "{rounded.md}"
+  button-secondary:
+    backgroundColor: "transparent"
+    textColor: "{colors.on-dark}"
+    typography: "{typography.button-md}"
+    rounded: "{rounded.md}"
+    padding: 8px 16px
+    height: 36px
+  button-tertiary:
+    backgroundColor: "{colors.surface-elevated}"
+    textColor: "{colors.on-dark}"
+    typography: "{typography.button-md}"
+    rounded: "{rounded.md}"
+    padding: 8px 16px
+    height: 36px
+  button-disabled:
+    backgroundColor: "{colors.surface-elevated}"
+    textColor: "{colors.ash}"
+    rounded: "{rounded.md}"
+  install-button:
+    backgroundColor: "transparent"
+    textColor: "{colors.on-dark}"
+    typography: "{typography.button-md}"
+    rounded: "{rounded.md}"
+    padding: 6px 14px
+  text-input:
+    backgroundColor: "{colors.surface-elevated}"
+    textColor: "{colors.on-dark}"
+    typography: "{typography.body-md}"
+    rounded: "{rounded.md}"
+    padding: 8px 12px
+    height: 36px
+  text-input-focused:
+    backgroundColor: "{colors.surface-elevated}"
+    textColor: "{colors.on-dark}"
+    rounded: "{rounded.md}"
+  store-search-bar:
+    backgroundColor: "{colors.surface-elevated}"
+    textColor: "{colors.on-dark}"
+    typography: "{typography.body-md}"
+    rounded: "{rounded.md}"
+    padding: 10px 16px
+    height: 44px
+  command-palette-row:
+    backgroundColor: "transparent"
+    textColor: "{colors.on-dark}"
+    typography: "{typography.body-md}"
+    rounded: "{rounded.sm}"
+    padding: 6px 10px
+  command-palette-row-active:
+    backgroundColor: "{colors.surface-card}"
+    textColor: "{colors.on-dark}"
+    typography: "{typography.body-md}"
+    rounded: "{rounded.sm}"
+  pill-tab:
+    backgroundColor: "transparent"
+    textColor: "{colors.body}"
+    typography: "{typography.body-sm}"
+    rounded: "{rounded.full}"
+    padding: 4px 10px
+  pill-tab-active:
+    backgroundColor: "{colors.surface-elevated}"
+    textColor: "{colors.on-dark}"
+    typography: "{typography.body-sm}"
+    rounded: "{rounded.full}"
+  badge-pro:
+    backgroundColor: "{colors.surface-elevated}"
+    textColor: "{colors.on-dark-mute}"
+    typography: "{typography.caption-sm}"
+    rounded: "{rounded.xs}"
+    padding: 2px 6px
+  badge-info-soft:
+    backgroundColor: "{colors.accent-blue-soft}"
+    textColor: "{colors.accent-blue}"
+    typography: "{typography.caption-sm}"
+    rounded: "{rounded.xs}"
+    padding: 2px 8px
+  keycap:
+    backgroundColor: "{colors.surface-card}"
+    textColor: "{colors.body}"
+    typography: "{typography.caption-md}"
+    rounded: "{rounded.xs}"
+    padding: 1px 6px
+    height: 20px
+  command-palette-card:
+    backgroundColor: "{colors.surface}"
+    textColor: "{colors.on-dark}"
+    typography: "{typography.body-md}"
+    rounded: "{rounded.lg}"
+    padding: 0px
+  feature-card-dark:
+    backgroundColor: "{colors.surface}"
+    textColor: "{colors.on-dark}"
+    typography: "{typography.body-md}"
+    rounded: "{rounded.lg}"
+    padding: 24px
+  feature-card-elevated:
+    backgroundColor: "{colors.surface-elevated}"
+    textColor: "{colors.on-dark}"
+    typography: "{typography.body-md}"
+    rounded: "{rounded.lg}"
+    padding: 24px
+  store-extension-card:
+    backgroundColor: "{colors.surface}"
+    textColor: "{colors.on-dark}"
+    typography: "{typography.body-md}"
+    rounded: "{rounded.md}"
+    padding: 16px
+  pricing-tier-card:
+    backgroundColor: "{colors.surface}"
+    textColor: "{colors.on-dark}"
+    typography: "{typography.body-md}"
+    rounded: "{rounded.lg}"
+    padding: 24px
+  pricing-tier-card-featured:
+    backgroundColor: "{colors.surface-elevated}"
+    textColor: "{colors.on-dark}"
+    typography: "{typography.body-md}"
+    rounded: "{rounded.lg}"
+    padding: 24px
+  hero-stripe-band:
+    backgroundColor: "{colors.canvas}"
+    textColor: "{colors.on-dark}"
+    typography: "{typography.display-xl}"
+    rounded: "{rounded.none}"
+    padding: 96px 48px
+  app-icon-tile:
+    backgroundColor: "{colors.surface-card}"
+    rounded: "{rounded.md}"
+    size: 48px
+  app-icon-tile-large:
+    backgroundColor: "{colors.surface-card}"
+    rounded: "{rounded.md}"
+    size: 64px
+  primary-nav:
+    backgroundColor: "{colors.canvas}"
+    textColor: "{colors.on-dark}"
+    typography: "{typography.body-sm-strong}"
+    rounded: "{rounded.none}"
+    height: 56px
+  footer-section:
+    backgroundColor: "{colors.canvas}"
+    textColor: "{colors.body}"
+    typography: "{typography.body-sm}"
+    rounded: "{rounded.none}"
+    padding: 64px 48px
+  link-inline:
+    textColor: "{colors.on-dark}"
+    typography: "{typography.link-md}"
+---
+
+## Overview
+
+Raycast's marketing site reads like an extended product screenshot. The chrome IS the in-product command palette at marketing scale: pure near-black canvas (`{colors.canvas}` — `#07080a`), hairline 1px borders (`{colors.hairline}` — `#242728`), command-palette-style cards with rounded corners between 6 and 16px, Inter typography with the **ss03 stylistic set enabled site-wide** (a single character — the alternate `g` — that gives Raycast's typography its signature subtle distinction), a single white CTA pill that anchors every primary action, and small splashes of saturated accent reserved for category illustrations.
+
+The system has effectively one surface mode — dark — with a faint three-step surface ladder (`{colors.canvas}` → `{colors.surface}` → `{colors.surface-elevated}` → `{colors.surface-card}`) carrying cards, in-card panels, and key-cap glyph backgrounds. The signature decorative moment is a **red diagonal-stripe gradient band** across the very top of the home page hero, used as a launch-banner motif behind the headline (the only time saturated red appears on chrome). Beyond that single moment, color in the chrome is reserved for category accents inside extension and feature illustrations: Hacker News yellow, Slack red, Linear green, info blue.
+
+The design philosophy is "the marketing page is the product." Section rhythm is generous (`{spacing.section}` 96px) but the page never breaks tonal continuity — the whole site sits in one continuous dark mode, full-bleed product UI screenshots show Raycast's actual command palette / store / AI chat surfaces, and the typography ligature settings (`ss03`) are inherited from the in-product app's text rendering.
+
+**Key Characteristics:**
+- Single dark surface mode with a 4-step surface ladder: `{colors.canvas}` (#07080a) → `{colors.surface}` (#0d0d0d) → `{colors.surface-elevated}` (#101111) → `{colors.surface-card}` (#121212)
+- White CTA pill (`{colors.primary}` — #ffffff) is the universal primary action; everything else is monochrome dark
+- Inter typography with `font-feature-settings: "calt", "kern", "liga", "ss03"` enabled site-wide — the ss03 alternate `g` is part of the brand voice
+- Hairline 1px borders (`{colors.hairline}` — #242728) carry every card edge; there are no drop shadows in the system
+- Multi-radius card vocabulary: `{rounded.sm}` (6px) for keycaps, `{rounded.md}` (8px) for buttons and small cards, `{rounded.lg}` (10px) for feature cards, `{rounded.xl}` (16px) for hero command-palette mockup containers
+- Saturated category accents (`{colors.accent-yellow}` for Hacker News, `{colors.accent-red}` for Slack/Apple, `{colors.accent-green}` for productivity tools, `{colors.accent-blue}` for info) appear only inside extension tile imagery — never on chrome
+- Signature red diagonal-stripe gradient band at the very top of the hero — three angled stripes in `{colors.hero-stripe-start}` → `{colors.hero-stripe-end}`, used once per page maximum
+
+## Colors
+
+> **Source pages:** `/` (home), `/store` (extension marketplace), `/core-features/ai` (feature page), `/pricing` (plan tiers), `/thomas/hacker-news` (single extension detail). The chrome palette is identical across all five pages — the dark surface ladder, hairline borders, white CTA, and ss03-enabled typography are the same on every page.
+
+### Brand & Accent
+- **White** (`{colors.primary}` — `#ffffff`): the universal primary CTA pill background. "Download" / "Install Extension" / "Get Pro" — every primary action carries it.
+- **White Pressed** (`{colors.primary-pressed}` — `#e8e8e8`): pressed-state for the primary pill — a single notch dimmer.
+- **On Primary** (`{colors.on-primary}` — `#000000`): pure black text on the white CTA — the only place black appears as text in the system.
+
+### Surface
+- **Canvas** (`{colors.canvas}` — `#07080a`): pure-near-black page background. The dominant surface across every page.
+- **Surface** (`{colors.surface}` — `#0d0d0d`): card and elevated panel background — one notch lighter than canvas.
+- **Surface Elevated** (`{colors.surface-elevated}` — `#101111`): button-tertiary fill, text-input fill, store-search-bar fill, pill-tab-active fill.
+- **Surface Card** (`{colors.surface-card}` — `#121212`): app-icon-tile background, keycap fill, command-palette row hover.
+- **Button FG (in-card)** (`{colors.button-fg}` — `#18191a`): rare deep-card variant used inside featured pricing tier card backgrounds.
+- **Hairline** (`{colors.hairline}` — `#242728`): the universal 1px card border. Carries every card edge across every page.
+- **Hairline Soft** (`{colors.hairline-soft}` — `rgba(255,255,255,0.08)`): even fainter border on translucent over-image overlays.
+- **Hairline Strong** (`{colors.hairline-strong}` — `rgba(255,255,255,0.16)`): stronger 1px divider where a regular hairline reads as too soft.
+
+### Text
+- **Ink** (`{colors.ink}` — `#f4f4f6`): primary headlines on dark canvas. Slightly off-white for tonal coherence with the near-black background.
+- **Body** (`{colors.body}` — `#cdcdcd`): default paragraph text and inline-link color.
+- **Charcoal** (`{colors.charcoal}` — `#d3d3d4`): subtly brighter body where ink reads too soft.
+- **Mute** (`{colors.mute}` — `#9c9c9d`): metadata, footer link text, secondary captions.
+- **Ash** (`{colors.ash}` — `#6a6b6c`): disabled-state text, lowest-emphasis utility.
+- **Stone** (`{colors.stone}` — `#434345`): least-emphasis caption text and disabled icon color.
+- **On Dark** (`{colors.on-dark}` — `#ffffff`): interactive-state primary text (button label, focused tab).
+- **On Dark Mute** (`{colors.on-dark-mute}` — `rgba(255,255,255,0.72)`): translucent secondary text on dark surfaces.
+
+### Semantic
+- **Accent Blue** (`{colors.accent-blue}` — `#57c1ff`) + **Soft** (`{colors.accent-blue-soft}` — `rgba(87,193,255,0.15)`): info and informational badge — used inside feature illustrations and the rare "New" pill.
+- **Accent Red** (`{colors.accent-red}` — `#ff6161`) + **Soft** (`{colors.accent-red-soft}` — `rgba(255,97,97,0.15)`): destructive/error indicator + Slack/Apple category accent in extension illustrations.
+- **Accent Green** (`{colors.accent-green}` — `#59d499`) + **Soft** (`{colors.accent-green-soft}` — `rgba(89,212,153,0.15)`): success state + productivity category accent in extension illustrations.
+- **Accent Yellow** (`{colors.accent-yellow}` — `#ffc533`) + **Soft** (`{colors.accent-yellow-soft}` — `rgba(255,197,51,0.15)`): "warning" semantic + the Hacker News orange-yellow that appears as the most prominent accent illustration on the home page hero.
+
+### Brand Gradient
+- **Hero Stripe Gradient** — three diagonal red stripes layered across the very top of the home page hero, fading from `{colors.hero-stripe-start}` (`#ff5757`) to `{colors.hero-stripe-end}` (`#a1131a`). The system's only chromatic gradient on chrome — used once per page maximum and reserved for hero launch-banner moments.
+- **Keycap Gradient** — the small key-glyph background uses a subtle linear-gradient from `{colors.key-bg-start}` (`#121212`) to `{colors.key-bg-end}` (`#0d0d0d`) that gives Raycast's keycap UI its slight 3D-key feel.
+
+## Typography
+
+### Font Family
+**Inter** is the system's primary face, loaded with the `Inter Fallback` system fallback variant. Critically, Raycast enables `font-feature-settings: "calt", "kern", "liga", "ss03"` site-wide — the **ss03 stylistic set** swaps in Inter's alternate `g` glyph (single-story open `g`), which is the brand's signature typographic detail. Standard ligatures (`liga`), kerning (`kern`), and contextual alternates (`calt`) are also active. The display tier additionally enables `ss02` and `ss08` and disables standard `liga` to render the hero "Raycast Pro" wordmark with its distinctive geometric construction.
+
+There is no monospace face used outside of inline `<code>` chips in documentation; the marketing pages use Inter for everything.
+
+### Hierarchy
+
+| Token | Size | Weight | Line Height | Letter Spacing | Use |
+|---|---|---|---|---|---|
+| `{typography.display-xl}` | 64px | 600 | 1.1 | 0 | Hero "Built for the perfect tools" / "The new way to..." headline (with `liga: 0`, `ss02`, `ss08`) |
+| `{typography.display-lg}` | 56px | 500 | 1.17 | 0.2px | Section headline ("Explore", "Pricing", store hero "Store") |
+| `{typography.heading-xl}` | 24px | 500 | 1.6 | 0.2px | Sub-section heading, pricing-tier name |
+| `{typography.heading-lg}` | 22px | 500 | 1.15 | 0 | Mid-section feature heading |
+| `{typography.heading-md}` | 20px | 500 | 1.4 | 0.2px | Card group title, in-card heading |
+| `{typography.heading-sm}` | 18px | 500 | 1.4 | 0.2px | Small heading, extension card title |
+| `{typography.body-lg}` | 18px | 400 | 1.6 | 0 | Pricing tier description, hero subtitle |
+| `{typography.body-md}` | 16px | 400 | 1.6 | 0 | Default body, paragraph text |
+| `{typography.body-strong}` | 16px | 500 | 1.4 | 0.2px | Inline emphasis, primary nav link |
+| `{typography.body-sm}` | 14px | 400 | 1.6 | 0 | Card description, secondary copy |
+| `{typography.body-sm-strong}` | 14px | 500 | 1.6 | 0.2px | In-card label, table-header text |
+| `{typography.caption-md}` | 13px | 400 | 1.4 | 0.1px | Caption, metadata |
+| `{typography.caption-sm}` | 12px | 400 | 1.5 | 0.4px | Smallest utility text, badge label |
+| `{typography.link-md}` | 16px | 500 | 1.4 | 0.3px | Inline body anchor link |
+| `{typography.button-md}` | 14px | 500 | 1.6 | 0.2px | Standard button label |
+
+### Principles
+The hierarchy works on a 1.6-line-height ladder for body and a 1.1–1.4 ladder for display/heading. Letter-spacing is consistently positive (0.1–0.4px) — slightly opening the type — which gives Raycast's chrome an airy quality at body sizes despite the dark canvas. The `ss03` stylistic set is the brand's most distinctive typographic detail; without it, the body face renders identically to plain Inter and loses Raycast's signature rendering.
+
+### Note on Font Substitutes
+Inter is open-source and Google-Fonts-hosted; load it directly. To preserve the brand's signature look, you must enable `font-feature-settings: "calt", "kern", "liga", "ss03"` on the body element. Without `ss03`, the typography is recognizably "Inter default" rather than "Raycast." On systems where Inter cannot be loaded, the documented fallback is `Inter Fallback` (a self-hosted variant) → `system-ui`. **JetBrains Mono** or **Geist Mono** are acceptable substitutes for inline code chips when needed, though Raycast's marketing chrome rarely uses code-styled text.
+
+## Layout
+
+### Spacing System
+- **Base unit:** 8px (with 2/4/12px steps for tight inline gaps).
+- **Tokens (front matter):** `{spacing.xxs}` (2px) · `{spacing.xs}` (4px) · `{spacing.sm}` (8px) · `{spacing.md}` (12px) · `{spacing.lg}` (16px) · `{spacing.xl}` (24px) · `{spacing.xxl}` (32px) · `{spacing.section}` (96px).
+- **Universal section rhythm:** every page in the set uses `{spacing.section}` (96px) as the vertical gap between major content blocks. Card grids use `{spacing.lg}` (16px) gutters; in-card padding sits at `{spacing.xl}` (24px) for feature cards and `{spacing.lg}` (16px) for store extension cards.
+
+### Grid & Container
+- **Max width:** ~1240px content area at desktop with 24px gutters (~48px at ultrawide). Hero command-palette mockups run wider (~1080px) with the page background extending to full bleed.
+- **Store extension grid:** 2-up at desktop with rows of 2 cards stacked, collapsing to 1-up at mobile. Each card is a horizontal layout with a large square app icon at the left and copy + Install button at the right.
+- **Pricing tier grid:** 3-up at desktop (Free / Pro / Pro+Advanced AI), collapsing to 1-up stacked at mobile.
+- **Featured extension card grid:** 3-up at desktop in the "Featured" row at the top of the store page.
+- **Comparison table:** full-width on the pricing page below the tier cards — 5-column table (Free / Pro / Advanced AI / Custom for Teams / Enterprise) with feature rows.
+- **Footer:** 6-column horizontal link grid at desktop, collapsing to 2-up at tablet and 1-up at mobile.
+
+### Whitespace Philosophy
+Whitespace is generous and the canvas is uninterrupted. Sections sit 96px apart with no decorative dividers between them — the dark canvas continues edge-to-edge from hero to footer. Inside a section, content is left-aligned in a tight column, with command-palette mockup imagery occupying the right 50–60% of the band on home-page feature rows. The signature decorative element — the red diagonal-stripe gradient band — only appears in the very first hero band; from the second section down, the page is monochrome dark.
+
+## Elevation & Depth
+
+| Level | Treatment | Use |
+|---|---|---|
+| 0 — Flat | No border, no shadow | Default for canvas-on-canvas blocks, hero text, footer body |
+| 1 — Hairline border | 1px solid `{colors.hairline}` (#242728) | Every card on `{colors.surface}`, store extension card, pricing tier card |
+| 2 — Hairline strong | 1px solid `{colors.hairline-strong}` | Stronger inline divider, table-row separator on the comparison table |
+| 3 — Surface ladder elevation | `{colors.canvas}` → `{colors.surface}` → `{colors.surface-elevated}` → `{colors.surface-card}` | Multi-step background-color ladder used to create elevation without shadows |
+
+The system has no drop-shadow elevation at all. Depth is built entirely from the surface-color ladder: each notch lighter on the dark scale reads as one step closer to the viewer.
+
+### Decorative Depth
+Depth comes from product imagery and a single stripe-gradient band:
+- **Hero stripe gradient** — three diagonal red stripes (`{colors.hero-stripe-start}` → `{colors.hero-stripe-end}`) layered across the home-page hero band, evoking a launch-banner / motion-blur effect. The system's signature decorative moment.
+- **Command-palette mockups** — full-fidelity Raycast in-product UI screenshots (the actual Spotlight-style overlay with rounded keycaps, command rows, and accent-color glyphs) sitting inside the home-page hero and feature rows. These ARE the brand decoration.
+- **App icon tiles** — small 48–64px rounded-corner tiles displaying real app icons (Slack, Spotify, Figma, Notion, Linear, Hacker News) inside store and feature illustrations.
+- **Keycap glyphs** — subtle gradient-filled rounded keycap glyphs used inline to indicate keyboard shortcuts (e.g., `⌘ K`), with a faint `{colors.key-bg-start}` → `{colors.key-bg-end}` linear gradient suggesting a physical key surface.
+
+## Shapes
+
+### Border Radius Scale
+
+| Token | Value | Use |
+|---|---|---|
+| `{rounded.none}` | 0px | Hero band, primary nav, footer, full-bleed structural surfaces |
+| `{rounded.xs}` | 4px | Keycap glyphs, badge-pro chips, small inline tags |
+| `{rounded.sm}` | 6px | Command-palette row, inline buttons, micro chips |
+| `{rounded.md}` | 8px | Standard buttons, text inputs, store search bar, app-icon tiles, store extension card |
+| `{rounded.lg}` | 10px | Feature card, command-palette mockup card, pricing tier card |
+| `{rounded.xl}` | 16px | Large hero command-palette mockup container, oversized feature panel |
+| `{rounded.full}` | 9999px | Pill-tab chips, avatar circles |
+
+The radius vocabulary clusters tightly between 4 and 16px, with most chrome at 6–10px. The system never goes flat (0px) on cards and never above 16px except for fully-rounded pills.
+
+### Photography Geometry
+There is no traditional photography. Visual elements are limited to:
+- **Command-palette mockups** — full-fidelity Raycast UI screenshots at 16:9 or 4:3 aspect inside `{rounded.xl}` (16px) containers.
+- **App icon tiles** — 48–64px square at `{rounded.md}` (8px), displaying real app icons.
+- **Avatar circles** — 32–40px at `{rounded.full}` for in-extension author attribution.
+- **Hero stripe gradient** — full-bleed wash with no aspect ratio.
+
+## Components
+
+> **No hover states documented** per system policy. Each spec covers Default and Active/Pressed only.
+
+### Buttons
+
+**`button-primary`** — the universal Raycast CTA
+- Background `{colors.primary}` (white), text `{colors.on-primary}` (black), type `{typography.button-md}`, padding `8px 16px`, height ~36px, rounded `{rounded.md}`.
+- Used for "Download" (sticky top-nav CTA), "Get Pro", "Install" — every primary action across every surface.
+- Pressed state lives in `button-primary-pressed` — background dims to `{colors.primary-pressed}`.
+
+**`button-secondary`** — transparent text button
+- Background transparent, text `{colors.on-dark}`, type `{typography.button-md}`, padding `8px 16px`, height ~36px, rounded `{rounded.md}`.
+- Lower-emphasis action: "Sign in" (top nav), "Learn more →", "View on GitHub".
+
+**`button-tertiary`** — soft surface button
+- Background `{colors.surface-elevated}`, text `{colors.on-dark}`, type `{typography.button-md}`, padding `8px 16px`, height ~36px, rounded `{rounded.md}`.
+- Mid-emphasis: "Watch demo", "View extension", "Manage" buttons inside cards.
+
+**`button-disabled`**
+- Background `{colors.surface-elevated}`, text `{colors.ash}` — dim utility state.
+
+**`install-button`** — the store-page install pill
+- Background transparent with 1px solid `{colors.hairline-strong}` border, text `{colors.on-dark}`, type `{typography.button-md}`, padding `6px 14px`, rounded `{rounded.md}`.
+- Sits at the right edge of every store extension card with the label "Install Extension".
+
+### Filter & Tab Chips
+
+**`pill-tab`** + **`pill-tab-active`** — small filter chip strip
+- Default: transparent background, text `{colors.body}`, type `{typography.body-sm}`, padding `4px 10px`, rounded `{rounded.full}`.
+- Active: background flips to `{colors.surface-elevated}`, text `{colors.on-dark}` — the chip "lifts" by one surface notch.
+- Used in the store filter row ("All Extensions", "Recently Added", "Most Popular") and similar segmented controls.
+
+**`badge-pro`** — small Pro/Plan label
+- Background `{colors.surface-elevated}`, text `{colors.on-dark-mute}`, type `{typography.caption-sm}`, padding `2px 6px`, rounded `{rounded.xs}`.
+- Inline "Pro" / "Pro+" / "Free" tier indicators on pricing tier cards.
+
+**`badge-info-soft`** — translucent info chip
+- Background `{colors.accent-blue-soft}`, text `{colors.accent-blue}`, type `{typography.caption-sm}`, padding `2px 8px`, rounded `{rounded.xs}`.
+- Rare "New" / "Beta" inline tag.
+
+### Inputs & Forms
+
+**`text-input`** + **`text-input-focused`**
+- Default: background `{colors.surface-elevated}`, text `{colors.on-dark}`, 1px solid `{colors.hairline}`, type `{typography.body-md}`, padding `8px 12px`, height ~36px, rounded `{rounded.md}`.
+- Focused: same surface; 1px border becomes `{colors.hairline-strong}` — a subtle brightening rather than a colored ring.
+
+**`store-search-bar`** — the store-page search field
+- Background `{colors.surface-elevated}`, text `{colors.on-dark}`, type `{typography.body-md}`, padding `10px 16px`, height ~44px, rounded `{rounded.md}`.
+- Sits at the top of the store page hero with a magnifier icon at the left and "Search the store..." placeholder. Slightly taller than the standard `text-input`.
+
+### Cards & Containers
+
+**`command-palette-card`** — the home-page hero command-palette mockup
+- Container: background `{colors.surface}`, 1px solid `{colors.hairline}`, padding 0 (the mockup contents fill the card), rounded `{rounded.lg}` or `{rounded.xl}` depending on hero size.
+- Layout: top header strip with macOS traffic-light dots + a search input row, body with a vertical stack of `{component.command-palette-row}` items, bottom-right keycap hint cluster.
+
+**`command-palette-row`** + **`command-palette-row-active`** — single row inside the command palette
+- Default: transparent background, text `{colors.on-dark}` in `{typography.body-md}`, padding `6px 10px`, rounded `{rounded.sm}`.
+- Active: background `{colors.surface-card}` (one notch lighter than the surrounding palette card) — the selection state.
+- Each row contains a small app-icon tile + label + optional keycap shortcut at the right edge.
+
+**`feature-card-dark`** — standard product feature card
+- Container: background `{colors.surface}`, 1px solid `{colors.hairline}`, padding `{spacing.xl}` (24px), rounded `{rounded.lg}`.
+- Used in 2- or 3-up grids on home and feature pages — pairs a small product mockup or app-icon row with body copy and a "Learn more →" `{component.button-secondary}`.
+
+**`feature-card-elevated`** — slightly-elevated variant
+- Same chrome as `feature-card-dark` but background flips to `{colors.surface-elevated}` — used to break visual rhythm in alternating feature rows.
+
+**`store-extension-card`** — store-page extension card
+- Container: background `{colors.surface}`, 1px solid `{colors.hairline}`, padding `{spacing.lg}` (16px), rounded `{rounded.md}`.
+- Layout: 48px `{component.app-icon-tile}` at left, vertical stack of name + by-author metadata + 1-line description in the center, `{component.install-button}` at the right edge.
+
+**`pricing-tier-card`** — pricing plan card (default tier)
+- Container: background `{colors.surface}`, 1px solid `{colors.hairline}`, padding `{spacing.xl}` (24px), rounded `{rounded.lg}`.
+- Layout: tier name in `{typography.heading-xl}` (24px), price in larger numeric in `{typography.display-lg}`, body description in `{typography.body-lg}`, CTA `{component.button-primary}` (or `{component.button-secondary}` for free tier), feature checklist with `✓` glyphs.
+
+**`pricing-tier-card-featured`** — middle "Pro" featured tier
+- Same chrome but background flips to `{colors.surface-elevated}` (one notch lighter) — the only visual cue distinguishing the featured tier from the surrounding cards.
+
+**`hero-stripe-band`** — home-page hero with red stripe gradient
+- Background `{colors.canvas}` with three diagonal red stripes layered across the top half (`{colors.hero-stripe-start}` → `{colors.hero-stripe-end}`).
+- Padding `{spacing.section}` 96px vertical / 48px horizontal, rounded `{rounded.none}`.
+- Carries the hero headline in `{typography.display-xl}` and a single `{component.button-primary}` "Download" CTA.
+
+### Decorative
+
+**`app-icon-tile`** — small 48px square app icon
+- Background `{colors.surface-card}`, padding 0 (icon fills the tile), rounded `{rounded.md}`, size 48×48.
+- Used in command-palette rows and store extension cards.
+
+**`app-icon-tile-large`** — 64px feature variant
+- Same but at 64×64. Used in featured store cards and home-page hero illustration rows.
+
+**`keycap`** — keyboard shortcut glyph
+- Background `{colors.surface-card}` with a subtle linear gradient `{colors.key-bg-start}` → `{colors.key-bg-end}`, text `{colors.body}` in `{typography.caption-md}`, padding `1px 6px`, height ~20px, rounded `{rounded.xs}`.
+- Renders inline command-palette shortcut hints like `⌘ K`, `⏎`, `Esc`. The signature "physical-key" feel on a flat dark canvas.
+
+### Navigation
+
+**`primary-nav`**
+- Background `{colors.canvas}`, text `{colors.on-dark}`, height ~56px, type `{typography.body-sm-strong}`, rounded `{rounded.none}`, with a 1px `{colors.hairline}` bottom rule.
+- Layout (desktop): Raycast wordmark at left, centered nav cluster ("Pro · AI · Store · Manual · Changelog · Blog · Pricing"), right cluster (Sign in link + the always-white `{component.button-primary}` "Download" CTA pill).
+
+**Top Nav (Mobile)**
+- Hamburger menu icon at left, Raycast wordmark at center, "Download" white CTA pill at right. Primary nav collapses into a full-screen drawer that slides from the left.
+
+### Footer
+
+**`footer-section`**
+- Background `{colors.canvas}`, text `{colors.body}` in `{typography.body-sm}`, padding `64px 48px`, with a 1px `{colors.hairline}` top rule.
+- Layout: 6-column horizontal link grid (Product · Core Features · Top Extensions · Company · Community · By Raycast) with column headers in `{typography.body-sm-strong}` `{colors.on-dark}` and link lists in `{typography.body-sm}` `{colors.body}`.
+- Bottom row: small Raycast wordmark + a subscribe newsletter input field with `{component.button-primary}` "Subscribe" at the right.
+- The very top of the footer band has a faint red stripe-gradient repeat — a smaller echo of the hero's diagonal stripe motif.
+
+### Inline
+
+**`link-inline`** — body-prose anchor link
+- `{colors.on-dark}` text with no underline by default; underlines on focus. Inline body links are full-white rather than a tinted accent color, which keeps the dark canvas tonally pure.
+
+## Do's and Don'ts
+
+### Do
+- Render the entire site in one continuous dark mode. There is no light variant in the system.
+- Use `{colors.primary}` (white pill) for every primary CTA. There is no second primary color — white IS the brand action.
+- Build elevation from the surface-color ladder (`{colors.canvas}` → `{colors.surface}` → `{colors.surface-elevated}` → `{colors.surface-card}`), never from drop shadows.
+- Enable `font-feature-settings: "calt", "kern", "liga", "ss03"` on the body element. The ss03 alternate `g` is part of the brand identity.
+- Anchor a `{component.command-palette-card}` mockup as the hero's load-bearing visual. Real Raycast UI is the brand.
+- Use `{component.keycap}` glyphs inline to indicate keyboard shortcuts. Subtle key-bg gradient (`{colors.key-bg-start}` → `{colors.key-bg-end}`) is the brand's only "depth" decoration.
+- Reserve `{colors.hero-stripe-start}` → `{colors.hero-stripe-end}` red gradient for the hero band exactly once per page. Never repeat the stripe gradient deeper in the page.
+- Use saturated category accents (`{colors.accent-yellow}`, `{colors.accent-red}`, `{colors.accent-green}`, `{colors.accent-blue}`) only inside extension and feature illustrations — never on chrome buttons or text.
+
+### Don't
+- Don't introduce a light mode. The system is dark-only by design.
+- Don't add drop shadows on cards. Elevation is built from the surface ladder, not from shadows.
+- Don't replace `{colors.primary}` (white) with a tinted accent for the primary CTA. Pure white is the brand action color.
+- Don't use the saturated accent colors (`{colors.accent-yellow}`, `{colors.accent-red}`, `{colors.accent-green}`, `{colors.accent-blue}`) on text, buttons, or chrome surfaces. They belong inside extension illustrations.
+- Don't repeat the hero stripe gradient outside the top hero band. The one-band rule is the system's restraint.
+- Don't use Inter without the `ss03` feature flag enabled. The chrome will lose its signature voice.
+- Don't pad cards with 32px+ on all sides. The system runs tight at 16–24px in-card padding.
+
+## Responsive Behavior
+
+### Breakpoints
+
+| Name | Width | Key Changes |
+|---|---|---|
+| ultrawide | 1920px+ | Content max-width holds at 1240px; outer gutters grow to ~80px |
+| desktop-large | 1440px | Default — 3-up pricing grid, 2-up store extension grid |
+| desktop | 1280px | Same with narrower outer gutters |
+| desktop-small | 1024px | 3-up pricing collapses to 2+1; primary nav remains horizontal |
+| tablet | 768px | Pricing → 1-up stacked; primary nav becomes hamburger drawer |
+| mobile | 480px | Single-column everything; hero `{typography.display-xl}` scales 64px → ~36px |
+| mobile-narrow | 320px | Section padding tightens to 48px |
+
+### Touch Targets
+All interactive elements meet WCAG AA at 36px+. `{component.button-primary}` and `{component.button-tertiary}` sit at 36px height with 16px padding. `{component.text-input}` sits at 36px. `{component.store-search-bar}` sits at 44px (above AAA). `{component.pill-tab}` is ~24–28px height with 10px padding extending to 36–40px tappable via inline padding (above AA but below AAA — intentional, the chips are compact). `{component.install-button}` sits at ~32px height with 14px padding.
+
+### Collapsing Strategy
+- **Primary nav:** desktop horizontal cluster → tablet hamburger drawer at 768px. The white "Download" CTA stays visible at every breakpoint.
+- **Hero command-palette mockup:** desktop full-fidelity 2-column with copy at left + mockup at right → tablet stacks vertical with mockup below copy → mobile mockup scales down to ~80% width.
+- **Store extension grid:** 2-up → 1-up at tablet.
+- **Pricing tier grid:** 3-up → 2+1 at desktop-small → 1-up stacked at tablet.
+- **Comparison table:** desktop full 5-column → tablet horizontal scroll → mobile vertical card stack with one tier per card.
+- **Footer:** 6-up link columns → 3-up at tablet → 2-up at mobile-landscape → 1-up at mobile.
+- **Section padding:** `{spacing.section}` (96px) desktop → 64px tablet → 48px mobile.
+- **Hero headline:** `{typography.display-xl}` (64px) at desktop, scaling 56px / 44px / 36px down the breakpoint stack.
+
+### Image Behavior
+The only "imagery" in the system is in-product Raycast UI screenshots and small app-icon assets:
+- **Command-palette mockups** scale fluidly with the container; the in-product UI itself is responsive and re-renders for each breakpoint.
+- **App-icon tiles** stay at 48–64px fixed size at every breakpoint; they tile in flexible rows that wrap at narrower widths.
+- **Hero stripe gradient** stays at the top of the hero band at every breakpoint with the stripe angle preserved.
+
+## Iteration Guide
+
+1. Focus on ONE component at a time. Pull its YAML entry and verify every property resolves.
+2. Reference component names and tokens directly (`{colors.primary}`, `{component.button-primary-pressed}`, `{rounded.md}`) — do not paraphrase.
+3. Run `npx @google/design.md lint DESIGN.md` after edits — `broken-ref`, `contrast-ratio`, and `orphaned-tokens` warnings flag issues automatically.
+4. Add new variants as separate component entries (`-pressed`, `-disabled`, `-active`) — do not bury them inside prose.
+5. Default body to `{typography.body-md}` (16px / 400 / 1.6); reach for `{typography.body-strong}` for emphasis; reserve `{typography.display-xl}` strictly for the hero band.
+6. Keep `{colors.primary}` (white CTA pill) scarce per viewport — at most one solid white pill per fold.
+7. When introducing a new component, ask whether it can be expressed with the existing surface-ladder + 8px-radius + ss03-Inter vocabulary before adding new tokens. The system's strength is that it almost never needs new ones.
+
+## Known Gaps
+
+- **Mobile screenshots not captured** — responsive behavior synthesizes Raycast's mobile pattern (hamburger drawer, single-column grid, hero downscale) from desktop evidence and the breakpoint stack.
+- **Hover states not documented** by system policy. Raycast's in-product app has rich hover behavior on command-palette rows that this document doesn't capture.
+- **In-product app chrome** (the actual Raycast launcher running on macOS) is referenced in marketing screenshots but not documented as a separate UI system here. The marketing site is documented; the in-product app surface is its own design system.
+- **Dark mode is the only mode** — no light variant exists in the captured surfaces.
+- **Form validation states** beyond the focused-input border treatment are not present in the captured surfaces.
+- **Authenticated chrome** (account dashboard, billing settings, team management) not in the captured pages.

--- a/astro/src/data/design-md/supabase.md
+++ b/astro/src/data/design-md/supabase.md
@@ -1,0 +1,462 @@
+---
+version: alpha
+name: Supabaze-Inspired-design-analysis
+description: An inspired interpretation of Supabaze's design language — an open-source database platform built on a clean white-and-near-black system with a single signature emerald-green CTA, a custom humanist sans display tier, and dense product UI mockups composited above the hero. The brand reads as quietly technical: minimal chrome, a near-monochrome palette, and the green primary acting as the only chromatic event on the page.
+
+colors:
+  primary: "#3ecf8e"
+  primary-deep: "#24b47e"
+  primary-soft: "#4ade80"
+  ink: "#171717"
+  ink-secondary: "#212121"
+  ink-mute: "#707070"
+  ink-mute-2: "#9a9a9a"
+  ink-faint: "#b2b2b2"
+  on-primary: "#171717"
+  on-dark: "#ffffff"
+  canvas: "#ffffff"
+  canvas-soft: "#fafafa"
+  canvas-night: "#1c1c1c"
+  canvas-night-soft: "#202020"
+  hairline: "#dfdfdf"
+  hairline-strong: "#c7c7c7"
+  hairline-cool: "#ededed"
+  hairline-cool-2: "#efefef"
+  hairline-cool-3: "#d4d4d4"
+  accent-purple: "#6b01c2"
+  accent-violet: "#644fc1"
+  accent-purple-soft: "#eddbf9"
+  accent-yellow: "#ffdb13"
+  accent-tomato: "#ff2201"
+  accent-pink: "#c7007e"
+  accent-indigo: "#054cff"
+  accent-crimson: "#e2005a"
+
+typography:
+  display-xxl:
+    fontFamily: "Circular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
+    fontSize: 64px
+    fontWeight: 500
+    lineHeight: 1.1
+    letterSpacing: -1.92px
+  display-xl:
+    fontFamily: "Circular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
+    fontSize: 48px
+    fontWeight: 500
+    lineHeight: 1.1
+    letterSpacing: -1.44px
+  display-lg:
+    fontFamily: "Circular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
+    fontSize: 36px
+    fontWeight: 500
+    lineHeight: 1.15
+    letterSpacing: -0.72px
+  display-md:
+    fontFamily: "Circular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
+    fontSize: 28px
+    fontWeight: 500
+    lineHeight: 1.2
+    letterSpacing: -0.42px
+  heading-lg:
+    fontFamily: "Circular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
+    fontSize: 22px
+    fontWeight: 500
+    lineHeight: 1.2
+    letterSpacing: 0
+  heading-md:
+    fontFamily: "Circular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
+    fontSize: 18px
+    fontWeight: 500
+    lineHeight: 1.4
+    letterSpacing: 0
+  body-lg:
+    fontFamily: "Circular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
+    fontSize: 18px
+    fontWeight: 400
+    lineHeight: 1.55
+    letterSpacing: 0
+  body-md:
+    fontFamily: "Circular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
+    fontSize: 16px
+    fontWeight: 400
+    lineHeight: 1.5
+    letterSpacing: 0
+  button-md:
+    fontFamily: "Circular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
+    fontSize: 14px
+    fontWeight: 500
+    lineHeight: 1.0
+    letterSpacing: 0
+  caption:
+    fontFamily: "Circular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
+    fontSize: 13px
+    fontWeight: 400
+    lineHeight: 1.45
+    letterSpacing: 0
+  micro:
+    fontFamily: "Circular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
+    fontSize: 12px
+    fontWeight: 400
+    lineHeight: 1.45
+    letterSpacing: 0
+  code:
+    fontFamily: "ui-monospace, Menlo, Monaco, Consolas, 'Liberation Mono', monospace"
+    fontSize: 14px
+    fontWeight: 400
+    lineHeight: 1.5
+    letterSpacing: 0
+
+rounded:
+  xs: 4px
+  sm: 6px
+  md: 8px
+  lg: 12px
+  xl: 16px
+  full: 9999px
+
+spacing:
+  xxs: 2px
+  xs: 4px
+  sm: 8px
+  md: 12px
+  lg: 16px
+  xl: 24px
+  xxl: 32px
+  huge: 64px
+
+components:
+  button-primary-green:
+    backgroundColor: "{colors.primary}"
+    textColor: "{colors.on-primary}"
+    typography: "{typography.button-md}"
+    rounded: "{rounded.sm}"
+    padding: 8px 16px
+  button-primary-green-pressed:
+    backgroundColor: "{colors.primary-deep}"
+    textColor: "{colors.on-primary}"
+    typography: "{typography.button-md}"
+    rounded: "{rounded.sm}"
+    padding: 8px 16px
+  button-secondary-outline:
+    backgroundColor: "{colors.canvas}"
+    textColor: "{colors.ink}"
+    typography: "{typography.button-md}"
+    rounded: "{rounded.sm}"
+    padding: 8px 16px
+  button-on-dark:
+    backgroundColor: "{colors.canvas-night}"
+    textColor: "{colors.on-dark}"
+    typography: "{typography.button-md}"
+    rounded: "{rounded.sm}"
+    padding: 8px 16px
+  button-link:
+    backgroundColor: "{colors.canvas}"
+    textColor: "{colors.ink}"
+    typography: "{typography.button-md}"
+    rounded: "{rounded.xs}"
+    padding: 0px
+  text-input:
+    backgroundColor: "{colors.canvas}"
+    textColor: "{colors.ink}"
+    typography: "{typography.body-md}"
+    rounded: "{rounded.sm}"
+    padding: 8px 12px
+  card-feature-light:
+    backgroundColor: "{colors.canvas}"
+    textColor: "{colors.ink}"
+    typography: "{typography.body-md}"
+    rounded: "{rounded.lg}"
+    padding: 32px
+  card-pricing:
+    backgroundColor: "{colors.canvas}"
+    textColor: "{colors.ink}"
+    typography: "{typography.body-md}"
+    rounded: "{rounded.lg}"
+    padding: 32px
+  card-pricing-featured:
+    backgroundColor: "{colors.canvas-night}"
+    textColor: "{colors.on-dark}"
+    typography: "{typography.body-md}"
+    rounded: "{rounded.lg}"
+    padding: 32px
+  card-feature-dark:
+    backgroundColor: "{colors.canvas-night}"
+    textColor: "{colors.on-dark}"
+    typography: "{typography.body-md}"
+    rounded: "{rounded.lg}"
+    padding: 32px
+  code-block:
+    backgroundColor: "{colors.canvas-night}"
+    textColor: "{colors.on-dark}"
+    typography: "{typography.code}"
+    rounded: "{rounded.sm}"
+    padding: 16px
+  pill-tag-green:
+    backgroundColor: "{colors.primary}"
+    textColor: "{colors.on-primary}"
+    typography: "{typography.micro}"
+    rounded: "{rounded.full}"
+    padding: 2px 8px
+  pill-tag-soft:
+    backgroundColor: "{colors.canvas-soft}"
+    textColor: "{colors.ink}"
+    typography: "{typography.micro}"
+    rounded: "{rounded.full}"
+    padding: 2px 8px
+  nav-bar-light:
+    backgroundColor: "{colors.canvas}"
+    textColor: "{colors.ink}"
+    typography: "{typography.body-md}"
+    rounded: "{rounded.xs}"
+    padding: 16px 24px
+  link-on-light:
+    backgroundColor: "{colors.canvas}"
+    textColor: "{colors.ink}"
+    typography: "{typography.body-md}"
+    rounded: "{rounded.xs}"
+    padding: 0px
+  footer-light:
+    backgroundColor: "{colors.canvas}"
+    textColor: "{colors.ink-mute}"
+    typography: "{typography.caption}"
+    rounded: "{rounded.xs}"
+    padding: 64px 24px
+---
+
+## Overview
+
+Supabaze's design language is engineered for clarity above all else. The marketing surfaces sit on `{colors.canvas}` (pure white), with text rendered in `{colors.ink}` (`#171717` — near-black, never pure black). Across the entire system the only consistent chromatic event is the **emerald green primary** (`{colors.primary}` — `#3ecf8e`) — used as the filled CTA, occasional accent dot, and the signature highlight color in the wordmark. Everything else is a calibrated grey ladder from `#ededed` hairline-cool to `#171717` ink, with thin black-on-white typography doing most of the visual work.
+
+Typography runs **Circular** at weight 500 for display and 400 for body. The display tier uses tight negative letter-spacing (-1.92px at 64px) to pull the rounded humanist letterforms into editorial density. There's no atmospheric gradient, no full-bleed photography, no dark-canvas marketing track — the brand commits to white.
+
+The product itself appears as composited UI screenshots on every page: dashboard tables, SQL editors, query builders, log streams. These screenshots are the brand's argument. They sit inside `{rounded.lg}` 12px containers with subtle 1px hairlines, often arranged 2-up or in a floating "stacked panes" composition above the hero band.
+
+**Key Characteristics:**
+- Single emerald primary (`{colors.primary}` `#3ecf8e`) as the only chromatic event; everything else is monochrome.
+- White canvas marketing track with greyscale hierarchy from `{colors.hairline-cool}` to `{colors.ink}`.
+- Custom humanist sans display tier at weight 500 with negative letter-spacing of -1.92px to -0.42px.
+- Composited product UI screenshots (dashboard, SQL editor, log stream) are the dominant decorative element — never photography, never illustrations.
+- Tight 6px / 8px button radii — square-ish, technical, never pill-shaped.
+- Code blocks rendered in deep `{colors.canvas-night}` (`#1c1c1c`) with monospace inline code; the brand's developer DNA is visible in every snippet.
+- Pricing tiers use a dark inverted `{colors.canvas-night}` featured tier, not a green one — the green is reserved for buttons and dot accents.
+
+## Colors
+
+> **Source pages:** home (`/`), `/database`, `/partners/integrations`, `/partners/integrations/powersync`, `/solutions/ai-builders`, `/pricing`.
+
+### Brand & Accent
+- **Emerald** (`{colors.primary}` — `#3ecf8e`): The signature CTA color. Filled-button background, brand wordmark accent, dot indicator.
+- **Emerald Deep** (`{colors.primary-deep}` — `#24b47e`): Pressed-state lift of the primary.
+- **Emerald Soft** (`{colors.primary-soft}` — `#4ade80`): Lighter emerald used in chart accents and product UI.
+- **Accent Purple** (`{colors.accent-purple}` — `#6b01c2`): Rare accent used in integration logos and chart points; never a button.
+- **Accent Violet** (`{colors.accent-violet}` — `#644fc1`): Secondary accent in the same role as accent purple.
+- **Accent Yellow** (`{colors.accent-yellow}` — `#ffdb13`): Chart accent / status indicator only.
+- **Accent Pink / Crimson / Indigo / Tomato**: Reserved for integration logos and rare chart highlights, never as system colors.
+
+### Surface
+- **Canvas** (`{colors.canvas}` — `#ffffff`): Default page background.
+- **Canvas Soft** (`{colors.canvas-soft}` — `#fafafa`): Barely-tinted off-white for alternating section bands.
+- **Canvas Night** (`{colors.canvas-night}` — `#1c1c1c`): Deep near-black used in code blocks, dashboard mockups, featured pricing tier.
+- **Canvas Night Soft** (`{colors.canvas-night-soft}` — `#202020`): Slightly lifted dark for nested chrome.
+- **Hairline** (`{colors.hairline}` — `#dfdfdf`): 1px borders on cards and tables.
+- **Hairline Strong** (`{colors.hairline-strong}` — `#c7c7c7`): Slightly darker border for emphasis.
+- **Hairline Cool** (`{colors.hairline-cool}` — `#ededed`) / **Hairline Cool 2** (`#efefef`) / **Hairline Cool 3** (`#d4d4d4`): The brand's grey ladder for fine chrome work.
+
+### Text
+- **Ink** (`{colors.ink}` — `#171717`): Default body text. Near-black, never pure.
+- **Ink Secondary** (`{colors.ink-secondary}` — `#212121`): Slightly cooler near-black for body emphasis.
+- **Ink Mute** (`{colors.ink-mute}` — `#707070`): Secondary text and helper copy.
+- **Ink Mute 2** (`{colors.ink-mute-2}` — `#9a9a9a`): Tertiary text.
+- **Ink Faint** (`{colors.ink-faint}` — `#b2b2b2`): Disabled / placeholder text.
+- **On Primary** (`{colors.on-primary}` — `#171717`): Text on the emerald primary fill — near-black, not white. The button reads as a "lit" surface with dark type, not a colored chip.
+- **On Dark** (`{colors.on-dark}` — `#ffffff`): Text on canvas-night surfaces.
+
+## Typography
+
+### Font Family
+
+The display and UI tier is **Circular** — a proprietary geometric humanist sans by Lineto. Fallback chain: `'Helvetica Neue', Helvetica, Arial`.
+
+For maximum brand fidelity when Circular isn't licensed, use **Inter** (open-source via Google Fonts) at weight 500 for display with `letter-spacing: -1.92px` at 64px. Inter is the closest open-source analogue to Circular's geometric humanist character.
+
+Code blocks use **system mono** (`ui-monospace`, with Menlo / Monaco / Consolas fallbacks).
+
+### Hierarchy
+
+| Token | Size | Weight | Line Height | Letter Spacing | Use |
+|---|---|---|---|---|---|
+| `{typography.display-xxl}` | 64px | 500 | 1.1 | -1.92px | Hero headline |
+| `{typography.display-xl}` | 48px | 500 | 1.1 | -1.44px | Section opener |
+| `{typography.display-lg}` | 36px | 500 | 1.15 | -0.72px | Sub-section / pricing tier |
+| `{typography.display-md}` | 28px | 500 | 1.2 | -0.42px | Card title |
+| `{typography.heading-lg}` | 22px | 500 | 1.2 | 0 | Compact heading |
+| `{typography.heading-md}` | 18px | 500 | 1.4 | 0 | Section sub-heading |
+| `{typography.body-lg}` | 18px | 400 | 1.55 | 0 | Marketing body lead |
+| `{typography.body-md}` | 16px | 400 | 1.5 | 0 | Default UI body |
+| `{typography.button-md}` | 14px | 500 | 1.0 | 0 | Button label |
+| `{typography.caption}` | 13px | 400 | 1.45 | 0 | Helper, footnote |
+| `{typography.micro}` | 12px | 400 | 1.45 | 0 | Pill label, fine print |
+| `{typography.code}` | 14px | 400 | 1.5 | 0 | Code block content |
+
+### Principles
+- **Weight 500 across display.** Mid-weight reads as engineered, not decorative.
+- **Negative tracking on display.** -1.92px at 64px scaling proportionally down — tightens the rounded humanist letterforms into editorial density.
+- **Mono for code.** System mono families (Menlo / Monaco) — no proprietary mono webfont.
+
+### Note on Font Substitutes
+Circular is proprietary. Use **Inter** at weight 500 with `letter-spacing: -1.92px` for display tiers. **Geist Sans** (open-source from Vercel) is another close alternative for both display and body. Avoid Helvetica defaults — they're heavier and lack the geometric warmth.
+
+## Layout
+
+### Spacing System
+- **Base unit**: 8px (with 2 / 4 / 12 sub-tokens for fine work).
+- **Tokens**: `{spacing.xxs}` 2px · `{spacing.xs}` 4px · `{spacing.sm}` 8px · `{spacing.md}` 12px · `{spacing.lg}` 16px · `{spacing.xl}` 24px · `{spacing.xxl}` 32px · `{spacing.huge}` 64px.
+- **Section padding**: 64–96px on marketing surfaces.
+- **Card internal padding**: 32px on feature/pricing cards.
+
+### Grid & Container
+- Marketing pages center in a ~1280px container with no edge-bleed; the brand keeps content inside the box.
+- Pricing collapses 4-up → 2-up → 1-up at 1024 / 768 breakpoints.
+- Product UI mockups stack 2-up or render as overlapping panes inside the same container.
+
+### Whitespace Philosophy
+The brand uses generous 64–96px section padding without atmospheric gradients filling the space — the white canvas is the design. The composited product UI mockups break up sections without requiring decoration.
+
+## Elevation & Depth
+
+| Level | Treatment | Use |
+|---|---|---|
+| 0 | Flat, 1px hairline | Default cards |
+| 1 | `box-shadow: 0 1px 3px rgba(0,0,0,0.06)` | Subtle card lift |
+| 2 | `box-shadow: 0 8px 24px rgba(0,0,0,0.08)` | Floating composited UI mockups |
+| 3 | `box-shadow: 0 16px 48px rgba(0,0,0,0.12)` | Modal overlays, deep elevation |
+
+### Decorative Depth
+The brand's depth is **product UI mockups** rather than gradients. Stacked dashboard / SQL editor / log panes composite together with subtle Level 2 shadows to suggest spatial hierarchy.
+
+## Shapes
+
+### Border Radius Scale
+
+| Token | Value | Use |
+|---|---|---|
+| `{rounded.xs}` | 4px | Form inputs, hairline tags |
+| `{rounded.sm}` | 6px | Buttons (the brand's signature button radius), code blocks |
+| `{rounded.md}` | 8px | Compact cards, alerts |
+| `{rounded.lg}` | 12px | Pricing cards, feature cards, product mockups |
+| `{rounded.xl}` | 16px | Modal dialogs, large container chrome |
+| `{rounded.full}` | 9999px | Pill tags, avatars |
+
+### Photography Geometry
+The brand uses minimal photography. Customer logo strips display wordmarks at uniform height (~24–32px) in greyscale; case-study cards (rare) use 4:3 photos inset in `{rounded.lg}` containers.
+
+## Components
+
+### Buttons
+
+**`button-primary-green`** — the signature CTA.
+- Background `{colors.primary}`, text `{colors.on-primary}` (near-black, NOT white), type `{typography.button-md}`, padding `{spacing.sm} {spacing.lg}` (8px 16px), rounded `{rounded.sm}` 6px.
+- Pressed state `button-primary-green-pressed` shifts to `{colors.primary-deep}`.
+
+**`button-secondary-outline`** — outline alternative on white.
+- Background `{colors.canvas}`, text `{colors.ink}`, 1px solid `{colors.hairline-strong}` border, same shape.
+
+**`button-on-dark`** — used on dark surfaces / code-block CTAs.
+- Background `{colors.canvas-night}`, text `{colors.on-dark}`, same shape.
+
+**`button-link`** — text-only inline button.
+- Transparent background, text `{colors.ink}` rendered in `{typography.button-md}`, no padding, with a subtle underline on hover.
+
+### Cards & Containers
+
+**`card-feature-light`** — feature card on white.
+- Background `{colors.canvas}`, padding `{spacing.xxl}`, rounded `{rounded.lg}` 12px, 1px `{colors.hairline}` border.
+
+**`card-pricing`** — standard pricing tier.
+- Background `{colors.canvas}`, padding `{spacing.xxl}`, rounded `{rounded.lg}`, 1px `{colors.hairline}` border. Title in `{typography.heading-lg}`, price in `{typography.display-md}`, body in `{typography.body-md}`, CTA `button-primary-green` pinned bottom.
+
+**`card-pricing-featured`** — inverted dark featured tier.
+- Background `{colors.canvas-night}`, text `{colors.on-dark}`, otherwise identical structure.
+
+**`card-feature-dark`** — feature card with deep dark fill.
+- Background `{colors.canvas-night}`, text `{colors.on-dark}`, padding `{spacing.xxl}`, rounded `{rounded.lg}`. Used for code-heavy feature explanations.
+
+**`code-block`** — code snippet container.
+- Background `{colors.canvas-night}`, text `{colors.on-dark}` rendered in `{typography.code}`. Padding `{spacing.lg}` 16px, rounded `{rounded.sm}` 6px.
+
+### Inputs & Forms
+
+**`text-input`** — standard form input.
+- Background `{colors.canvas}`, text `{colors.ink}`, type `{typography.body-md}`, padding `{spacing.sm} {spacing.md}` (8px 12px), rounded `{rounded.sm}` 6px, 1px `{colors.hairline}` border.
+
+### Navigation
+
+**`nav-bar-light`** — top nav across the site.
+- Background `{colors.canvas}`, text `{colors.ink}`, padding `{spacing.lg} {spacing.xl}`. Logo on the left, primary nav center, "Sign In" link + filled `button-primary-green` on the right.
+
+### Pills, Tags, and Chips
+
+**`pill-tag-green`** — small green pill used for "new" or featured indicators.
+- Background `{colors.primary}`, text `{colors.on-primary}`, type `{typography.micro}`, padding `{spacing.xxs} {spacing.sm}`, rounded `{rounded.full}`.
+
+**`pill-tag-soft`** — neutral pill on light surfaces.
+- Background `{colors.canvas-soft}`, text `{colors.ink}`, otherwise same shape.
+
+### Signature Components
+
+**Composited Product UI Mockups** — multi-layer dashboard / SQL editor / log pane composites with subtle Level 2 shadows. The product is the brand's argument; mockups always sit on white canvas with no surrounding decoration.
+
+**`link-on-light`** — inline links in body copy.
+- Text `{colors.ink}` rendered in `{typography.body-md}` with a persistent underline.
+
+**`footer-light`** — site-wide footer.
+- Background `{colors.canvas}`, text `{colors.ink-mute}`, type `{typography.caption}`, padding `{spacing.huge} {spacing.xl}` (64px 24px). Holds 4–5 columns of link groups, social icons, and a small legal row.
+
+## Do's and Don'ts
+
+### Do
+- Reserve `{colors.primary}` emerald for filled CTAs and the wordmark accent — it should appear sparingly.
+- Render display tiers at weight 500 with negative letter-spacing — the engineered tightness is part of the brand.
+- Use `{rounded.sm}` 6px for buttons — square-ish radii, never pill-shaped.
+- Composite product UI mockups inside `{rounded.lg}` containers with subtle Level 2 shadows.
+- Use near-black `{colors.ink}` on the emerald button (not white) — the green reads as "lit" with dark type, which is the brand's idiosyncratic choice.
+- Apply system mono for every code block.
+
+### Don't
+- Don't introduce additional accent colors as system colors — purples, yellows, and pinks belong inside chart points and integration logos only.
+- Don't bump display weight above 500 — the brand's calibrated mid-weight breaks at 600+.
+- Don't use pill-shaped buttons; the brand's button radius is square-ish 6px.
+- Don't use white text on the emerald button — the brand specifically uses near-black on green.
+- Don't add atmospheric gradients to hero bands — the white canvas is the design.
+
+## Responsive Behavior
+
+### Breakpoints
+
+| Name | Width | Key Changes |
+|---|---|---|
+| Wide | ≥ 1440px | Full container width; product mockups at full scale |
+| Desktop | 1024–1440px | Default content max-width; pricing 4-up |
+| Tablet | 768–1023px | Pricing 2-up; mockups simplify to single panel |
+| Mobile | < 768px | Pricing 1-up; hamburger nav; display drops 64 → 36px |
+
+### Touch Targets
+- Buttons hit ≥ 36×36px on mobile; vertical padding scales up to maintain WCAG AA minimum.
+- Form fields stay at 36px minimum height.
+
+### Collapsing Strategy
+- Display tiers stair-step 64 → 48 → 36 → 28 → 22px.
+- Product UI mockups simplify to a single primary panel on mobile.
+- Pricing tiers stair-step 4-up → 2-up → 1-up; dark featured tier always distinguished.
+
+### Image Behavior
+Product UI mockups use `srcset` with desktop / mobile crops; mobile crops focus on the most actionable inner panel.
+
+## Iteration Guide
+
+1. Focus on ONE component at a time.
+2. Reference component names and tokens directly.
+3. Run `npx @google/design.md lint DESIGN.md` after edits.
+4. Default body to `{typography.body-md}`; use `{typography.code}` for any developer-facing snippet.
+5. Keep emerald scarce; one filled green button per viewport.
+6. The white-canvas commitment is non-negotiable — adding atmospheric backdrops breaks the brand.

--- a/astro/src/data/design-md/wired.md
+++ b/astro/src/data/design-md/wired.md
@@ -1,0 +1,497 @@
+---
+version: alpha
+name: Wired-Inspired-design-analysis
+description: An inspired interpretation of Wired's design language — a flagship technology-magazine brand whose surface is a strict editorial duet of stark black wordmark on white canvas, anchored by a tall narrow custom display serif for hero headlines, a humanist serif body face for long-form reading, and a clean sans face for metadata; layout reads like a printed magazine ported to the web with very little marketing chrome.
+
+colors:
+  primary: "#000000"
+  on-primary: "#ffffff"
+  ink: "#000000"
+  ink-soft: "#1a1a1a"
+  body: "#757575"
+  hairline: "#e0e0e0"
+  canvas: "#ffffff"
+  canvas-soft: "#f5f5f5"
+  link: "#057dbc"
+
+typography:
+  display-hero:
+    fontFamily: WiredDisplay, "Times New Roman", Georgia, serif
+    fontSize: 64px
+    fontWeight: 400
+    lineHeight: 59.52px
+    letterSpacing: -0.5px
+  display-lg:
+    fontFamily: WiredDisplay, "Times New Roman", Georgia, serif
+    fontSize: 48px
+    fontWeight: 400
+    lineHeight: 50.4px
+    letterSpacing: -0.4px
+  display-md:
+    fontFamily: WiredDisplay, "Times New Roman", Georgia, serif
+    fontSize: 32px
+    fontWeight: 400
+    lineHeight: 35.2px
+    letterSpacing: -0.3px
+  display-sm:
+    fontFamily: WiredDisplay, "Times New Roman", Georgia, serif
+    fontSize: 26px
+    fontWeight: 400
+    lineHeight: 28.08px
+  display-xs:
+    fontFamily: Apercu, "Helvetica Neue", Helvetica, Arial, sans-serif
+    fontSize: 20px
+    fontWeight: 700
+    lineHeight: 24px
+    letterSpacing: -0.28px
+  body-serif-lg:
+    fontFamily: BreveText, Georgia, "Times New Roman", serif
+    fontSize: 19px
+    fontWeight: 400
+    lineHeight: 27.93px
+    letterSpacing: 0.108px
+  body-serif-md:
+    fontFamily: BreveText, Georgia, "Times New Roman", serif
+    fontSize: 16px
+    fontWeight: 400
+    lineHeight: 24px
+    letterSpacing: 0.09px
+  body-md:
+    fontFamily: Apercu, "Helvetica Neue", Helvetica, Arial, sans-serif
+    fontSize: 17px
+    fontWeight: 400
+    lineHeight: 20px
+  body-md-strong:
+    fontFamily: Apercu, "Helvetica Neue", Helvetica, Arial, sans-serif
+    fontSize: 17px
+    fontWeight: 700
+    lineHeight: 22px
+    letterSpacing: -0.144px
+  body-sm:
+    fontFamily: Apercu, "Helvetica Neue", Helvetica, Arial, sans-serif
+    fontSize: 14px
+    fontWeight: 400
+    lineHeight: 18px
+    letterSpacing: 0.4px
+  body-sm-strong:
+    fontFamily: Apercu, "Helvetica Neue", Helvetica, Arial, sans-serif
+    fontSize: 14px
+    fontWeight: 700
+    lineHeight: 18px
+    letterSpacing: 0.4px
+  byline:
+    fontFamily: BreveText, Georgia, "Times New Roman", serif
+    fontSize: 12.73px
+    fontWeight: 700
+    lineHeight: 28px
+    letterSpacing: 0.108px
+  caption:
+    fontFamily: Apercu, "Helvetica Neue", Helvetica, Arial, sans-serif
+    fontSize: 12px
+    fontWeight: 400
+    lineHeight: 16px
+  button-md:
+    fontFamily: Apercu, "Helvetica Neue", Helvetica, Arial, sans-serif
+    fontSize: 16px
+    fontWeight: 700
+    lineHeight: 20px
+    letterSpacing: 0.3px
+
+rounded:
+  none: 0px
+  full: 9999px
+
+spacing:
+  xxs: 2px
+  xs: 4px
+  sm: 8px
+  md: 12px
+  lg: 16px
+  xl: 20px
+  2xl: 24px
+  3xl: 32px
+  4xl: 48px
+
+components:
+  nav-bar:
+    backgroundColor: "{colors.canvas}"
+    textColor: "{colors.ink}"
+    typography: "{typography.body-sm-strong}"
+    padding: "{spacing.md} {spacing.xl}"
+  nav-link:
+    textColor: "{colors.ink}"
+    typography: "{typography.body-sm-strong}"
+  button-primary:
+    backgroundColor: "{colors.primary}"
+    textColor: "{colors.on-primary}"
+    typography: "{typography.button-md}"
+    rounded: "{rounded.none}"
+    padding: "{spacing.md} {spacing.xl}"
+  button-outline:
+    backgroundColor: "{colors.canvas}"
+    textColor: "{colors.ink}"
+    borderColor: "{colors.ink}"
+    typography: "{typography.button-md}"
+    rounded: "{rounded.none}"
+    padding: "{spacing.md} {spacing.xl}"
+  button-icon-circular:
+    backgroundColor: "{colors.canvas}"
+    textColor: "{colors.ink}"
+    rounded: "{rounded.full}"
+    padding: "{spacing.sm}"
+  text-input:
+    backgroundColor: "{colors.canvas}"
+    textColor: "{colors.ink}"
+    borderColor: "{colors.ink}"
+    typography: "{typography.body-md}"
+    rounded: "{rounded.none}"
+    padding: "{spacing.md} {spacing.lg}"
+  story-card-large:
+    backgroundColor: "{colors.canvas}"
+    textColor: "{colors.ink}"
+    typography: "{typography.display-md}"
+    padding: "{spacing.lg}"
+  story-card:
+    backgroundColor: "{colors.canvas}"
+    textColor: "{colors.ink}"
+    typography: "{typography.display-xs}"
+    padding: "{spacing.md}"
+  story-row:
+    backgroundColor: "{colors.canvas}"
+    textColor: "{colors.ink}"
+    borderColor: "{colors.hairline}"
+    typography: "{typography.body-md-strong}"
+    padding: "{spacing.lg} 0"
+  category-eyebrow:
+    textColor: "{colors.ink}"
+    typography: "{typography.body-sm-strong}"
+  byline-row:
+    backgroundColor: "{colors.canvas}"
+    textColor: "{colors.body}"
+    typography: "{typography.byline}"
+  hero-band:
+    backgroundColor: "{colors.canvas}"
+    textColor: "{colors.ink}"
+    typography: "{typography.display-hero}"
+    padding: "{spacing.4xl} {spacing.xl}"
+  masthead-band:
+    backgroundColor: "{colors.canvas}"
+    textColor: "{colors.ink}"
+    typography: "{typography.body-md-strong}"
+    padding: "{spacing.md} {spacing.xl}"
+  hairline-divider:
+    borderColor: "{colors.hairline}"
+  footer:
+    backgroundColor: "{colors.primary}"
+    textColor: "{colors.on-primary}"
+    typography: "{typography.body-sm}"
+    padding: "{spacing.4xl} {spacing.xl}"
+
+  # ─── Examples (illustrative) — auto-derived; resolve any TO_FILL markers below ───
+  ex-pricing-tier:
+    description: "Default Pricing tier card. Re-uses feature-card chrome with brand canvas-soft surface."
+    backgroundColor: "{colors.canvas-soft}"
+    textColor: "{colors.ink}"
+    borderColor: "{colors.hairline}"
+    rounded: "{rounded.none}"
+    padding: "{spacing.lg}"
+  ex-pricing-tier-featured:
+    description: "Featured/highlighted tier — polarity-flipped surface (dark fill + light text in light mode, light fill + dark text in dark mode)."
+    backgroundColor: "{colors.ink}"
+    textColor: "{colors.on-primary}"
+    rounded: "{rounded.none}"
+    padding: "{spacing.lg}"
+  ex-product-selector:
+    description: "What's Included summary card — re-purposed for SaaS / B2B verticals (NOT a literal product gallery)."
+    backgroundColor: "{colors.canvas-soft}"
+    rounded: "{rounded.none}"
+    padding: "{spacing.lg}"
+  ex-cart-drawer:
+    description: "Subscription summary — re-purposed for SaaS / B2B (line items per add-on, not literal cart)."
+    backgroundColor: "{colors.canvas}"
+    rounded: "{rounded.none}"
+    padding: "{spacing.lg}"
+    item-divider: "{colors.hairline}"
+  ex-app-shell-row:
+    description: "Sidebar nav row inside the App Shell example. Active state uses brand primary as the indicator."
+    backgroundColor: "{colors.canvas}"
+    activeIndicator: "{colors.primary}"
+    rounded: "{rounded.none}"
+    padding: "{spacing.md} {spacing.lg}"
+  ex-data-table-cell:
+    description: "Default data-table th + td chrome. Header uses mono-caps eyebrow typography; body uses body-sm."
+    headerBackground: "{colors.canvas-soft}"
+    headerTypography: "{typography.caption}"
+    bodyTypography: "{typography.body-sm}"
+    cellPadding: "{spacing.md} {spacing.lg}"
+    rowBorder: "{colors.hairline}"
+  ex-auth-form-card:
+    description: "Sign-in / sign-up card. Re-uses feature-card chrome with text-input primitives inside."
+    backgroundColor: "{colors.canvas-soft}"
+    rounded: "{rounded.none}"
+    padding: "{spacing.lg}"
+  ex-modal-card:
+    description: "Modal dialog surface — same chrome as feature-card with elevated shadow."
+    backgroundColor: "{colors.canvas}"
+    rounded: "{rounded.none}"
+    padding: "{spacing.lg}"
+  ex-empty-state-card:
+    description: "Empty-state illustration frame."
+    backgroundColor: "{colors.canvas-soft}"
+    rounded: "{rounded.none}"
+    padding: "{spacing.3xl}"
+    captionTypography: "{typography.body-md}"
+  ex-toast:
+    description: "Toast notification surface — feature-card shape + medium shadow."
+    backgroundColor: "{colors.canvas}"
+    rounded: "{rounded.none}"
+    padding: "{spacing.md} {spacing.lg}"
+    typography: "{typography.body-sm}"
+
+---
+
+
+## Overview
+
+Wired is the flagship technology-magazine brand under Condé Nast — and the web surface refuses to dress itself as a SaaS marketing site. The page is unmistakably an editorial product: a white canvas, a strict black wordmark in the brand's proprietary `WiredDisplay` (a tall, narrow, high-contrast serif used at 64 px), and stacked story cards that read as a printed magazine grid ported to the screen. There is no atmospheric gradient, no decorative chrome, no chromatic accent — the brand's only colour beyond the black-and-white duet is the small `{colors.link}` (`#057dbc`) used for inline body links inside long-form articles.
+
+Type carries the entire identity. Three families ladder the system: `WiredDisplay` (the proprietary high-contrast serif) for hero / section headlines; `BreveText` (a humanist serif) for long-form body and bylines; and `Apercu` (a humanist sans) for metadata, captions, eyebrow tags, and buttons. The pairing is editorial-grade: serifs for narrative, sans for navigation and structural labels.
+
+Buttons are square. The brand uses `{rounded.none}` 0 px corners across the entire UI — newsletter sign-ups, login forms, "Read more" CTAs all render as sharp rectangles. The only circular shape is the `button-icon-circular` used for social-share affordances. There are no soft drop-shadows; the brand uses hairline borders for elevation when needed.
+
+**Key Characteristics:**
+- A strict black-and-white duet with no chromatic accent except the inline link blue `{colors.link}`. The brand reads as a printed magazine.
+- Three-face typographic system — `WiredDisplay` serif for display, `BreveText` serif for body, `Apercu` sans for metadata and buttons.
+- Square buttons (`{rounded.none}`) — the brand never softens corners on interactive elements.
+- A magazine-style story grid: large feature card at top, two-up secondary, then a vertical stack of bylined story rows separated by `{colors.hairline}` 1 px dividers.
+- The brand's only signature decorative move is the **masthead band** — a thin black strip with the wordmark centred, no other decoration.
+- A near-black `{colors.ink}` (`#000000`) footer band, no graphics, just text columns and the wordmark repeating.
+
+## Colors
+
+### Brand & Accent
+- **Ink Black** (`{colors.primary}` — `#000000`): The brand's only "accent." Used for wordmark, headlines, CTAs, footer fill. Pure black, never softened.
+
+### Surface
+- **Canvas** (`{colors.canvas}` — `#ffffff`): The default page background.
+- **Canvas Soft** (`{colors.canvas-soft}` — `#f5f5f5`): Rare tint used for the comment-section background and search-result row hover states (not in the main page rhythm).
+- **Hairline** (`{colors.hairline}` — `#e0e0e0`): 1 px dividers between story rows. The brand's only "line."
+
+### Text
+- **Ink** (`{colors.ink}` — `#000000`): Every headline, every body paragraph in BreveText.
+- **Ink Soft** (`{colors.ink-soft}` — `#1a1a1a`): A near-black variant used for caption-strong / footer link emphasis.
+- **Body** (`{colors.body}` — `#757575`): Secondary metadata — bylines, timestamps, supporting body lines.
+
+### Semantic
+The brand operates with one inline link colour and no separate error / success / warning palette in its marketing surface. Validation cues on form pages use the ink black + body grey hierarchy.
+
+- **Link** (`{colors.link}` — `#057dbc`): The inline body-link blue. Used only inside long-form article body copy, never on UI buttons or navigation.
+
+## Typography
+
+### Font Family
+Three families ladder the system:
+1. **WiredDisplay** — the proprietary tall-narrow high-contrast serif used exclusively for display headlines (64 px hero, scaling down to 26 px sub-display). The brand's most-recognisable typographic signature.
+2. **BreveText** — the proprietary humanist serif used for long-form body, bylines, and editorial captions. Used at 16 – 19 px line-height 1.45 – 1.50 for comfortable reading density.
+3. **Apercu** — a humanist sans used for nav, button labels, category eyebrows, metadata, and captions. Weights 400 / 700.
+
+Inter is loaded as a fourth fallback face for embedded utility surfaces (the comment section, account pages) but does not appear on the main marketing / article surface.
+
+### Hierarchy
+
+| Token | Size | Weight | Line Height | Letter Spacing | Use |
+|---|---|---|---|---|---|
+| `{typography.display-hero}` | 64px | 400 | 59.5px | -0.5px | Cover-story headline. |
+| `{typography.display-lg}` | 48px | 400 | 50.4px | -0.4px | Major section / feature headlines. |
+| `{typography.display-md}` | 32px | 400 | 35.2px | -0.3px | Story-card large variant. |
+| `{typography.display-sm}` | 26px | 400 | 28px | 0 | Sub-display headings inside long-form articles. |
+| `{typography.display-xs}` | 20px | 700 | 24px | -0.28px | Sans (Apercu) display micro-headings for category callouts. |
+| `{typography.body-serif-lg}` | 19px | 400 | 27.93px | 0.108px | Lead paragraph of an article (BreveText). |
+| `{typography.body-serif-md}` | 16px | 400 | 24px | 0.09px | Default article body (BreveText). |
+| `{typography.body-md}` | 17px | 400 | 20px | 0 | Sans body (Apercu) for nav / metadata. |
+| `{typography.body-md-strong}` | 17px | 700 | 22px | -0.144px | Bold sans body. |
+| `{typography.body-sm}` | 14px | 400 | 18px | 0.4px | Secondary sans body. |
+| `{typography.body-sm-strong}` | 14px | 700 | 18px | 0.4px | Bold caption / nav-link. |
+| `{typography.byline}` | 12.73px | 700 | 28px | 0.108px | Article byline (BreveText). |
+| `{typography.caption}` | 12px | 400 | 16px | 0 | Fine print, image captions. |
+| `{typography.button-md}` | 16px | 700 | 20px | 0.3px | Button label. |
+
+### Principles
+- **Serif for narrative, sans for structure.** The serif faces never carry button labels or nav text; the sans face never carries article body.
+- **Display weight 400** — the proprietary WiredDisplay reads as elegant by virtue of its thin-tall-narrow design at default weight, not via weight 700+.
+- **Bylines use BreveText weight 700 with relaxed line-height 2.2.** The vertical breathing is part of the editorial signature.
+
+### Note on Font Substitutes
+The three proprietary faces have no exact substitutes. Best open-source approximations:
+- **WiredDisplay** — *Playfair Display* weight 400 at large display sizes captures the high-contrast didone feel, though wider than the brand's tall-narrow proportions.
+- **BreveText** — *Lora* or *Source Serif Pro* at 16 – 19 px.
+- **Apercu** — *Inter* or *Manrope* weights 400 / 700.
+
+## Layout
+
+### Spacing System
+- **Base unit**: 4 px.
+- **Tokens**: `{spacing.xxs}` 2 px · `{spacing.xs}` 4 px · `{spacing.sm}` 8 px · `{spacing.md}` 12 px · `{spacing.lg}` 16 px · `{spacing.xl}` 20 px · `{spacing.2xl}` 24 px · `{spacing.3xl}` 32 px · `{spacing.4xl}` 48 px.
+- **Section padding**: hero / story grid use `{spacing.4xl}` 48 px top/bottom on desktop.
+- **Story row padding**: `{spacing.lg}` 16 px vertical between bylined story rows.
+
+### Grid & Container
+- Marketing content uses a wide container (~1400 px max).
+- Cover-story grid: 1 large hero + 2-up secondary stories + vertical stack.
+- Story-row stack: full-width single column with hairline dividers.
+
+### Responsive Strategy
+
+#### Breakpoints
+
+| Name | Width | Key Changes |
+|---|---|---|
+| Mobile | < 768px | Cover hero 64→40 px; all grids 1-up; hamburger nav. |
+| Tablet | 768–1023px | 2-up secondary story grid. |
+| Desktop | ≥ 1024px | Full magazine grid. |
+
+#### Touch Targets
+Button-primary renders ~44 px tall (12 vertical padding + 20 line). WCAG AAA at all widths.
+
+#### Collapsing Strategy
+- Nav: full link row + Subscribe CTA at desktop. Hamburger at mobile.
+- Magazine grid: hero stays full-width; 2-up secondary drops to 1-up at mobile.
+- Story rows: stay single-column at all viewports.
+
+#### Image Behavior
+- Cover images: full-bleed 16:9 hero / 4:3 secondary.
+- Article body images: full-width inside the article column.
+- Author avatars: small inline circular crops next to bylines.
+
+## Elevation & Depth
+
+| Level | Treatment | Use |
+|---|---|---|
+| Level 0 — Flat | No shadow, no border. | Default — almost every surface lives at this level. |
+| Level 1 — Hairline | 1 px solid `{colors.hairline}` border. | Story-row dividers, input borders. |
+| Level 2 — Heavy Black Border | 2 px solid `{colors.ink}` border. | Subscribe CTA on certain campaign moments. |
+
+The brand uses no drop-shadows. Surface contrast and hairline borders carry all visual hierarchy.
+
+## Shapes
+
+### Border Radius Scale
+
+| Token | Value | Use |
+|---|---|---|
+| `{rounded.none}` | 0px | Every interactive shape — buttons, inputs, cards. The brand's signature square geometry. |
+| `{rounded.full}` | 9999px | Circular icon containers only (social-share, account avatar). |
+
+### Photography Geometry
+- Cover stories: 16:9 hero, edge-to-edge.
+- Secondary story cards: 4:3 thumbnails.
+- Article body images: native aspect, full column width.
+- Bylines / avatars: circular `{rounded.full}` 28 px crops.
+
+## Components
+
+### Buttons
+
+**`button-primary`** — the square black CTA.
+- Background `{colors.primary}`, text `{colors.on-primary}`, label `{typography.button-md}` (Apercu 16 px / 700 / 0.3 px tracking), padding `{spacing.md} {spacing.xl}`, shape `{rounded.none}` 0 px.
+
+**`button-outline`** — the white outline CTA.
+- Background `{colors.canvas}`, text `{colors.ink}`, 1 px solid `{colors.ink}` border, same typography / padding / shape.
+
+**`button-icon-circular`** — the circular share-icon button.
+- Background `{colors.canvas}`, ink icon, shape `{rounded.full}`.
+
+### Cards & Containers
+
+**`story-card-large`** — the cover-story card with `{typography.display-md}` headline.
+- Background `{colors.canvas}`, text `{colors.ink}`, padding `{spacing.lg}`. No border — the card lives on the canvas with the photo doing the work.
+
+**`story-card`** — the secondary story card.
+- Background `{colors.canvas}`, text `{colors.ink}`, padding `{spacing.md}`. Photo at top, sans display heading + body lead below.
+
+**`story-row`** — the bylined story list row.
+- Background `{colors.canvas}`, text `{colors.ink}`, 1 px solid `{colors.hairline}` bottom border, body in `{typography.body-md-strong}`, padding `{spacing.lg}` 0.
+
+### Inputs & Forms
+
+**`text-input`** — the standard text input.
+- Background `{colors.canvas}`, text `{colors.ink}`, 1 px solid `{colors.ink}` border, body in `{typography.body-md}`, padding `{spacing.md} {spacing.lg}`, shape `{rounded.none}`.
+
+### Navigation
+
+**`nav-bar`** — the top nav, light by default.
+- Background `{colors.canvas}`, text `{colors.ink}`, padding `{spacing.md} {spacing.xl}`. Layout: hamburger left, masthead centre, Subscribe right.
+
+**`nav-link`** — link items inside nav.
+- Text `{colors.ink}`, set in `{typography.body-sm-strong}` (Apercu 14 / 700).
+
+**`footer`** — the black footer band.
+- Background `{colors.primary}`, text `{colors.on-primary}`, padding `{spacing.4xl} {spacing.xl}`. Body in `{typography.body-sm}` (Apercu 14 / 400). Footer column eyebrows in `{typography.body-sm-strong}`.
+
+### Signature Components
+
+**`hero-band`** — the white hero band hosting the cover-story.
+- Background `{colors.canvas}`, text `{colors.ink}`, padding `{spacing.4xl} {spacing.xl}`. Cover headline in `{typography.display-hero}` (WiredDisplay 64 px).
+
+**`masthead-band`** — the thin top band with the wordmark.
+- Background `{colors.canvas}`, text `{colors.ink}`, padding `{spacing.md} {spacing.xl}`. The wordmark sits centred; flanked by section nav.
+
+**`category-eyebrow`** — the small uppercase category label above story headlines.
+- Text `{colors.ink}`, set in `{typography.body-sm-strong}` (Apercu 14 / 700 — though some campaigns use ALL CAPS via CSS).
+
+**`byline-row`** — the article byline strip.
+- Background `{colors.canvas}`, text `{colors.body}`, body in `{typography.byline}` (BreveText 12.73 / 700 / line-height 2.2). Includes an author avatar + name + date.
+
+**`hairline-divider`** — the 1 px line between story rows.
+- 1 px solid `{colors.hairline}`.
+
+### Examples (illustrative)
+
+> Auto-derived kit-mirror demonstration surfaces (`scripts/derive-examples-block.mjs`). Each `ex-*` entry references brand-native primitives so downstream consumers (`/preview-design`, `/generate-kit`) re-skin the same 10 surfaces consistently. `TO_FILL` markers indicate missing primitives — resolve in the LLM judgment pass.
+
+**`ex-pricing-tier`** — Default Pricing tier card. Re-uses feature-card chrome with brand canvas-soft surface.
+- Properties: `backgroundColor`, `textColor`, `borderColor`, `rounded`, `padding`
+
+**`ex-pricing-tier-featured`** — Featured/highlighted tier — polarity-flipped surface (dark fill + light text in light mode, light fill + dark text in dark mode).
+- Properties: `backgroundColor`, `textColor`, `rounded`, `padding`
+
+**`ex-product-selector`** — What's Included summary card — re-purposed for SaaS / B2B verticals (NOT a literal product gallery).
+- Properties: `backgroundColor`, `rounded`, `padding`
+
+**`ex-cart-drawer`** — Subscription summary — re-purposed for SaaS / B2B (line items per add-on, not literal cart).
+- Properties: `backgroundColor`, `rounded`, `padding`, `item-divider`
+
+**`ex-app-shell-row`** — Sidebar nav row inside the App Shell example. Active state uses brand primary as the indicator.
+- Properties: `backgroundColor`, `activeIndicator`, `rounded`, `padding`
+
+**`ex-data-table-cell`** — Default data-table th + td chrome. Header uses mono-caps eyebrow typography; body uses body-sm.
+- Properties: `headerBackground`, `headerTypography`, `bodyTypography`, `cellPadding`, `rowBorder`
+
+**`ex-auth-form-card`** — Sign-in / sign-up card. Re-uses feature-card chrome with text-input primitives inside.
+- Properties: `backgroundColor`, `rounded`, `padding`
+
+**`ex-modal-card`** — Modal dialog surface — same chrome as feature-card with elevated shadow.
+- Properties: `backgroundColor`, `rounded`, `padding`
+
+**`ex-empty-state-card`** — Empty-state illustration frame.
+- Properties: `backgroundColor`, `rounded`, `padding`, `captionTypography`
+
+**`ex-toast`** — Toast notification surface — feature-card shape + medium shadow.
+- Properties: `backgroundColor`, `rounded`, `padding`, `typography`
+
+
+## Do's and Don'ts
+
+### Do
+- Reserve `{colors.primary}` black for the wordmark, every CTA, and the footer fill. The brand IS the strict black-on-white duet.
+- Set hero headlines in `{typography.display-hero}` (WiredDisplay 64 px weight 400). The proprietary serif IS the brand's typographic signature.
+- Use `{rounded.none}` 0 px on every button and form input. The brand reads as a printed magazine — square corners are non-negotiable.
+- Pair WiredDisplay (serif display) with BreveText (serif body) and Apercu (sans labels). Three faces, three roles.
+- Render story rows with `{colors.hairline}` 1 px dividers — the brand's only elevation cue.
+
+### Don't
+- Don't introduce a chromatic brand accent. The link blue is reserved for inline body links inside articles only.
+- Don't round button corners. The brand never softens its rectangular geometry.
+- Don't drop a soft drop-shadow on cards. Surface contrast and hairlines carry elevation.
+- Don't substitute the proprietary serif faces with a generic sans for display. The serif voice is the brand.
+- Don't promote display weight beyond 400. The brand's elegance is in the typeface design, not bold weight.

--- a/astro/src/data/designBrands.ts
+++ b/astro/src/data/designBrands.ts
@@ -71,7 +71,8 @@ export const designBrands: DesignBrand[] = [
 			{
 				sample: 'Payments at scale',
 				spec: 'display-xxl · 56px / 300 / -1.4px · Sohne',
-				style: 'font-weight:300;font-size:clamp(30px,4.5vw,46px);letter-spacing:-0.032em;color:#0d253d;line-height:1.05',
+				style:
+					'font-weight:300;font-size:clamp(30px,4.5vw,46px);letter-spacing:-0.032em;color:#0d253d;line-height:1.05',
 			},
 			{
 				sample: 'Built for developers',
@@ -86,7 +87,8 @@ export const designBrands: DesignBrand[] = [
 			{
 				sample: '$1,284,502.00 · 2026-08-26',
 				spec: 'caption · 13px · tnum 等宽数字（钱必须对齐）',
-				style: 'font-size:13px;color:#64748d;font-variant-numeric:tabular-nums;letter-spacing:-0.02em',
+				style:
+					'font-size:13px;color:#64748d;font-variant-numeric:tabular-nums;letter-spacing:-0.02em',
 			},
 		],
 		dos: [
@@ -103,7 +105,8 @@ export const designBrands: DesignBrand[] = [
 		],
 		plate: {
 			bg: '#ffffff',
-			strip: 'linear-gradient(100deg, #f5e9d4, #ffb199 22%, #cabffd 47%, #533afd 72%, #ea2261 100%)',
+			strip:
+				'linear-gradient(100deg, #f5e9d4, #ffb199 22%, #cabffd 47%, #533afd 72%, #ea2261 100%)',
 			headline: 'Financial infrastructure to grow your revenue',
 			headlineStyle:
 				'font-weight:300;font-size:clamp(26px,3.6vw,40px);letter-spacing:-0.04em;color:#0d253d;line-height:1.12',
@@ -146,7 +149,8 @@ export const designBrands: DesignBrand[] = [
 			{
 				sample: 'Plan and build products',
 				spec: 'display · 80px 时字距 -3.0px · 600 字重',
-				style: 'font-weight:600;font-size:clamp(28px,4vw,42px);letter-spacing:-0.035em;color:#f7f8f8;line-height:1.05',
+				style:
+					'font-weight:600;font-size:clamp(28px,4vw,42px);letter-spacing:-0.035em;color:#f7f8f8;line-height:1.05',
 			},
 			{
 				sample: 'Purpose-built for modern product development.',
@@ -214,7 +218,8 @@ export const designBrands: DesignBrand[] = [
 			{
 				sample: 'Meet the night shift.',
 				spec: 'display · Notion-Sans（Inter 系）· 居中 hero',
-				style: 'font-weight:700;font-size:clamp(26px,4vw,40px);letter-spacing:-0.02em;color:#191918',
+				style:
+					'font-weight:700;font-size:clamp(26px,4vw,40px);letter-spacing:-0.02em;color:#191918',
 			},
 			{
 				sample: 'One workspace, every team.',
@@ -283,7 +288,8 @@ export const designBrands: DesignBrand[] = [
 			{
 				sample: 'Develop. Preview. Ship.',
 				spec: 'display · Geist 600 · 48px 时字距 -2.4px · 句首大写',
-				style: 'font-weight:600;font-size:clamp(28px,4vw,42px);letter-spacing:-0.045em;color:#171717;line-height:1.05',
+				style:
+					'font-weight:600;font-size:clamp(28px,4vw,42px);letter-spacing:-0.045em;color:#171717;line-height:1.05',
 			},
 			{
 				sample: 'The platform for frontend developers.',
@@ -293,7 +299,8 @@ export const designBrands: DesignBrand[] = [
 			{
 				sample: 'DEPLOYS — vercel.json',
 				spec: 'caption-mono · Geist Mono · 技术眉题专用',
-				style: "font-family:ui-monospace,'SF Mono',monospace;font-size:12px;color:#888;letter-spacing:0.04em",
+				style:
+					"font-family:ui-monospace,'SF Mono',monospace;font-size:12px;color:#888;letter-spacing:0.04em",
 			},
 		],
 		dos: [
@@ -352,7 +359,8 @@ export const designBrands: DesignBrand[] = [
 			{
 				sample: 'JUST DO IT.',
 				spec: 'display-campaign · Nike Futura ND · 96px / 行高 0.9 / 全大写',
-				style: 'font-weight:900;font-size:clamp(30px,5vw,48px);text-transform:uppercase;letter-spacing:-0.02em;line-height:0.95;color:#111',
+				style:
+					'font-weight:900;font-size:clamp(30px,5vw,48px);text-transform:uppercase;letter-spacing:-0.02em;line-height:0.95;color:#111',
 			},
 			{
 				sample: 'Trail Running Collection',
@@ -392,7 +400,8 @@ export const designBrands: DesignBrand[] = [
 		name: 'Claude',
 		category: 'AI',
 		tagline: '奶油纸底 + 赤陶珊瑚的书房气质',
-		nameStyle: "font-family:Georgia,'Songti SC',serif;font-weight:400;letter-spacing:-0.01em;color:#29261b",
+		nameStyle:
+			"font-family:Georgia,'Songti SC',serif;font-weight:400;letter-spacing:-0.01em;color:#29261b",
 		heroTitle: 'Claude：AI 品类里最暖的一张纸',
 		lede: '当所有 AI 品牌都在用冷灰和科技蓝时，Claude 选了一张暖调奶油纸 #faf9f5。衬线体 Copernicus 只用 400 字重排大标题，珊瑚色 #cc785c 在单个按钮上稀缺、在整幅 callout 卡上慷慨。奶油与深色产品卡交替铺排，是整个页面的呼吸节奏。',
 		philosophy: [
@@ -420,7 +429,8 @@ export const designBrands: DesignBrand[] = [
 			{
 				sample: 'Helpful, honest, harmless',
 				spec: 'display · Copernicus 衬线 · 恒 400 字重 · 负字距',
-				style: "font-family:Georgia,'Songti SC',serif;font-weight:400;font-size:clamp(26px,4vw,38px);letter-spacing:-0.02em;color:#141413",
+				style:
+					"font-family:Georgia,'Songti SC',serif;font-weight:400;font-size:clamp(26px,4vw,38px);letter-spacing:-0.02em;color:#141413",
 			},
 			{
 				sample: 'Warm paper, serif voice, one terracotta accent.',
@@ -430,7 +440,8 @@ export const designBrands: DesignBrand[] = [
 			{
 				sample: 'claude -p "explain this codebase"',
 				spec: 'code · 深色产品面上的等宽',
-				style: "font-family:ui-monospace,'SF Mono',monospace;font-size:13px;color:#faf9f5;background:#181715;padding:8px 12px;border-radius:8px;display:inline-block",
+				style:
+					"font-family:ui-monospace,'SF Mono',monospace;font-size:13px;color:#faf9f5;background:#181715;padding:8px 12px;border-radius:8px;display:inline-block",
 			},
 		],
 		dos: [
@@ -488,7 +499,8 @@ export const designBrands: DesignBrand[] = [
 			{
 				sample: 'Titanium. So strong. So light. So Pro.',
 				spec: 'hero-display · SF Pro Display 600 · 负字距「Apple tight」',
-				style: 'font-weight:600;font-size:clamp(26px,3.6vw,40px);letter-spacing:-0.015em;color:#1d1d1f;line-height:1.08',
+				style:
+					'font-weight:600;font-size:clamp(26px,3.6vw,40px);letter-spacing:-0.015em;color:#1d1d1f;line-height:1.08',
 			},
 			{
 				sample: 'Body copy reads at seventeen pixels, not sixteen.',
@@ -556,7 +568,8 @@ export const designBrands: DesignBrand[] = [
 			{
 				sample: 'Think bigger. Build faster.',
 				spec: 'display-xl · figmaSans · 86px 时字距 -1.72px',
-				style: 'font-weight:700;font-size:clamp(26px,3.6vw,40px);letter-spacing:-0.04em;color:#000000;line-height:1.05',
+				style:
+					'font-weight:700;font-size:clamp(26px,3.6vw,40px);letter-spacing:-0.04em;color:#000000;line-height:1.05',
 			},
 			{
 				sample: 'Body hovers at weight 320–340 of the same variable family.',
@@ -566,7 +579,8 @@ export const designBrands: DesignBrand[] = [
 			{
 				sample: 'DESIGN SYSTEMS',
 				spec: 'figmaMono · 眉题 · 永远大写、正字距',
-				style: "font-family:ui-monospace,'SF Mono',monospace;font-size:12px;letter-spacing:0.14em;color:#000000",
+				style:
+					"font-family:ui-monospace,'SF Mono',monospace;font-size:12px;letter-spacing:0.14em;color:#000000",
 			},
 		],
 		dos: [
@@ -625,7 +639,8 @@ export const designBrands: DesignBrand[] = [
 			{
 				sample: 'Music for everyone.',
 				spec: 'SpotifyMixUI（CircularSp）700 · 紧凑',
-				style: 'font-weight:700;font-size:clamp(24px,3.4vw,38px);letter-spacing:-0.02em;color:#ffffff;line-height:1.1',
+				style:
+					'font-weight:700;font-size:clamp(24px,3.4vw,38px);letter-spacing:-0.02em;color:#ffffff;line-height:1.1',
 			},
 			{
 				sample: 'Compact and functional — the whole system lives in 10–24px.',
@@ -693,7 +708,8 @@ export const designBrands: DesignBrand[] = [
 			{
 				sample: 'Belong anywhere.',
 				spec: 'Airbnb Cereal VF · display 500–700 · 克制字重',
-				style: 'font-weight:600;font-size:clamp(24px,3.4vw,38px);letter-spacing:-0.02em;color:#222222;line-height:1.1',
+				style:
+					'font-weight:600;font-size:clamp(24px,3.4vw,38px);letter-spacing:-0.02em;color:#222222;line-height:1.1',
 			},
 			{
 				sample: 'Photography carries the weight; type stays modest.',
@@ -761,7 +777,8 @@ export const designBrands: DesignBrand[] = [
 			{
 				sample: "Let's create something that changes everything",
 				spec: 'display · IBM Plex Sans 300 · 细体是签名',
-				style: 'font-weight:300;font-size:clamp(26px,3.6vw,40px);letter-spacing:-0.01em;color:#161616;line-height:1.15',
+				style:
+					'font-weight:300;font-size:clamp(26px,3.6vw,40px);letter-spacing:-0.01em;color:#161616;line-height:1.15',
 			},
 			{
 				sample: 'Body copy carries 0.16px letter-spacing — a Carbon precision detail.',
@@ -771,7 +788,8 @@ export const designBrands: DesignBrand[] = [
 			{
 				sample: 'Start building →',
 				spec: 'button · 方角 0px · 蓝底白字',
-				style: 'display:inline-block;background:#0f62fe;color:#ffffff;padding:10px 18px;font-size:13.5px',
+				style:
+					'display:inline-block;background:#0f62fe;color:#ffffff;padding:10px 18px;font-size:13.5px',
 			},
 		],
 		dos: [
@@ -830,7 +848,8 @@ export const designBrands: DesignBrand[] = [
 			{
 				sample: 'Tech, science, art.',
 				spec: 'Manuka display · 最大 107px · 只做 60px+',
-				style: 'font-weight:800;font-size:clamp(26px,3.8vw,42px);text-transform:uppercase;letter-spacing:-0.01em;color:#ffffff;line-height:0.95',
+				style:
+					'font-weight:800;font-size:clamp(26px,3.8vw,42px);text-transform:uppercase;letter-spacing:-0.01em;color:#ffffff;line-height:0.95',
 			},
 			{
 				sample: 'PolySans carries the body on the dark canvas.',
@@ -840,7 +859,8 @@ export const designBrands: DesignBrand[] = [
 			{
 				sample: 'FEB 26 · 14:02 EST',
 				spec: 'PolySans Mono · 永远大写 · 字距 1.5–1.9px',
-				style: "font-family:ui-monospace,'SF Mono',monospace;font-size:12px;letter-spacing:0.16em;color:#3cffd0",
+				style:
+					"font-family:ui-monospace,'SF Mono',monospace;font-size:12px;letter-spacing:0.16em;color:#3cffd0",
 			},
 		],
 		dos: [
@@ -865,6 +885,559 @@ export const designBrands: DesignBrand[] = [
 		},
 		sourceFile: 'theverge',
 	},
+	{
+		id: 'cursor',
+		name: 'Cursor',
+		category: '开发工具',
+		tagline: '奶油画布上的一滴橙：AI 编辑器的杂志感',
+		nameStyle: 'font-weight:400;letter-spacing:-0.02em;color:#26251e',
+		heroTitle: 'Cursor：把 IDE 做成一本安静的杂志',
+		lede: '画布不是纯白而是暖奶油色 #f7f7f4，文字是暖黑 #26251e——Cursor 从一开始就拒绝了「开发者工具＝冷灰蓝」的默认设定。橙色 #f54e00 全站只出现在一处 CTA 上；标题永远 400 字重不加粗，像杂志正文一样说话。',
+		philosophy: [
+			'奶油色画布是身份：#f7f7f4 的暖白加上 #26251e 暖黑文字，让编辑器看起来像纸而非机器。',
+			'单一 CTA 色：Cursor 橙 #f54e00 稀缺地只给主行动按钮，橙色的出现本身就是「该点这里了」。',
+			'杂志感排版：display 字重钉死在 400，从不加粗——用字距和字号做层级，不做音量。',
+			'发丝线-only 的深度系统：没有投影，1px 描边承担一切分隔，8px 小圆角是开发者方言而非 SaaS 圆润感。',
+		],
+		colors: [
+			{ name: 'primary', hex: '#f54e00', role: 'Cursor 橙 · 全站唯一的 CTA 色' },
+			{ name: 'primary-active', hex: '#d04200', role: '按压态深橙' },
+			{ name: 'canvas', hex: '#f7f7f4', role: '暖奶油画布 · 从不用纯白' },
+			{ name: 'ink', hex: '#26251e', role: '暖黑主文字 · 从不用纯黑' },
+			{ name: 'body', hex: '#5a5852', role: '正文灰棕' },
+			{ name: 'muted', hex: '#807d72', role: '辅助说明' },
+			{ name: 'muted-soft', hex: '#a09c92', role: '弱化标注' },
+			{ name: 'hairline', hex: '#e6e5e0', role: '主要描边线 · 无投影系统的骨架' },
+			{ name: 'hairline-soft', hex: '#efeee8', role: '次级描边线' },
+		],
+		typeScale: [
+			{
+				sample: 'The AI Code Editor',
+				spec: 'display-lg · 36px / 400 / -0.72px · CursorGothic',
+				style:
+					'font-weight:400;font-size:clamp(26px,3.6vw,34px);letter-spacing:-0.02em;color:#26251e;line-height:1.2',
+			},
+			{
+				sample: 'Body text sits warm on cream, never cold.',
+				spec: 'body · 15px / 400 · 暖灰棕',
+				style: 'font-size:15px;color:#5a5852',
+			},
+			{
+				sample: 'agent · editing · reviewing · done',
+				spec: 'micro · AI 时间线的五个粉彩色阶',
+				style: 'font-size:12px;color:#807d72;letter-spacing:0.04em',
+			},
+		],
+		dos: [
+			'全站保持奶油底 + 暖黑字的纸质感',
+			'标题钉死 400 字重，靠字距做层级',
+			'橙色只给主 CTA，一屏一颗',
+			'深度只用 1px 发丝线表达',
+		],
+		donts: [
+			'不要换成纯白背景——暖奶油才是品牌',
+			'标题加粗到 600+ 就成了通用 SaaS 脸',
+			'不要给按钮换药丸形——8px 小圆角是开发者方言',
+			'不要加投影——描边就是全部深度',
+		],
+		plate: {
+			bg: '#f7f7f4',
+			headline: 'The AI Code Editor',
+			headlineStyle:
+				'color:#26251e;font-weight:400;font-size:clamp(28px,4vw,44px);letter-spacing:-0.025em;line-height:1.15',
+			spec: 'CursorGothic 400 · 暖奶油画布 · 一颗橙 CTA · hairline only',
+			specColor: '#807d72',
+		},
+		sourceFile: 'cursor',
+	},
+	{
+		id: 'raycast',
+		name: 'Raycast',
+		category: 'SaaS',
+		tagline: '近黑阶梯上的白色药丸：键盘党的效率剧场',
+		nameStyle: 'font-weight:600;letter-spacing:-0.02em;color:#f4f4f6',
+		heroTitle: 'Raycast：深色阶梯与一颗白色药丸',
+		lede: '#07080a 到抬升面的四级暗色阶梯里，几乎一切都是单色的；唯一的「彩色 CTA」是一颗纯白药丸。分类强调色（黄红绿蓝）只为扩展商店的品类服务，按 app 各自的品牌染色——这是把「效率」做成剧场的克制方案。',
+		philosophy: [
+			'单一暗色模式：canvas #07080a → surface #0d0d0d → 更高抬升面，用明度阶梯代替色彩分区。',
+			'白药丸即 CTA：#ffffff 实心按钮是全站唯一的主行动语言，其余全是单色暗面。',
+			'Inter + ss03：站级启用 OpenType 替代字形，连小写 g 都在替品牌说话。',
+			'发丝线承担一切卡片边缘：没有投影，商店里的彩色是各个 App 自己的品牌色。',
+		],
+		typePanelStyle: 'background:#0d0d0d;border-color:#242728',
+		colors: [
+			{ name: 'primary', hex: '#ffffff', role: '白色药丸 · 全站唯一主 CTA' },
+			{ name: 'on-primary', hex: '#000000', role: '白底上的黑字' },
+			{ name: 'canvas', hex: '#07080a', role: '最深画布' },
+			{ name: 'surface', hex: '#0d0d0d', role: '一级抬升面' },
+			{ name: 'ink', hex: '#f4f4f6', role: '主文字' },
+			{ name: 'body', hex: '#cdcdcd', role: '正文' },
+			{ name: 'mute', hex: '#9c9c9d', role: '辅助说明' },
+			{ name: 'stone', hex: '#434345', role: '弱化文字 / 图标' },
+			{ name: 'hairline', hex: '#242728', role: '全部卡片描边' },
+			{ name: 'accent-yellow', hex: '#ffc533', role: 'Hacker News 等品类色' },
+			{ name: 'accent-red', hex: '#ff6161', role: 'Slack/Apple 等品类色' },
+			{ name: 'accent-green', hex: '#59d499', role: '生产力品类色' },
+			{ name: 'accent-blue', hex: '#57c1ff', role: '开发工具品类色' },
+		],
+		typeScale: [
+			{
+				sample: 'A shortcut to everything',
+				spec: 'display-xl · 64px / 600 / 0 · Inter ss03',
+				style:
+					'font-weight:600;font-size:clamp(30px,4.6vw,48px);letter-spacing:-0.01em;color:#f4f4f6;line-height:1.08',
+			},
+			{
+				sample: 'Extensions put your tools one keystroke away.',
+				spec: 'body · 15px / 400 · cdcdcd',
+				style: 'font-size:15px;color:#cdcdcd',
+			},
+			{
+				sample: '⌘ ⇧ P  ·  one keystroke',
+				spec: 'mono 标注 · stone 弱化',
+				style: 'font-size:13px;color:#6a6b6c;letter-spacing:0.03em',
+			},
+		],
+		dos: [
+			'主 CTA 只用纯白药丸',
+			'层级用暗色明度阶梯，不用彩色分区',
+			'卡边一律 1px 发丝线 #242728',
+			'站级开启 Inter 的 ss03 替代字形',
+		],
+		donts: [
+			'不要引入浅色模式——这个品牌只有夜晚',
+			'不要给白药丸之外再发明第二实心按钮色',
+			'不要加投影——描边和抬升就够了',
+			'品类强调色不要用在界面装饰上，它们属于扩展商店',
+		],
+		plate: {
+			bg: '#07080a',
+			headline: 'Your shortcut to everything',
+			headlineStyle:
+				'color:#f4f4f6;font-weight:600;font-size:clamp(28px,3.9vw,44px);letter-spacing:-0.015em;line-height:1.1',
+			spec: 'Inter 600 · 白药丸 CTA · 四级暗色阶梯 · 零投影',
+			specColor: '#9c9c9d',
+		},
+		sourceFile: 'raycast',
+	},
+	{
+		id: 'supabase',
+		name: 'Supabase',
+		category: '基础设施',
+		tagline: '一片翡翠绿点亮单色世界：开源后端的工程师美学',
+		nameStyle: 'font-weight:500;letter-spacing:-0.03em;color:#171717',
+		heroTitle: 'Supabase：绿色只在功能处发光',
+		lede: '整个品牌是一场单色演出，翡翠绿 #3ecf8e 是唯一被允许出现的彩色事件——而它只属于产品：数据库、认证、边缘函数的真实 UI 截图才是页面的主角。自定义人文主义无衬线体以 500 字重配负字距压阵，按钮永远是方正的 6/8px，拒绝药丸。',
+		philosophy: [
+			'唯一的彩色事件：祖母绿 #3ecf8e 只做品牌强调，其余全是灰阶层次。',
+			'产品截图即装饰：仪表盘、SQL 编辑器、日志流拼成页面主角，从不用摄影和插画。',
+			'人文学排版：自定义无衬线 display 500 字重，-1.92px 到 -0.42px 的负字距拉开层级。',
+			'夜航代码块：代码片段躺在 #1c1c1c 的深夜底色里，行内等宽字体——开发者 DNA 写在每个片段里。',
+		],
+		colors: [
+			{ name: 'brand', hex: '#3ecf8e', role: '招牌翡翠绿 · 唯一的彩色事件' },
+			{ name: 'brand-dark', hex: '#24b47e', role: '按压态深绿' },
+			{ name: 'brand-light', hex: '#4ade80', role: '浅绿变体' },
+			{ name: 'ink', hex: '#171717', role: '主文字 / 绿底上的字' },
+			{ name: 'ink-mute', hex: '#707070', role: '辅助说明' },
+			{ name: 'ink-faint', hex: '#b2b2b2', role: '弱化标注' },
+			{ name: 'night', hex: '#1c1c1c', role: '代码块深夜底色' },
+			{ name: 'on-dark', hex: '#ffffff', role: '深底文字' },
+			{ name: 'canvas', hex: '#ffffff', role: '营销区白色画布' },
+		],
+		typeScale: [
+			{
+				sample: 'Build in a weekend',
+				spec: 'display-xl · 48px / 500 / -1.44px · Circular',
+				style:
+					'font-weight:500;font-size:clamp(28px,4vw,40px);letter-spacing:-0.03em;color:#171717;line-height:1.1',
+			},
+			{
+				sample: 'Scale to millions of users.',
+				spec: 'body · 15px / 400 · 212121',
+				style: 'font-size:15px;color:#212121',
+			},
+			{
+				sample: 'const { data } = await supabase.from(...)',
+				spec: 'code · 夜航底色内联等宽',
+				style:
+					'font-family:ui-monospace,monospace;font-size:13px;color:#3ecf8e;background:#1c1c1c;padding:2px 6px;border-radius:4px',
+			},
+		],
+		dos: [
+			'绿色只用于品牌强调与激活态',
+			'每段能力介绍都配真实产品 UI 截图',
+			'display 保持 500 字重加负字距',
+			'代码示例一律进深夜底色块',
+		],
+		donts: [
+			'不要给按钮做成药丸——6/8px 方正感是工程味',
+			'不要引入第二个品牌色相',
+			'不要用摄影或插画当装饰',
+			'不要把绿色大面积铺背景',
+		],
+		plate: {
+			bg: '#ffffff',
+			headline: 'Build in a weekend, scale to millions',
+			headlineStyle:
+				'color:#171717;font-weight:500;font-size:clamp(26px,3.7vw,42px);letter-spacing:-0.03em;line-height:1.1',
+			spec: 'Circular 500 · -1.44px · 翡翠绿单点 · night 代码块',
+			specColor: '#707070',
+		},
+		sourceFile: 'supabase',
+	},
+	{
+		id: 'framer',
+		name: 'Framer',
+		category: '设计工具',
+		tagline: '黑幕上的海报标题：85px 与 -4.25px 的动效宣言',
+		nameStyle: 'font-weight:500;letter-spacing:-0.05em;color:#ffffff',
+		heroTitle: 'Framer：把营销页做成动效海报',
+		lede: '整站一块纯黑画布 #090909 打到底，没有任何浅色间奏；GT Walsheim 以 85px 配 -4.25px 的极端负字距砸出海报纸的节奏。白药丸是唯一 CTA 形态，紫、洋红、橙、珊瑚的渐变聚光灯卡片在黑网格里自己发光。',
+		philosophy: [
+			'全黑画布：hero、定价、FAQ、footer 共享 #090909，夜幕本身就是页面结构。',
+			'海报级字距：display 层 -5.5px 到 -3.1px 的负字距，字号越大越用力。',
+			'白药丸专制：主 CTA 只有纯白胶囊一种形态，次级行动降为炭黑胶囊。',
+			'自发光的渐变卡：紫罗兰、洋红、橙、珊瑚的大尺寸 spotlight 卡片像舞台灯一样嵌在黑网格中。',
+		],
+		typePanelStyle: 'background:#121212;border-color:#262626',
+		colors: [
+			{ name: 'canvas', hex: '#090909', role: '全站纯黑画布' },
+			{ name: 'primary', hex: '#ffffff', role: '白药丸 · 唯一主 CTA' },
+			{ name: 'on-primary', hex: '#000000', role: '白底黑字' },
+			{ name: 'ink', hex: '#ffffff', role: '主文字' },
+			{ name: 'ink-muted', hex: '#999999', role: '次级文字' },
+			{ name: 'hairline', hex: '#262626', role: '黑幕上的卡片描边' },
+			{ name: 'accent-blue', hex: '#0099ff', role: '品牌蓝点缀' },
+			{ name: 'gradient-violet', hex: '#6a4cf5', role: '聚光灯卡渐变起' },
+			{ name: 'gradient-magenta', hex: '#d44df0', role: '聚光灯卡洋红' },
+			{ name: 'gradient-orange', hex: '#ff7a3d', role: '聚光灯卡橙' },
+			{ name: 'gradient-coral', hex: '#ff5577', role: '聚光灯卡珊瑚收尾' },
+		],
+		typeScale: [
+			{
+				sample: 'Start designing for free',
+				spec: 'display-xl · 85px / 500 / -4.25px · GT Walsheim',
+				style:
+					'font-weight:500;font-size:clamp(32px,5.6vw,58px);letter-spacing:-0.05em;color:#ffffff;line-height:0.98',
+			},
+			{
+				sample: 'Ship sites that move like motion.',
+				spec: 'body · Inter Variable · cv01/ss03 特性',
+				style: 'font-size:15px;color:#999999',
+			},
+			{
+				sample: 'Free → Mini → Basic',
+				spec: 'pill · 炭黑次级胶囊',
+				style:
+					'font-size:13px;color:#ffffff;background:#1a1a1a;border:1px solid #262626;padding:4px 12px;border-radius:999px;display:inline-block',
+			},
+		],
+		dos: [
+			'display 用到极限负字距，越大越紧',
+			'渐变 spotlight 卡作为独立展示瓦片使用',
+			'主 CTA 统一纯白胶囊',
+			'正文字开 Inter 的 cv/ss OpenType 特性',
+		],
+		donts: [
+			'不要在黑幕上加入浅色区块',
+			'不要弱化负字距——海报感立刻塌掉',
+			'渐变只属于聚光灯卡，不要铺满背景',
+			'不要给 CTA 换形状',
+		],
+		plate: {
+			bg: '#090909',
+			headline: 'Ship sites that move',
+			headlineStyle:
+				'color:#ffffff;font-weight:500;font-size:clamp(30px,4.4vw,50px);letter-spacing:-0.045em;line-height:1.0',
+			spec: 'GT Walsheim 500 · 85px / -4.25px · 黑幕白药丸 · 渐变 spotlight',
+			specColor: '#999999',
+		},
+		sourceFile: 'framer',
+	},
+	{
+		id: 'nvidia',
+		name: 'NVIDIA',
+		category: 'AI',
+		tagline: '一角荧光绿的绝对秩序：2px 圆角的工业硬朗',
+		nameStyle: 'font-weight:700;letter-spacing:-0.01em;color:#76b900',
+		heroTitle: 'NVIDIA：一颗绿方块统治所有角落',
+		lede: '荧光绿 #76b900 承包了全部 CTA、激活态与装饰动机，其余只剩黑白灰的两极切换：hero/footer 黑章与白底正文章交替出现。全站没有一个药丸按钮，交互件圆角统一 2px，资源卡的右上角总摆着一枚小小的绿色方块徽记。',
+		philosophy: [
+			'单色独裁：荧光绿是唯一的品牌声部，出现即是官方发言。',
+			'双模式节奏：深色 hero/页脚章节与白色正文章节交替，形成可预测的呼吸。',
+			'超角几何：2px 圆角贯穿所有交互件——没有药丸、没有软糖感，一切都很工程师。',
+			'角落签名：约 12px 的绿色方块锚在资源卡一角，是全站唯一的装饰动作。',
+		],
+		colors: [
+			{ name: 'brand-green', hex: '#76b900', role: 'NVIDIA 绿 · 唯一强调色' },
+			{ name: 'green-dark', hex: '#5a8d00', role: '深绿变体 / 按压态' },
+			{ name: 'ink', hex: '#000000', role: '纯黑主文字 / 深色章节底' },
+			{ name: 'surface-soft', hex: '#f7f7f7', role: '浅灰软面' },
+			{ name: 'surface-elevated', hex: '#1a1a1a', role: '深色抬升面' },
+			{ name: 'hairline', hex: '#cccccc', role: '卡片描边' },
+			{ name: 'canvas', hex: '#ffffff', role: '正文白底' },
+		],
+		typeScale: [
+			{
+				sample: 'Accelerated Computing',
+				spec: 'display-xl · 48px / 700 / 0 · NVIDIA Sans',
+				style:
+					'font-weight:700;font-size:clamp(28px,4vw,40px);letter-spacing:-0.01em;color:#000000;line-height:1.15',
+			},
+			{
+				sample: 'Powering AI factories worldwide.',
+				spec: 'body · 16px / 400',
+				style: 'font-size:16px;color:#333333',
+			},
+			{
+				sample: '■  Developer Resources',
+				spec: 'corner-square 徽记 · 资源卡标准位',
+				style: 'font-size:13px;color:#000000',
+			},
+		],
+		dos: [
+			'绿色留给 CTA、激活态与角标方块',
+			'黑白章节交替形成页面节奏',
+			'交互件圆角锁死 2px',
+			'用 hairline 描边与软面区分层级，不靠投影',
+		],
+		donts: [
+			'不要给按钮做成药丸',
+			'不要给绿色增加同族新色相',
+			'不要去掉卡角的绿色方块签名',
+			'不要引入插画式装饰',
+		],
+		plate: {
+			bg: '#ffffff',
+			headline: 'The engine of AI',
+			headlineStyle:
+				'color:#000000;font-weight:700;font-size:clamp(26px,3.6vw,42px);letter-spacing:-0.01em;line-height:1.15',
+			spec: 'NVIDIA Sans 700 · 2px 圆角 · 单一绿 · ■ 角落徽记',
+			specColor: '#5a8d00',
+		},
+		sourceFile: 'nvidia',
+	},
+	{
+		id: 'mistral',
+		name: 'Mistral',
+		category: 'AI',
+		tagline: '山顶日落：橙色欧洲灵魂与奶油纸张',
+		nameStyle: 'font-weight:400;letter-spacing:-0.02em;color:#fa520f',
+		heroTitle: 'Mistral：把大模型写成南法日落',
+		lede: '山脊剪影压着橙红黄的落日天空摄影，页面底部横着一条向奶油过渡的「日落条带」，表单和特性卡全是奶油黄纸张——在欧洲 AI 公司里，Mistral 是唯一一个把开放精神做成风景画的品牌。饱和橙 #fa520f 承担每一次行动召唤。',
+		philosophy: [
+			'日落是 logo 也是版式：山顶剪影摄影 hero 与横向日落条带带贯穿首尾。',
+			'奶油纸张系：cream 三阶底色构成表单与特性卡的纸质温度。',
+			'衬线仪式感：PP Editorial Old 近衬线负责 hero 大字，Inter 接管其余一切。',
+			'克制的几何：8px 按钮、12px 卡片——比硅谷同行更收敛，更像出版物。',
+		],
+		colors: [
+			{ name: 'primary', hex: '#fa520f', role: '落日橙 · 所有 CTA 的颜色' },
+			{ name: 'primary-deep', hex: '#cc3a05', role: '深橙按压态' },
+			{ name: 'sunshine', hex: '#ffd900', role: '日落条带的亮黄停' },
+			{ name: 'cream', hex: '#fff8e0', role: '奶油黄面板底' },
+			{ name: 'cream-light', hex: '#fffaeb', role: '最浅奶油' },
+			{ name: 'cream-deep', hex: '#fff0c2', role: '深一档奶油' },
+			{ name: 'beige-deep', hex: '#e6d5a8', role: '沙金分界' },
+			{ name: 'ink', hex: '#1f1f1f', role: '近黑主文字' },
+		],
+		typeScale: [
+			{
+				sample: 'Open, portable, customizable',
+				spec: 'display-lg · 64px / 400 / -1px · PP Editorial Old',
+				style:
+					"font-family:Georgia,'Times New Roman',serif;font-weight:400;font-size:clamp(30px,4.4vw,46px);letter-spacing:-0.015em;color:#1f1f1f;line-height:1.1",
+			},
+			{
+				sample: 'Frontier AI in your hands.',
+				spec: 'body · Inter · 奶油纸上仍保持清晰',
+				style: 'font-size:15px;color:#44403c',
+			},
+		],
+		dos: [
+			'hero 必须是日落山景 photography',
+			'页面底部横贯日落条带',
+			'表单/特性卡用三阶奶油底',
+			'CTA 统一饱和橙',
+		],
+		donts: [
+			'不要给几何加太多圆角——保持出版物式的收敛',
+			'不要让 Inter 做 hero——衬线的仪式感是品牌',
+			'不要把亮黄单独用作按钮',
+		],
+		plate: {
+			bg: '#fff8e0',
+			strip: 'linear-gradient(90deg,#fa520f,#ffd900 55%,#fff8e0 100%)',
+			headline: 'Frontier AI, European made',
+			headlineStyle:
+				"font-family:Georgia,'Times New Roman',serif;color:#1f1f1f;font-weight:400;font-size:clamp(27px,3.8vw,43px);letter-spacing:-0.015em;line-height:1.1",
+			spec: 'PP Editorial Old · 日落条带 · 奶油纸张 · 单橙 CTA',
+			specColor: '#cc3a05',
+		},
+		sourceFile: 'mistral',
+	},
+	{
+		id: 'minimax',
+		name: 'MiniMax',
+		category: 'AI',
+		tagline: '黑白底座上一条产品线一种荧光色',
+		nameStyle: 'font-weight:700;letter-spacing:-0.03em;color:#0a0a0a',
+		heroTitle: 'MiniMax：用色彩编码模型家族',
+		lede: '系统几乎是彻底的黑与白，但每条模型线都有自己的专属荧光色：coral 珊瑚给 M2.7、洋红给 Music、蓝给海螺、橙给语音。DM Sans 以 80px/600/-2px 的重拳开路，全站的按钮与标签全是药丸，像一家把产品矩阵当成调色盘管理的公司。',
+		philosophy: [
+			'色彩即产品地图：每个模型线锁定一种荧光色，看到颜色就知道是哪条产品线。',
+			'黑白打底：主色其实是近黑 #0a0a0a，所有的彩都发生在渐变卡与产品标识层。',
+			'药丸行星：按钮、tab 全是 full-round，矩形只在数据表格与文档密集区出没。',
+			'重拳标题：hero 80px、600 字重、-2px 字距、1.10 行高——冲击力优先。',
+		],
+		colors: [
+			{ name: 'primary', hex: '#0a0a0a', role: '近黑主色 · 全局底座' },
+			{ name: 'on-primary', hex: '#ffffff', role: '反白' },
+			{ name: 'coral', hex: '#ff5530', role: 'M2.7 模型线专属' },
+			{ name: 'magenta', hex: '#ea5ec1', role: 'Music 模型线专属' },
+			{ name: 'blue', hex: '#1456f0', role: 'Hailuo 视频线专属' },
+			{ name: 'cyan', hex: '#3daeff', role: '辅助亮蓝' },
+			{ name: 'primary-soft', hex: '#181e25', role: '深色软面' },
+		],
+		typeScale: [
+			{
+				sample: 'Intelligence, minimized',
+				spec: 'hero-display · 80px / 600 / -2px / 1.10 · DM Sans',
+				style:
+					'font-weight:700;font-size:clamp(32px,5vw,52px);letter-spacing:-0.03em;color:#0a0a0a;line-height:1.06',
+			},
+			{
+				sample: 'One color per product line.',
+				spec: 'body · DM Sans / Inter fallback',
+				style: 'font-size:15px;color:#3f4650',
+			},
+		],
+		dos: ['每条产品线只用它的专属色', '渐变卡是颜色的合法居所', 'UI 元素尽量 pill 化'],
+		donts: ['不要跨产品线混用颜色', '不要在正文用荧光色', '表格密集区不要强行 pill'],
+		plate: {
+			bg: '#0a0a0a',
+			headline: 'Models for everyone',
+			headlineStyle:
+				'color:#ffffff;font-weight:700;font-size:clamp(30px,4.3vw,48px);letter-spacing:-0.03em;line-height:1.08',
+			spec: 'DM Sans 600 · 产品线色彩编码 · 药丸行星',
+			specColor: '#3daeff',
+		},
+		sourceFile: 'minimax',
+	},
+	{
+		id: 'coinbase',
+		name: 'Coinbase',
+		category: '金融',
+		tagline: '蓝色托管的世界：涨跌二色永不换岗',
+		nameStyle: 'font-weight:400;letter-spacing:-0.03em;color:#0052ff',
+		heroTitle: 'Coinbase：把信任炼成一种蓝',
+		lede: '#0052ff 包办了 brand CTA、字标与内联链接的一切高光时刻——用量如此节制以至于每一次出现都像盖章。展示字重从不超过 400，药丸按钮做到 100px 满半径，卡片 24px；深色 hero 里漂浮的产品 mockup 是品牌的第一视觉语言，而涨绿跌红永远只是文字色，从不填底。',
+		philosophy: [
+			'单一强调色统治：Coinbase 蓝 #0052ff 出现得越少越有分量，它是签名不是涂料。',
+			'编辑部式的克制字重：Coinbase Display 最高 400，绝不用 700 咆哮。',
+			'几何分级：CTA=100px 药丸、资产图标=full circle、卡片=24px，不同物件不同圆角阶层。',
+			'交易语义只做文字色：上涨绿 #05b169、下跌红 #cf202f，永不当背景填色。',
+		],
+		colors: [
+			{ name: 'brand-blue', hex: '#0052ff', role: '招牌蓝 · CTA 与字标专属' },
+			{ name: 'blue-active', hex: '#003ecc', role: '按压态' },
+			{ name: 'blue-disabled', hex: '#a8b8cc', role: '不可用态淡蓝' },
+			{ name: 'semantic-up', hex: '#05b169', role: '上涨绿 · 仅文字色' },
+			{ name: 'semantic-down', hex: '#cf202f', role: '下跌红 · 仅文字色' },
+			{ name: 'ink', hex: '#0a0b0d', role: '近黑主文字' },
+			{ name: 'body', hex: '#5b616e', role: '正文灰蓝' },
+			{ name: 'muted', hex: '#7c828a', role: '辅助说明' },
+			{ name: 'hairline', hex: '#dee1e6', role: '分隔线' },
+		],
+		typeScale: [
+			{
+				sample: 'Jump start your crypto portfolio',
+				spec: 'display-xl · 64px / 400 / -1.6px · Coinbase Display',
+				style:
+					'font-weight:500;font-size:clamp(28px,4.2vw,44px);letter-spacing:-0.025em;color:#0a0b0d;line-height:1.05',
+			},
+			{
+				sample: 'Buy, sell, and store cryptocurrency.',
+				spec: 'body · 16px / 400',
+				style: 'font-size:16px;color:#5b616e',
+			},
+			{
+				sample: '+2.41% BTC   -1.08% ETH',
+				spec: 'semantic up/down · 文字色语义',
+				style: 'font-variant-numeric:tabular-nums;font-size:14px',
+			},
+		],
+		dos: [
+			'蓝只给 brand 表达，稀缺使用',
+			'CTA 保持 100px 满药丸',
+			'卡片维持 24px 圆角阶层',
+			'涨跌只用文字色表达',
+		],
+		donts: ['展示字重不要超过 400', '涨跌色不要做背景填充', '不要稀释蓝色的稀缺性——泛滥即贬值'],
+		plate: {
+			bg: '#ffffff',
+			headline: 'Update your portfolio',
+			headlineStyle:
+				'color:#0a0b0d;font-weight:500;font-size:clamp(28px,4vw,44px);letter-spacing:-0.025em;line-height:1.05',
+			spec: 'Coinbase Display · 100px 药丸 · 24px 卡片 · 涨跌仅文字色',
+			specColor: '#0052ff',
+		},
+		sourceFile: 'coinbase',
+	},
+	{
+		id: 'wired',
+		name: 'WIRED',
+		category: '媒体',
+		tagline: '黑白双人的排印实验场：衬线上位，方角到底',
+		nameStyle:
+			"font-family:Georgia,'Times New Roman',serif;font-weight:400;letter-spacing:-0.01em;color:#000000",
+		heroTitle: 'WIRED：印刷杂志的网页复刻',
+		lede: '一对纯粹的黑白双人舞：唯一的彩色破例是内联链接蓝 #057dbc。三种字脸各司其职——WiredDisplay 衬线管 display，BreveText 衬线管正文，Apercu 无衬线管元数据与按钮。按钮永远是方角，报头黑带是全站唯一的装饰动作，像一份搬上网页的印刷杂志。',
+		philosophy: [
+			'印刷品逻辑：黑白对比直接承继纸刊，彩色仅剩链接蓝一枚标本。',
+			'三脸分工：衬线 display + 衬线 body + sans metadata，按钮也是 sans 的领地。',
+			'方角党：rounded-none 贯穿全部可点击元素——直角就是媒体立场。',
+			'报头条带：细黑带居中放 wordmark，除此之外不再有任何装饰。',
+		],
+		colors: [
+			{ name: 'primary', hex: '#000000', role: '纯黑 · 双人舞的另一半' },
+			{ name: 'on-primary', hex: '#ffffff', role: '黑底反白' },
+			{ name: 'link', hex: '#057dbc', role: '唯一允许的内联链接蓝' },
+			{ name: 'ink-soft', hex: '#1a1a1a', role: '柔化黑' },
+			{ name: 'body', hex: '#757575', role: '正文灰' },
+			{ name: 'hairline', hex: '#e0e0e0', role: '故事行分隔线' },
+			{ name: 'canvas-soft', hex: '#f5f5f5', role: '次级面' },
+		],
+		typeScale: [
+			{
+				sample: 'The wired world',
+				spec: 'display-hero · 64px / 400 / -0.5px · WiredDisplay serif',
+				style:
+					"font-family:Georgia,'Times New Roman',serif;font-weight:400;font-size:clamp(30px,4.4vw,46px);letter-spacing:-0.01em;color:#000000;line-height:1.0",
+			},
+			{
+				sample: 'Longform reporting on technology and culture.',
+				spec: 'body · BreveText serif · 18px',
+				style: "font-family:Georgia,'Times New Roman',serif;font-size:16px;color:#333333",
+			},
+		],
+		dos: [
+			'story grid 维持头条+两列+行列表的经典结构',
+			'byline 行之间用发丝线分隔',
+			'masthead 黑带永远居中放字标',
+		],
+		donts: ['不要给按钮加圆角', '除链接蓝外不要引入其它彩色', '不要让无衬线接管 display 层'],
+		plate: {
+			bg: '#ffffff',
+			headline: 'Reporting on what comes next',
+			headlineStyle:
+				"font-family:Georgia,'Times New Roman',serif;color:#000000;font-weight:400;font-size:clamp(27px,3.9vw,44px);letter-spacing:-0.01em;line-height:1.05",
+			spec: 'WiredDisplay serif · 方角按钮 · 报头黑带 · 唯一链接蓝',
+			specColor: '#057dbc',
+		},
+		sourceFile: 'wired',
+	},
 ];
 
 export const designBrandById = new Map(designBrands.map((brand) => [brand.id, brand]));
@@ -881,24 +1454,34 @@ export const designBrandGroups: DesignBrandGroup[] = [
 		id: 'tools',
 		label: '工具与 SaaS',
 		note: '效率工具和开发平台的界面语言：克制、系统化、让产品截图自己说话。',
-		brandIds: ['notion', 'linear', 'vercel', 'figma', 'ibm'],
+		brandIds: [
+			'notion',
+			'linear',
+			'vercel',
+			'figma',
+			'ibm',
+			'cursor',
+			'raycast',
+			'supabase',
+			'framer',
+		],
 	},
 	{
 		id: 'tech',
 		label: '科技产品',
 		note: '面向亿级用户的消费科技：摄影、氛围，和一个不容妥协的强调色。',
-		brandIds: ['apple', 'spotify', 'claude'],
+		brandIds: ['apple', 'spotify', 'claude', 'nvidia', 'mistral', 'minimax'],
 	},
 	{
 		id: 'commerce',
 		label: '商业与消费',
 		note: '钱与生活方式的生意：信任感、精密感，和摄影的张力。',
-		brandIds: ['stripe', 'nike', 'airbnb'],
+		brandIds: ['stripe', 'nike', 'airbnb', 'coinbase'],
 	},
 	{
 		id: 'media',
 		label: '媒体',
 		note: '内容为王的编辑视觉：最大胆的排印实验发生在这里。',
-		brandIds: ['theverge'],
+		brandIds: ['theverge', 'wired'],
 	},
 ];


### PR DESCRIPTION
## Summary

- Design.md 设计图鉴从 12 个品牌扩充到 **21 个**，新增：
  - 工具与 SaaS：Cursor、Raycast、Supabase、Framer
  - 科技产品：NVIDIA、Mistral、MiniMax（媒体组不再只有一个成员）
  - 商业与消费：Coinbase
  - 媒体：WIRED
- 每个品牌 = 上游 VoltAgent/awesome-design-md 的 DESIGN.md 全文 + 本站中文声音的注册条目（philosophy / 色板 / 字阶 / Do's & Don'ts / 版式 plate），数据均取自上游实测 token
- 分组重排为 9/6/4/2

## Test plan

- [x] astro check / eslint / vitest 42 通过（真实退出码）
- [x] npm run build + verify-site：路由 762 → 771（+9 详情页）
- [x] dev server 抽查 cursor/raycast/wired/minimax 页面 200，首页分组计数 9/6/4/2 正确