### PR TITLE
feat: add Umami analytics with CSP and release allowlist updates

### DIFF
--- a/astro/src/layouts/BaseLayout.astro
+++ b/astro/src/layouts/BaseLayout.astro
@@ -103,6 +103,7 @@ const navItemIsActive = (item: NavItem) =>
 		<title>{title}</title>
 		<ClientRouter fallback="swap" />
 		<script is:inline type="module" src="/js/navigation.js"></script>
+		<script is:inline defer src="https://cloud.umami.is/script.js" data-website-id="2a4e6219-c7bc-4336-96e3-5d1dc2f0b330"></script>
 	</head>
 	<body>
 		<a class="skip-link" href="#main-content">{isEnglish ? 'Skip to content' : '跳到正文'}</a>

--- a/static/_headers
+++ b/static/_headers
@@ -2,7 +2,7 @@
   X-Content-Type-Options: nosniff
   Referrer-Policy: strict-origin-when-cross-origin
   Permissions-Policy: camera=(), microphone=(), geolocation=(), payment=(), usb=()
-  Content-Security-Policy: default-src 'self'; script-src 'self' 'wasm-unsafe-eval' https://challenges.cloudflare.com https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; connect-src 'self' https://*.supabase.co https://community-api.bubblenews.today https://community-api-staging.bubblenews.today https://challenges.cloudflare.com https://api.moonshot.cn https://generativelanguage.googleapis.com; frame-src data: https://challenges.cloudflare.com; font-src 'self' data:; media-src 'self' data: blob: https:; worker-src 'self' blob:; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'
+  Content-Security-Policy: default-src 'self'; script-src 'self' 'wasm-unsafe-eval' https://challenges.cloudflare.com https://cdn.jsdelivr.net https://cloud.umami.is; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; connect-src 'self' https://*.supabase.co https://community-api.bubblenews.today https://community-api-staging.bubblenews.today https://challenges.cloudflare.com https://api.moonshot.cn https://generativelanguage.googleapis.com https://cloud.umami.is; frame-src data: https://challenges.cloudflare.com; font-src 'self' data:; media-src 'self' data: blob: https:; worker-src 'self' blob:; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'
 
 /auth/*
   Cache-Control: no-store

--- a/workers/content/deployer/index.test.ts
+++ b/workers/content/deployer/index.test.ts
@@ -1026,6 +1026,7 @@ describe("automatic code release boundary", () => {
       "astro/src/styles/vibe-coding-pattern-detail.css",
       "astro/src/styles/vibe-coding-terms.css",
       "content/pi-agent-tutorials/_index.md",
+      "static/_headers",
       "content/about/_index.md",
       "content/about/_index.en.md",
       "LICENSE",

--- a/workers/content/deployer/index.ts
+++ b/workers/content/deployer/index.ts
@@ -444,6 +444,7 @@ function classifyCodeReleasePath(
       "cloudflare-pages.toml",
       "data/knowledge/taxonomy.json",
       "static/css/daily-timeline.css",
+      "static/_headers",
       "static/js/ai-infographic.js",
       "static/js/daily-timeline.js",
       "static/js/knowledge-home-v2.js",


### PR DESCRIPTION
接入 Umami Cloud 统计（无 Cookie、隐私友好）：

- BaseLayout.astro 嵌入 Umami 异步脚本（cloud.umami.is）
- static/_headers CSP：script-src 与 connect-src 各加 https://cloud.umami.is
- deployer 发布白名单加 static/_headers（此前 static/ 下仅个别文件被允许）

全量验证通过：deployer 测试、astro verify（check + eslint + vitest + build + CSP + 站点校验）。