### PR TITLE
fix: allow design gallery release paths

### DIFF
--- a/workers/content/deployer/index.test.ts
+++ b/workers/content/deployer/index.test.ts
@@ -937,6 +937,113 @@ describe("automatic code release boundary", () => {
     ).toHaveLength(releasePaths.length);
   });
 
+  it("accepts the design gallery release change set", () => {
+    const added = [
+      "astro/src/components/DesignBrandPlate.astro",
+      ...[
+        "airbnb",
+        "apple",
+        "claude",
+        "cohere",
+        "coinbase",
+        "cursor",
+        "figma",
+        "framer",
+        "ibm",
+        "linear",
+        "mastercard",
+        "minimax",
+        "mintlify",
+        "mistral",
+        "nike",
+        "notion",
+        "nvidia",
+        "ollama",
+        "posthog",
+        "raycast",
+        "resend",
+        "shopify",
+        "spotify",
+        "stripe",
+        "supabase",
+        "theverge",
+        "together",
+        "vercel",
+        "warp",
+        "wired",
+        "xai",
+      ].map((brand) => `astro/src/data/design-md/${brand}.md`),
+      "astro/src/data/designBrands.ts",
+      "astro/src/pages/vibe-coding/design/[brand].astro",
+      "astro/src/pages/vibe-coding/design/index.astro",
+      "astro/src/styles/design-gallery.css",
+      "docs/archive/README.md",
+      "static/js/design-gallery.js",
+      "static/js/design-tabs.js",
+      "static/js/vibe-coding-patterns.js",
+    ];
+    const modified = [
+      "astro/AGENTS.md",
+      "astro/package-lock.json",
+      "astro/src/components/KnowledgeIndexHome.astro",
+      "astro/src/components/VibeCodingConceptVisual.astro",
+      "astro/src/components/VibeCodingFlowLab.astro",
+      "astro/src/components/VibeCodingPatternDetail.astro",
+      "astro/src/components/VibeCodingTerms.astro",
+      "astro/src/data/vibeCodingPatternDetails.ts",
+      "astro/src/data/vibeCodingTermDetails.ts",
+      "astro/src/data/vibeCodingTerms.ts",
+      "astro/src/layouts/BaseLayout.astro",
+      "astro/src/lib/legacyContent.ts",
+      "astro/src/lib/searchIndex.test.ts",
+      "astro/src/lib/siteManifest.test.ts",
+      "astro/src/lib/siteManifest.ts",
+      "astro/src/styles/vibe-coding-flow-lab.css",
+      "astro/src/styles/vibe-coding-pattern-detail.css",
+      "astro/src/styles/vibe-coding-terms.css",
+      "content/pi-agent-tutorials/_index.md",
+      "README.md",
+      "scripts/verify-site.mjs",
+    ];
+    const renamed = [
+      ["CF-PAGES-DOMAIN.md", "docs/archive/CF-PAGES-DOMAIN.md"],
+      ["CF-PAGES-QUICK.md", "docs/archive/CF-PAGES-QUICK.md"],
+      ["CLOUDFLARE-PAGES-SETUP.md", "docs/archive/CLOUDFLARE-PAGES-SETUP.md"],
+      ["DOMAIN-QUICK-GUIDE.md", "docs/archive/DOMAIN-QUICK-GUIDE.md"],
+      ["DOMAIN-SETUP.md", "docs/archive/DOMAIN-SETUP.md"],
+      ["ENV-SETUP.md", "docs/archive/ENV-SETUP.md"],
+      ["HUGO-DEBUG.md", "docs/archive/HUGO-DEBUG.md"],
+      ["HUGO-README.md", "docs/archive/HUGO-README.md"],
+      ["hugo.toml.bak", "docs/archive/hugo.toml.bak"],
+      ["SSL-FIX.md", "docs/archive/SSL-FIX.md"],
+      ["WORKFLOW-OPTIMIZATION.md", "docs/archive/WORKFLOW-OPTIMIZATION.md"],
+      ["WORKFLOW.md", "docs/archive/WORKFLOW.md"],
+    ];
+    const removed = ["astro/src/lib/deepseekHarnessTutorials.test.ts"];
+
+    const files = [
+      ...added.map((filename) => ({ filename, status: "added" })),
+      ...modified.map((filename) => ({ filename, status: "modified" })),
+      ...renamed.map(([previous_filename, filename]) => ({
+        filename,
+        status: "renamed",
+        previous_filename,
+      })),
+      ...removed.map((filename) => ({ filename, status: "removed" })),
+    ];
+
+    expect(
+      validateCodeReleaseChangeSet(
+        comparison(files),
+        {
+          baseCodeSha,
+          targetCodeSha,
+          structuredCutoverDate: "2026-07-16",
+        },
+      ),
+    ).toHaveLength(files.length);
+  });
+
   it.each([
     "assets/daily.json",
     "data/daily/.gitkeep",

--- a/workers/content/deployer/index.ts
+++ b/workers/content/deployer/index.ts
@@ -278,6 +278,7 @@ const INERT_ROOT_SCRIPTS = new Set([
 const RETIRED_HUGO_PATHS = new Set([
   "archetypes/daily.md",
   "hugo.toml",
+  "hugo.toml.bak",
   "scripts/auto-sync-and-cleanup.sh",
   "scripts/fix-github-dirs.sh",
   "scripts/migrate-to-cf-pages.sh",
@@ -416,12 +417,14 @@ function classifyCodeReleasePath(
       "content/deepseek-harness-tutorials/",
       "content/highlights/",
       "content/pi-agent-tutorials/",
+      "astro/src/data/design-md/",
       "content/workbuddy-tutorials/",
       "static/fonts/",
       "static/media/",
     ].some((prefix) => path.startsWith(prefix)) ||
     [
       "astro/src/content.config.ts",
+      "astro/src/data/designBrands.ts",
       "astro/src/data/vibeCodingPatternDetails.ts",
       "astro/src/data/vibeCodingTermDetails.ts",
       "astro/src/data/vibeCodingTerms.ts",
@@ -445,6 +448,9 @@ function classifyCodeReleasePath(
       "static/js/site-shell.js",
       "static/js/vibe-coding-flow-lab.js",
       "static/js/vibe-coding-pattern-detail.js",
+      "static/js/design-gallery.js",
+      "static/js/design-tabs.js",
+      "static/js/vibe-coding-patterns.js",
       "static/js/vibe-coding-terms.js",
       "static/images/brain-cat.jpg",
       "static/images/cat-pose-1.jpg",


### PR DESCRIPTION
## Summary

- 合并 #326/#327/#328 后 Automatic Code Release 被 content-deployer 的路径白名单拒绝（首个未知路径：astro/src/data/design-md/airbnb.md），线上版本停在 b0183af
- 白名单补充：astro/src/data/design-md/ 目录、designBrands.ts、design-gallery/design-tabs/vibe-coding-patterns 三个新客户端脚本；hugo.toml.bak 按 retired Hugo 路径允许移除
- 新增回归测试固化本次被拒的完整 75 路径变更集（含重命名与删除）

## Test plan

- [x] 根目录 npm test 全绿（52 files / 792 tests，含新增回归用例）
- [ ] 合并后观察 main 上 Automatic Code Release 通过并验证 https://bubblenews.today 生效