### PR TITLE
docs: update site sections in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,9 @@ Bubble's Brain 是一个面向 AI 实践者的个人知识库，沉淀值得长�
 ## 站点栏目
 
 - **Codex 教程**（`codex-tutorials/`）：从安装入门到真实工作流的系统指南。
-- **DeepSeek Harness 教程**（`deepseek-harness-tutorials/`）：从 Web UI 到 CLI、SDK 与插件开发的分篇指南。
+- **Pi Agent 教程**（`pi-agent-tutorials/`）：Pi Agent 的安装、会话存储与工具系统实践指南。
 - **WorkBuddy 教程**（`workbuddy-tutorials/`）：从安装入门到办公自动化的实用指南。
+- **Vibe Coding**（`vibe-coding/`）：术语表、Skills 与 Design 三个子栏目。
 - **X 热门 AI 内容精选**（`x-trending/`）：亲选的 X 热门博主 AI 内容。
 - **精选阅读**（`highlights/`）：一手资料、官方文章与深度解读。
 - **关于**（`about/`）：站点与作者介绍。

--- a/astro/README.md
+++ b/astro/README.md
@@ -1,6 +1,6 @@
 # Bubble's Brain Astro site
 
-Astro 是 Bubble's Brain 知识库的正式展示层。它从 `../content` 读取 Codex 教程、WorkBuddy 教程、精选阅读、Prompt、模型评测、研究笔记与个人文章，并生成静态站点。AI 工具内容暂时保留在源码中，但不会生成公开栏目、搜索结果或 RSS。
+Astro 是 Bubble's Brain 知识库的正式展示层。它从 `../content` 读取 Codex 教程、Pi Agent 教程、WorkBuddy 教程、Vibe Coding、精选阅读、Prompt、模型评测、研究笔记与个人文章，并生成静态站点。AI 工具内容暂时保留在源码中，但不会生成公开栏目、搜索结果或 RSS。
 
 ## 站点能力
 


### PR DESCRIPTION
## 改动内容

对照导航源码（BaseLayout.astro）与构建产物路由，修正 README 中过时的站点栏目清单：

### README.md
- 删除「DeepSeek Harness 教程」——已下线，不在导航与构建产物中
- 补充「Pi Agent 教程」——导航一级栏目
- 补充「Vibe Coding」——术语/Skills/Design 分组

### astro/README.md
- 开头内容源列举同步补充 Pi Agent 教程与 Vibe Coding，与主 README 保持一致

纯文档改动，不影响构建产物。