### PR TITLE
feat: add GitHub link to navigation rail

### DIFF
--- a/astro/src/layouts/BaseLayout.astro
+++ b/astro/src/layouts/BaseLayout.astro
@@ -169,6 +169,16 @@ const navItemIsActive = (item: NavItem) =>
 					<div class="rail-controls">
 						<AuthControls locale={lang} />
 						<a href={languageHref}>{isEnglish ? '中文' : 'EN'}</a>
+						<a
+							class="rail-github-link"
+							href="https://github.com/DylanDDeng/ai-bubblebrain-daily-news"
+							target="_blank"
+							rel="noopener noreferrer"
+							aria-label="GitHub"
+							title="GitHub"
+						>
+							<i class="ph ph-github-logo" aria-hidden="true"></i>
+						</a>
 					</div>
 					<p class="rail-motto">{isEnglish ? 'Build links, not noise.' : '建立连接，长期主义。'}</p>
 				</div>

--- a/astro/src/styles/ricoui-theme.css
+++ b/astro/src/styles/ricoui-theme.css
@@ -289,6 +289,13 @@ h3 {
 	transform: none;
 }
 
+.rail-controls > .rail-github-link {
+	width: 38px;
+	padding: 0;
+	font-size: 1.1rem;
+	justify-content: center;
+}
+
 .rail-controls .auth-panel {
 	top: calc(100% + 10px);
 	right: 0;


### PR DESCRIPTION
## Summary

- add a compact GitHub repository link beside the language switcher
- preserve the link in the expanded mobile navigation menu
- keep the external link accessible and isolated with noopener/noreferrer

## Verification

- `npm run verify` in `astro/`
- Playwright desktop and 390x844 mobile-menu checks
- verified the link opens the repository in a new tab