### PR TITLE
fix: classify Hugo/mdBook cleanup paths in code release

### DIFF
--- a/workers/content/deployer/index.test.ts
+++ b/workers/content/deployer/index.test.ts
@@ -825,6 +825,39 @@ describe("automatic code release boundary", () => {
     ]);
   });
 
+  it("accepts the Hugo/mdBook cleanup change set", () => {
+    expect(() =>
+      validateCodeReleaseChangeSet(
+        comparison([
+          { filename: ".gitignore", status: "modified" },
+          { filename: ".gitmodules", status: "removed" },
+          { filename: "book.toml", status: "removed" },
+          { filename: "cron-docker/Dockerfile", status: "removed" },
+          { filename: "cron-docker/entrypoint.sh", status: "removed" },
+          { filename: "cron-docker/scripts/build.sh", status: "removed" },
+          { filename: "cron-docker/scripts/work/book.toml", status: "removed" },
+          { filename: ".github/workflows/unzip_and_commit.yml", status: "removed" },
+          { filename: "scripts/check-dns.sh", status: "removed" },
+          { filename: "scripts/check-github-pages.sh", status: "removed" },
+          { filename: "scripts/fix-dns.sh", status: "removed" },
+          { filename: "scripts/cleanup-dns-for-pages.sh", status: "removed" },
+          { filename: "scripts/diagnose-ssl-issue.sh", status: "removed" },
+          { filename: "scripts/content-route-build-contract.mjs", status: "modified" },
+          { filename: "astro/package.json", status: "modified" },
+          { filename: "astro/route-ownership.json", status: "modified" },
+          { filename: "astro/scripts/build-legacy-compat.mjs", status: "removed" },
+          { filename: "docs/archive/DEPLOYMENT.md", status: "added" },
+          { filename: "workers/content/broker/index.ts", status: "modified" },
+        ]),
+        {
+          baseCodeSha,
+          targetCodeSha,
+          structuredCutoverDate: "2026-07-16",
+        },
+      ),
+    ).not.toThrow();
+  });
+
   it.each(["unknown/release-input.json"])(
     "rejects a mixed release containing %s",
     (forbiddenPath) => {

--- a/workers/content/deployer/index.ts
+++ b/workers/content/deployer/index.ts
@@ -257,8 +257,14 @@ type CodeReleasePathClass = "publishable" | "inert" | "db_owned";
 const INERT_ROOT_SCRIPTS = new Set([
   "scripts/check-content-observability.mjs",
   "scripts/check-content-observation-window.mjs",
+  "scripts/check-dns.sh",
+  "scripts/check-github-pages.sh",
+  "scripts/cleanup-dns-for-pages.sh",
+  "scripts/content-route-build-contract.mjs",
   "scripts/create-content-addressed-artifact.mjs",
   "scripts/daily-localization-contract.mjs",
+  "scripts/diagnose-ssl-issue.sh",
+  "scripts/fix-dns.sh",
   "scripts/html-local-references.mjs",
   "scripts/materialize-content-addressed-artifact.mjs",
   "scripts/preview-media-types.mjs",
@@ -279,6 +285,8 @@ const RETIRED_HUGO_PATHS = new Set([
   "archetypes/daily.md",
   "hugo.toml",
   "hugo.toml.bak",
+  ".gitmodules",
+  "book.toml",
   "scripts/auto-sync-and-cleanup.sh",
   "scripts/fix-github-dirs.sh",
   "scripts/migrate-to-cf-pages.sh",
@@ -291,7 +299,7 @@ const RETIRED_HUGO_PATHS = new Set([
   "view-site.sh",
 ]);
 
-const RETIRED_HUGO_PREFIXES = ["i18n/", "layouts/", "themes/"];
+const RETIRED_HUGO_PREFIXES = ["i18n/", "layouts/", "themes/", "cron-docker/"];
 const RETIRED_HIGHLIGHT_INDEXES = new Set([
   "static/highlights.json",
   "static/en/highlights.json",
@@ -382,6 +390,7 @@ function classifyCodeReleasePath(
     path.startsWith("src/") ||
     INERT_ROOT_SCRIPTS.has(path) ||
     [
+      ".gitignore",
       "astro/.editorconfig",
       "astro/.gitignore",
       "astro/.nvmrc",


### PR DESCRIPTION
## Summary
The automatic code release for PR #347 failed with `422 unsafe_code_release`: the cleanup touched paths the content-deployer had never classified. This classifies them via the existing mechanisms:

- Root `.gitignore` → inert root files
- `.gitmodules`, `book.toml` → RETIRED_HUGO_PATHS (removal-only)
- `cron-docker/` → RETIRED_HUGO_PREFIXES
- 5 retired GitHub Pages/SSL shell scripts + `scripts/content-route-build-contract.mjs` → INERT_ROOT_SCRIPTS

Adds a regression test covering the full #347 cleanup change set.

## Verification
- npm test: 52 files / 793 tests pass (new regression test included)
- content-deployer dry-run compiles

## Deploy note
After merge, the content-deployer Worker MUST be redeployed (`npx wrangler deploy --config wrangler.content-deployer.toml`) before rerunning the failed release.