### PR TITLE
fix: classify LICENSE as inert path in code release validation

### DIFF
--- a/workers/content/deployer/index.test.ts
+++ b/workers/content/deployer/index.test.ts
@@ -1026,6 +1026,7 @@ describe("automatic code release boundary", () => {
       "astro/src/styles/vibe-coding-pattern-detail.css",
       "astro/src/styles/vibe-coding-terms.css",
       "content/pi-agent-tutorials/_index.md",
+      "LICENSE",
       "README.md",
       "scripts/verify-site.mjs",
     ];

--- a/workers/content/deployer/index.ts
+++ b/workers/content/deployer/index.ts
@@ -392,6 +392,7 @@ function classifyCodeReleasePath(
       "astro/prettier.config.mjs",
       "astro/vitest.config.ts",
       "package.json",
+      "LICENSE",
       "start.sh",
       "vitest.config.js",
       "wrangler.content-broker.toml",


### PR DESCRIPTION
## 问题

自 #337（GPL→MIT 换证）起，生产发布全部被 content-deployer 拒绝：

```
Error: Automatic code release was rejected (422):
{"error":"unsafe_code_release","detail":"Code release contains forbidden or unknown path: LICENSE"}
```

根因：deployer 的路径分类里，根目录文档靠正则 `^[^/]+\.md$` 识别为 inert，而 `LICENSE` 无扩展名、又不在白名单 → 整包发布被拒。当前已积压 4 次未上线的更新（#338 Humanizer 技能、#339 双语 README、#340 关于页翻新、#341 Warp 精选文章）。

## 修复

- `workers/content/deployer/index.ts`：inert 白名单加入 `LICENSE`
- `workers/content/deployer/index.test.ts`：大型混合发布用例的 modified 清单加入 `LICENSE`
- 测试 52 个全部通过

合并后 Automatic Code Release 会以最后一次成功发布的 SHA 为基准补发全部积压变更。