### PR TITLE
chore: hide record count on about page, drop transition clause

### DIFF
--- a/astro/src/components/LegacyPage.astro
+++ b/astro/src/components/LegacyPage.astro
@@ -374,7 +374,7 @@ const libraryApi =
 							<strong data-directory-count>{directoryItems.length}</strong>
 							<span>{isEnglish ? 'picks · updated continually' : '篇 · 持续收录中'}</span>
 						</p>
-					) : (
+					) : record.section === 'about' ? null : (
 						<p class="directory-count">
 							<>
 								<strong data-directory-count>{directoryItems.length || children.length}</strong>

--- a/content/about/_index.en.md
+++ b/content/about/_index.en.md
@@ -5,7 +5,7 @@ description: "About Bubble's Brain and its author"
 
 Bubble's Brain is a personal AI knowledge base — a home for content worth revisiting and reusing. Not the daily feed, but structured knowledge that lasts.
 
-The site began as an AI daily-news project. Today it maintains:
+The site currently maintains:
 
 - **Codex / Pi Agent / WorkBuddy tutorials**: hands-on guides from installation to real-world workflows.
 - **Vibe Coding**: a glossary, Skills, and Design notes — a shared language for working with AI.

--- a/content/about/_index.md
+++ b/content/about/_index.md
@@ -5,7 +5,7 @@ description: "关于 Bubble's Brain 与作者"
 
 Bubble's Brain 是一个个人 AI 知识库，沉淀值得长期检索和复用的内容：不追逐每日信息流，而是把值得留下的东西整理成结构化的知识。
 
-本站由 AI 日报站点转型而来，目前主要维护这些栏目：
+站点目前主要维护这些栏目：
 
 - **Codex 教程 / Pi Agent 教程 / WorkBuddy 教程**：从安装入门到真实工作流的实践指南。
 - **Vibe Coding**：术语表、Skills 与 Design，帮你和 AI 协作时说同一种语言。


### PR DESCRIPTION
关于页两处清理（用户反馈）：

- 隐藏 about 区头部的「0 条记录」计数徽章（LegacyPage.astro 中 section 为 about 时不渲染，其他栏目不受影响）
- 删除「本站由 AI 日报站点转型而来」句，英文版同步

构建已验证：about 页徽章为 0、教程页计数保留。