### PR TITLE
fix: make header navigation groups exclusive

### DIFF
--- a/astro/src/scripts/siteShell.test.ts
+++ b/astro/src/scripts/siteShell.test.ts
@@ -1,0 +1,45 @@
+import { readFileSync } from 'node:fs';
+import { runInNewContext } from 'node:vm';
+
+import { describe, expect, it } from 'vitest';
+
+const source = readFileSync(new URL('../../../static/js/site-shell.js', import.meta.url), 'utf8');
+
+class FakeNavGroup {
+	dataset: Record<string, string> = {};
+	open = false;
+	private listeners = new Map<string, () => void>();
+
+	addEventListener(type: string, listener: () => void) {
+		this.listeners.set(type, listener);
+	}
+
+	toggle(open: boolean) {
+		this.open = open;
+		this.listeners.get('toggle')?.();
+	}
+}
+
+describe('site shell navigation groups', () => {
+	it('keeps only the most recently opened navigation group expanded', () => {
+		const groups = [new FakeNavGroup(), new FakeNavGroup(), new FakeNavGroup()];
+		const document = {
+			documentElement: { dataset: { theme: 'light' } },
+			querySelectorAll: (selector: string) =>
+				selector === 'details[data-nav-group]' ? groups : [],
+			querySelector: () => null,
+			addEventListener: () => undefined,
+		};
+
+		runInNewContext(source, { document, localStorage: { setItem: () => undefined } });
+
+		groups[0].toggle(true);
+		groups[1].toggle(true);
+
+		expect(groups.map((group) => group.open)).toEqual([false, true, false]);
+
+		groups[2].toggle(true);
+
+		expect(groups.map((group) => group.open)).toEqual([false, false, true]);
+	});
+});

--- a/static/js/site-shell.js
+++ b/static/js/site-shell.js
@@ -33,6 +33,20 @@ function initSiteShell() {
     });
   }
 
+  // Exclusive accordion for the rail nav groups: opening one collapses the
+  // others so the sidebar keeps a single expanded submenu at a time.
+  const navGroups = document.querySelectorAll("details[data-nav-group]");
+  for (const group of navGroups) {
+    if (group.dataset.shellBound === "true") continue;
+    group.dataset.shellBound = "true";
+    group.addEventListener("toggle", () => {
+      if (!group.open) return;
+      for (const other of navGroups) {
+        if (other !== group && other.open) other.open = false;
+      }
+    });
+  }
+
   syncThemeIcons();
 }
 


### PR DESCRIPTION
## Summary
- collapse other header navigation groups when one group opens
- preserve existing Astro page-load rebinding behavior
- add a regression test for exclusive expansion

## Verification
- `npm run verify` (Node 22.17.0)
- Playwright: opened 教程, then Vibe Coding; only Vibe Coding remained expanded