### PR TITLE
fix: classify content/about as publishable in code release

### DIFF
--- a/workers/content/deployer/index.test.ts
+++ b/workers/content/deployer/index.test.ts
@@ -825,7 +825,7 @@ describe("automatic code release boundary", () => {
     ]);
   });
 
-  it.each(["content/about/index.md", "unknown/release-input.json"])(
+  it.each(["unknown/release-input.json"])(
     "rejects a mixed release containing %s",
     (forbiddenPath) => {
       expect(() =>
@@ -1026,6 +1026,8 @@ describe("automatic code release boundary", () => {
       "astro/src/styles/vibe-coding-pattern-detail.css",
       "astro/src/styles/vibe-coding-terms.css",
       "content/pi-agent-tutorials/_index.md",
+      "content/about/_index.md",
+      "content/about/_index.en.md",
       "LICENSE",
       "README.md",
       "scripts/verify-site.mjs",

--- a/workers/content/deployer/index.ts
+++ b/workers/content/deployer/index.ts
@@ -415,6 +415,7 @@ function classifyCodeReleasePath(
       "astro/src/scripts/",
       "astro/src/lib/",
       "content/codex-tutorials/",
+      "content/about/",
       "content/deepseek-harness-tutorials/",
       "content/highlights/",
       "content/pi-agent-tutorials/",


### PR DESCRIPTION
 follow-up to #342。发布守门验证对 `content/about/` 是 fail-closed 的未知路径，但站点实际从 git 静态构建 /about/。将其与 content/highlights/ 同等归类为 publishable，测试同步更新（51 个全过）。