### PR TITLE
docs: refresh about page for knowledge base positioning

### DIFF
--- a/content/about/_index.en.md
+++ b/content/about/_index.en.md
@@ -1,20 +1,24 @@
 ---
 title: "About"
-description: "About Bubble's Brain"
+description: "About Bubble's Brain and its author"
 ---
 
-This site is a curated collection of information in the AI space — things I find useful and worth saving. I hope you can also find resources here that help you.
+Bubble's Brain is a personal AI knowledge base — a home for content worth revisiting and reusing. Not the daily feed, but structured knowledge that lasts.
+
+The site began as an AI daily-news project. Today it maintains:
+
+- **Codex / Pi Agent / WorkBuddy tutorials**: hands-on guides from installation to real-world workflows.
+- **Vibe Coding**: a glossary, Skills, and Design notes — a shared language for working with AI.
+- **Highlights**: primary sources, official articles, and in-depth commentary.
 
 ## About me
 
-- I’ve worked as a data analyst, product, and in ops — now I’m an ML/algorithm engineer.
-- I have a cat named **Bubble**.
-- Capricorn, ISFJ, and a long-time Kobe fan.
-- I write as a creator: WeChat public account **BubbleBrain**, focusing on AI models and product evaluations, plus interesting finds.
+- I've worked as a data analyst, a product manager, and in ops — now I'm an ML/algorithm engineer.
+- I create content as **BubbleBrain** on WeChat, focusing on AI model and product reviews, with the occasional interesting find.
 
-## More
+## Find me
 
-- Website: https://bubblebrain.me/
-- Twitter/X: https://x.com/dylandddeng
+- Website: <https://bubblebrain.me/>
+- Twitter/X: <https://x.com/dylandddeng>
 - WeChat public account: BubbleBrain
 - Xiaohongshu: Bubble Brain (with a space)

--- a/content/about/_index.md
+++ b/content/about/_index.md
@@ -1,27 +1,24 @@
+---
+title: "关于"
+description: "关于 Bubble's Brain 与作者"
+---
 
- 这里主要作为AI领域的信息集合地，放置着我看到的比较不错且有用的资讯。 也希望你能在这里找到对你有用的资讯。 
+Bubble's Brain 是一个个人 AI 知识库，沉淀值得长期检索和复用的内容：不追逐每日信息流，而是把值得留下的东西整理成结构化的知识。
 
-## 关于我     
+本站由 AI 日报站点转型而来，目前主要维护这些栏目：
+
+- **Codex 教程 / Pi Agent 教程 / WorkBuddy 教程**：从安装入门到真实工作流的实践指南。
+- **Vibe Coding**：术语表、Skills 与 Design，帮你和 AI 协作时说同一种语言。
+- **精选阅读**：一手资料、官方文章与深度解读。
+
+## 关于我
 
 - 做过数据分析师、当过产品、搞过点运营，现在是算法工程师。
-- 有一只猫，叫 **Bubble**
-- 摩羯座、ISFJ、科比死忠粉
-- 自媒体创作者 ，<u>公众号：BubbleBrain 主理人</u>，专注于 AI 模型、产品的评测和体验，有时也会分享很多有意思的内容   
+- 自媒体创作者，公众号 **BubbleBrain** 主理人，专注 AI 模型与产品的评测和体验，偶尔分享些有意思的内容。
 
-## 更多信息： 
+## 找到我
 
-- 个人站点: https://bubblebrain.me/  
-- Twitter/X: https://x.com/dylandddeng   
-- 公众号：BubbleBrain 
-- 小红书：Bubble Brain(有空格) 
-
-
-
-
-
-
-
-
-
-
-
+- 个人站点：<https://bubblebrain.me/>
+- Twitter/X：<https://x.com/dylandddeng>
+- 公众号：BubbleBrain
+- 小红书：Bubble Brain（有空格）


### PR DESCRIPTION
关于页全面翻新，与知识库定位对齐：

- 站点介绍改为个人 AI 知识库定位，说明日报转型背景，新增栏目导览（三组教程 / Vibe Coding / 精选阅读）
- 个人介绍精简：保留职业经历、公众号与社交链接，移除生活化信息
- 修复格式遗留：中文版补齐 frontmatter，去掉多余空行与下划线标签
- 英文版同步重写，两版内容一致

构建已验证，/about/ 与 /en/about/ 正常生成。