### PR TITLE
feat: add AI forgetting tutorial and context labs

### DIFF
--- a/astro/src/lib/newbieTutorials.test.ts
+++ b/astro/src/lib/newbieTutorials.test.ts
@@ -18,6 +18,17 @@ const chapters = [
 		phrases: ['猜下一个词', 'https://arxiv.org/abs/2509.04664'],
 	},
 	{
+		route: '/newbie-tutorials/why-ai-forgets/',
+		weight: 3,
+		visuals: ['ctx-desk.svg', 'ctx-lost-middle.svg', 'ctx-compaction.svg'],
+		labs: ['desk', 'compact', 'risk'],
+		phrases: [
+			'上下文窗口',
+			'/vibe-coding/terms/context-window/',
+			'/newbie-tutorials/why-llms-hallucinate/',
+		],
+	},
+	{
 		route: '/newbie-tutorials/what-is-a-knowledge-base/',
 		weight: 2,
 		visuals: ['kb-pipeline.svg', 'kb-chunks-and-embeddings.svg', 'kb-failure-points.svg'],

--- a/astro/src/scripts/newbie-lab.ts
+++ b/astro/src/scripts/newbie-lab.ts
@@ -457,6 +457,166 @@ function setupSearchLab(lab: HTMLElement): void {
 	render();
 }
 
+// LAB (context) 01 — a tiny 8000-token desk; the opening requirement gets
+// evicted from the front once the desk overflows.
+const DESK_CAPACITY = 8000;
+const DESK_ITEMS: Record<string, { label: string; size: number }> = {
+	ask: { label: '你的问题', size: 300 },
+	chat: { label: '闲聊', size: 500 },
+	long: { label: '它的长回答', size: 1500 },
+	doc: { label: '长合同', size: 5200 },
+};
+const DESK_REQ = { key: 'req', label: '你的要求', size: 600 };
+
+function setupDeskLab(lab: HTMLElement): void {
+	const bar = lab.querySelector<HTMLElement>('[data-nb-desk-bar]');
+	const used = lab.querySelector<HTMLElement>('[data-nb-desk-used]');
+	const evictedBox = lab.querySelector<HTMLElement>('[data-nb-desk-evicted]');
+	const ask = lab.querySelector<HTMLButtonElement>('[data-nb-desk-ask]');
+	const reset = lab.querySelector<HTMLButtonElement>('[data-nb-reset]');
+	const result = lab.querySelector<HTMLElement>('[data-nb-result]');
+	const adders = lab.querySelectorAll<HTMLButtonElement>('[data-nb-desk-add]');
+	if (!bar || !used || !evictedBox || !ask || !reset || !result) return;
+
+	let blocks: Array<{ key: string; label: string; size: number }> = [];
+	let evicted: string[] = [];
+
+	const render = () => {
+		const total = blocks.reduce((sum, block) => sum + block.size, 0);
+		used.textContent = `已用 ${total} / ${DESK_CAPACITY} token`;
+		bar.replaceChildren();
+		for (const block of blocks) {
+			const span = document.createElement('span');
+			span.className = block.key === 'req' ? 'nb-desk-block is-req' : 'nb-desk-block';
+			span.style.width = `${(block.size / DESK_CAPACITY) * 100}%`;
+			span.title = `${block.label} · ${block.size} token`;
+			const text = document.createElement('i');
+			text.textContent = block.label;
+			span.append(text);
+			bar.append(span);
+		}
+		if (evicted.length > 0) {
+			evictedBox.hidden = false;
+			const hasReq = evicted.includes(DESK_REQ.label);
+			evictedBox.textContent = `⚠ 已被挤出桌面：${evicted.join('、')}${hasReq ? '——包括你开头的要求' : ''}`;
+		} else {
+			evictedBox.hidden = true;
+		}
+	};
+
+	const start = () => {
+		blocks = [{ ...DESK_REQ }];
+		evicted = [];
+		result.hidden = true;
+		render();
+	};
+
+	const add = (kind: string) => {
+		const item = DESK_ITEMS[kind];
+		if (!item) return;
+		blocks.push({ key: kind, label: item.label, size: item.size });
+		let total = blocks.reduce((sum, block) => sum + block.size, 0);
+		while (total > DESK_CAPACITY && blocks.length > 1) {
+			const gone = blocks.shift()!;
+			evicted.push(gone.label);
+			total -= gone.size;
+		}
+		result.hidden = true;
+		render();
+	};
+
+	const answer = () => {
+		const reqAlive = blocks.some((block) => block.key === 'req');
+		result.replaceChildren();
+		result.dataset.tone = reqAlive ? 'good' : 'bad';
+		const line = document.createElement('p');
+		line.className = 'nb-kb-answer';
+		line.textContent = reqAlive
+			? '回答：「你要求全程用中文，预算 3 万 5，不能超。」'
+			: '回答：「从当前对话里，我没有看到你提过整体要求。需要我们现在定一个吗？」';
+		const verdict = document.createElement('p');
+		verdict.className = 'nb-kb-verdict';
+		verdict.textContent = reqAlive
+			? '那块橙色的要求还在桌上，它当然答得一字不差。再往桌上塞点大东西试试。'
+			: '它没有撒谎，也没有装傻。那条消息已经被挤出桌面，对它来说等于从未存在过——这就是「聊着聊着忘了」的真相。';
+		result.append(line, verdict);
+		result.hidden = false;
+	};
+
+	for (const button of adders) {
+		button.addEventListener('click', () => add(button.dataset.nbDeskAdd ?? ''));
+	}
+	ask.addEventListener('click', answer);
+	reset.addEventListener('click', start);
+	start();
+}
+
+// LAB (context) 02 — compaction keeps the gist and drops the details.
+const COMPACT_ANSWERS: Record<
+	string,
+	{ answer: string; note: string; tone: 'good' | 'bad' | 'meh' }
+> = {
+	budget: {
+		answer: '回答：「预算之前已经确定过了。如果需要，我先按 3 万左右来规划？」',
+		note: '具体数字在压缩时丢了，摘要里只剩「已确定预算」。它嘴里那个「3 万左右」是现编的——语气很稳，数字是错的。长对话后期的数字错误，多半就是这么来的。',
+		tone: 'bad',
+	},
+	color: {
+		answer: '回答：「主色是深蓝色系。」',
+		note: '大方向保住了，但色号 #1B3A6B 没了。设计稿会照着「深蓝」跑偏一点点——这种半对不对的答案最难被发现。',
+		tone: 'meh',
+	},
+	lang: {
+		answer: '回答：「后续全程用中文沟通。」',
+		note: '这条在摘要里完整活了下来，答得没问题。压缩不是全丢，是保大意、丢细节。',
+		tone: 'good',
+	},
+};
+
+function setupCompactLab(lab: HTMLElement): void {
+	const transcript = lab.querySelector<HTMLElement>('[data-nb-transcript]');
+	const compact = lab.querySelector<HTMLButtonElement>('[data-nb-compact]');
+	const summary = lab.querySelector<HTMLElement>('[data-nb-summary]');
+	const questions = lab.querySelector<HTMLElement>('[data-nb-compact-questions]');
+	const result = lab.querySelector<HTMLElement>('[data-nb-result]');
+	const reset = lab.querySelector<HTMLButtonElement>('[data-nb-reset]');
+	if (!transcript || !compact || !summary || !questions || !result || !reset) return;
+
+	compact.addEventListener('click', () => {
+		transcript.classList.add('is-compacted');
+		compact.hidden = true;
+		summary.hidden = false;
+		questions.hidden = false;
+		reset.hidden = false;
+	});
+
+	for (const button of questions.querySelectorAll<HTMLButtonElement>('[data-nb-q]')) {
+		button.addEventListener('click', () => {
+			const outcome = COMPACT_ANSWERS[button.dataset.nbQ ?? ''];
+			if (!outcome) return;
+			result.replaceChildren();
+			result.dataset.tone = outcome.tone;
+			const answer = document.createElement('p');
+			answer.className = 'nb-kb-answer';
+			answer.textContent = outcome.answer;
+			const note = document.createElement('p');
+			note.className = 'nb-kb-verdict';
+			note.textContent = outcome.note;
+			result.append(answer, note);
+			result.hidden = false;
+		});
+	}
+
+	reset.addEventListener('click', () => {
+		transcript.classList.remove('is-compacted');
+		compact.hidden = false;
+		summary.hidden = true;
+		questions.hidden = true;
+		result.hidden = true;
+		reset.hidden = true;
+	});
+}
+
 function setupNewbieLabs(): void {
 	for (const lab of document.querySelectorAll<HTMLElement>('[data-nb-lab]')) {
 		if (lab.dataset.nbReady === 'true') continue;
@@ -468,6 +628,8 @@ function setupNewbieLabs(): void {
 		else if (kind === 'risk') setupRiskLab(lab);
 		else if (kind === 'retrieve') setupRetrieveLab(lab);
 		else if (kind === 'search') setupSearchLab(lab);
+		else if (kind === 'desk') setupDeskLab(lab);
+		else if (kind === 'compact') setupCompactLab(lab);
 	}
 }
 

--- a/astro/src/styles/newbie-lab.css
+++ b/astro/src/styles/newbie-lab.css
@@ -599,6 +599,100 @@
 	font-weight: 700;
 }
 
+/* Context-window labs: desk bar, transcript, summary card */
+.article-content .nb-desk {
+	display: flex;
+	gap: 2px;
+	height: 52px;
+	margin-top: 10px;
+	padding: 4px;
+	border: 2px solid #b9b9b5;
+	background: var(--paper-muted);
+}
+
+.article-content .nb-desk-block {
+	position: relative;
+	display: flex;
+	align-items: center;
+	overflow: hidden;
+	min-width: 0;
+	border: 1px solid var(--rule);
+	background: var(--paper);
+	transition: width 240ms ease;
+}
+
+.article-content .nb-desk-block i {
+	overflow: hidden;
+	padding-inline: 8px;
+	color: var(--ink-soft);
+	font-size: 0.66rem;
+	font-style: normal;
+	white-space: nowrap;
+	text-overflow: ellipsis;
+}
+
+.article-content .nb-desk-block.is-req {
+	border-color: var(--blue);
+	background: var(--blue-soft);
+}
+
+.article-content .nb-desk-block.is-req i {
+	color: var(--blue-strong);
+	font-weight: 700;
+}
+
+.article-content .nb-desk-evicted {
+	margin-top: 8px;
+	color: var(--blue-strong);
+	font-family: var(--mono);
+	font-size: 0.68rem;
+	letter-spacing: 0.04em;
+}
+
+.article-content .nb-lab-hint + .nb-choices,
+.article-content .nb-desk + .nb-lab-hint {
+	margin-top: 14px;
+}
+
+.article-content .nb-transcript {
+	display: grid;
+	gap: 6px;
+	transition: opacity 240ms ease;
+}
+
+.article-content .nb-transcript.is-compacted {
+	opacity: 0.3;
+}
+
+.article-content .nb-transcript.is-compacted .nb-msg {
+	text-decoration: line-through;
+	text-decoration-color: var(--ink-faint);
+}
+
+.article-content .nb-msg {
+	padding: 8px 12px;
+	border: 1px solid var(--rule);
+	font-size: 0.85rem;
+	line-height: 1.6;
+}
+
+.article-content .nb-summary {
+	margin-top: 14px;
+	padding: 12px 14px;
+	border: 1px solid var(--ink);
+	background: var(--paper);
+}
+
+.article-content .nb-summary p {
+	font-size: 0.92rem;
+	font-weight: 600;
+	line-height: 1.7;
+}
+
+.article-content .nb-lab-result[data-tone='meh'] .nb-kb-answer {
+	color: var(--ink);
+}
+
 /* Quality meter variant: high is the good end. */
 .article-content .nb-risk-meter[data-nb-good][data-level='low'] .nb-risk-level {
 	color: var(--blue-strong);

--- a/content/newbie-tutorials/2026-08-31-why-ai-forgets.md
+++ b/content/newbie-tutorials/2026-08-31-why-ai-forgets.md
@@ -1,0 +1,162 @@
+---
+title: "为什么 AI 聊着聊着就忘了"
+description: "不讲参数，从「一张大小固定的桌子」出发，看明白模型为什么会忘掉你最早的要求、为什么长对话会变笨，以及怎么和一个没有记忆的家伙好好合作。"
+date: 2026-08-31
+lastmod: 2026-08-31
+draft: false
+weight: 3
+slug: "why-ai-forgets"
+tags: ["新手村", "大模型", "上下文窗口", "新手教程"]
+---
+
+你在对话开头交代得清清楚楚：「接下来全程用中文。」聊到第 40 条消息，它突然蹦出一大段英文。你贴过预算是 3 万 5，后来再问，它笃定地说 3 万。你忍不住想：这东西的记性怎么这么差？
+
+这一篇解释这个现象。和前两篇一样，先说一个反直觉的事实。
+
+## 它不是忘了，是从来没记住
+
+大模型**没有记忆**。两次回答之间，它什么都不保留——不是记性差，是压根没有「记」这个动作。
+
+那它怎么能接得上你上一句话？因为每次你发新消息，产品都在幕后把**整段聊天记录从头到尾**重新发给它读一遍。你以为在和一个认识你的老朋友聊天，实际情况更像：每次都把完整的对话记录塞给一个初次见面的人，让他现场读完、接着写下一句。
+
+读过第二篇的话，你会发现这和知识库是同一个思路：模型不保存任何东西，需要什么，就在作答前摆到它面前。对话记录也一样，只是这次摆的是你们聊过的每一句话。
+
+这套机制平时运转得很好，好到你察觉不到它的存在。直到那份「对话记录」太长，放不下了。
+
+## 桌面只有这么大
+
+模型一次能读的内容有一个硬上限。所有东西——系统设定、你们聊过的每一句、你贴的文档、它自己写的回答——都要摊在一张**大小固定的桌面**上，它只能看见桌上的东西。这张桌面的学名叫[上下文窗口](/vibe-coding/terms/context-window/)（context window）。
+
+桌面大小按 token 计——就是第一篇动图里，模型一次「猜」出来的那个「词」（术语页 [Token](/vibe-coding/terms/token/) 有个可以亲手拆句子的小工具）。如今主流模型的窗口有几十万 token，听起来像一张巨桌，够摊一本长篇小说。但一份长 PDF 就是几万 token，它自己一段认真的长回答也要上千，几个来回就见底了。
+
+桌子满了会发生什么？看这张图：
+
+![每次作答都要把一切重新摊上这张桌：你的要求先放上去，几轮问答、长合同、它的长回答陆续加入，桌子满了之后，最早的要求被挤出桌面，彻底消失](/media/newbie-tutorials/ctx-desk.svg)
+
+注意最后一幕：被挤出去的内容**不是存档了，是对它彻底不存在**——而且没有任何提示。于是你看到的现象就是「聊着聊着忘了」：它不是变笨了，是你最早那条要求已经不在桌上。
+
+亲手试一次，比看十遍动图都直观。
+
+<div class="nb-lab" data-nb-lab="desk">
+  <div class="nb-lab-head">
+    <span class="nb-lab-kicker">LAB 01</span>
+    <strong>亲手塞满一张桌面</strong>
+    <p>这是一个迷你模型，桌面只有 8000 token。你的要求「全程中文、预算 3 万 5」已经放在最前面。往桌上加东西，随时问它还记不记得。</p>
+  </div>
+  <div class="nb-lab-stage">
+    <p class="nb-lab-hint" data-nb-desk-used aria-live="polite">已用 600 / 8000 token</p>
+    <div class="nb-desk" data-nb-desk-bar></div>
+    <p class="nb-desk-evicted" data-nb-desk-evicted aria-live="polite" hidden></p>
+    <p class="nb-lab-hint">往桌上加点东西：</p>
+    <div class="nb-choices nb-choices-inline">
+      <button type="button" class="nb-pill" data-nb-desk-add="ask">发一条问题 +300</button>
+      <button type="button" class="nb-pill" data-nb-desk-add="chat">随便聊几句 +500</button>
+      <button type="button" class="nb-pill" data-nb-desk-add="long">让它写段长回答 +1500</button>
+      <button type="button" class="nb-pill" data-nb-desk-add="doc">贴一份长合同 +5200</button>
+    </div>
+    <div class="nb-lab-actions"><button type="button" class="nb-btn" data-nb-desk-ask>问它：我开头要求过什么？</button> <button type="button" class="nb-btn nb-btn-ghost" data-nb-reset>重来</button></div>
+    <div class="nb-lab-result" data-nb-result hidden></div>
+    <p class="nb-lab-nojs">这个小实验需要开启 JavaScript 才能操作。</p>
+  </div>
+</div>
+
+只要那块橙色的「你的要求」还在桌上，它就答得一字不差；被挤出去之后，它会一脸无辜地反问你。它没有撒谎，也没有装傻——**那条消息对它来说，从未存在过**。
+
+## 都在桌上，也分「记得牢」和「记不清」
+
+那是不是只要不被挤出去就万事大吉？可惜还有第二个问题。
+
+桌上摊了两百张纸的时候，模型「读」的质量并不均匀。研究者发现一个稳定的规律：**开头和结尾的内容用得最牢，埋在中间的最容易被漏掉**——这个现象有个形象的名字，叫「迷失在中间」（lost in the middle）。
+
+![迷失在中间：一排消息卡代表长对话，两端颜色深表示记得牢，中间逐渐变浅表示容易被漏掉，你的第 3 条要求恰好埋在正中间](/media/newbie-tutorials/ctx-lost-middle.svg)
+
+这解释了另一种常见的「忘」：要求明明还在窗口里，它却没照做。不是丢了，是被淹没了。塞得越满，中间那片沼泽就越大——这也是第二篇里知识库「只给最相关的几段」的原因：多塞不但占地方，还会互相淹没。
+
+对策也写在图里了：**重要要求放开头；聊久了，把它再说一遍**——一头一尾，占住两个好位置。
+
+## 桌子快满时，它会偷偷做总结
+
+被挤出去、被淹没，都还不是全部。很多产品在桌子快满时会做第三件事：把前面几十条对话**压缩**成一小段摘要，用摘要换掉原文，给新消息腾地方。
+
+![桌子快满时它会偷偷做总结：八条带具体细节的对话被压缩成一段摘要，清点后发现「全程用中文」保住了，预算数字、色号、评审时间只剩模糊说法，对接人完全消失](/media/newbie-tutorials/ctx-compaction.svg)
+
+压缩是个不错的折中——总比把最早的内容整条扔掉强。但总结这个动作天然**保大意、丢细节**：「预算 3 万 5」变成「已确定预算」，「色号 #1B3A6B」变成「主色」。丢了之后你再问细节，它手里只有摘要，要么答不上，要么——想起[第一篇](/newbie-tutorials/why-llms-hallucinate/)了吗——现编一个听起来很对的数。**长对话后期的数字错误，十有八九是这么来的。**
+
+<div class="nb-lab" data-nb-lab="compact">
+  <div class="nb-lab-head">
+    <span class="nb-lab-kicker">LAB 02</span>
+    <strong>压缩之后，还剩下什么</strong>
+    <p>下面是一段聊了很久的对话。桌子快满了——点「压缩」，然后问它几个问题试试。</p>
+  </div>
+  <div class="nb-lab-stage">
+    <div class="nb-transcript" data-nb-transcript>
+      <p class="nb-msg">你：官网改版的事开始推进吧，后面全程用中文沟通。</p>
+      <p class="nb-msg">你：预算定了，3 万 5，不能超。</p>
+      <p class="nb-msg">它：好的。两种改版方案的对比是……</p>
+      <p class="nb-msg">你：主色就用那个深蓝，色号 #1B3A6B。</p>
+      <p class="nb-msg">它：收到，按深蓝出了三版配色……</p>
+      <p class="nb-msg">你：评审定在周四下午 3 点，记得提醒我。</p>
+      <p class="nb-msg">你：供应商那边对接人是林工。</p>
+      <p class="nb-msg">它：都记下了：预算 3 万 5、深蓝主色、周四评审、对接林工。</p>
+    </div>
+    <div class="nb-lab-actions"><button type="button" class="nb-btn" data-nb-compact>桌子快满了，压缩</button></div>
+    <div class="nb-summary" data-nb-summary hidden>
+      <span class="nb-chunk-src">压缩后，桌上只剩这一段</span>
+      <p>用户在推进官网改版，已确定预算、主色与评审安排，后续用中文沟通。</p>
+    </div>
+    <div class="nb-choices nb-choices-inline" data-nb-compact-questions hidden>
+      <button type="button" class="nb-pill" data-nb-q="budget">预算是多少？</button>
+      <button type="button" class="nb-pill" data-nb-q="color">主色是什么？</button>
+      <button type="button" class="nb-pill" data-nb-q="lang">用什么语言沟通？</button>
+    </div>
+    <div class="nb-lab-result" data-nb-result hidden></div>
+    <div class="nb-lab-actions"><button type="button" class="nb-btn nb-btn-ghost" data-nb-reset hidden>重来</button></div>
+    <p class="nb-lab-nojs">这个小实验需要开启 JavaScript 才能操作。</p>
+  </div>
+</div>
+
+## 怎么和一个没有记忆的家伙合作
+
+把这一篇的机制翻成几条日常习惯：
+
+1. **重要设定放开头，聊久了重复一遍。** 一头一尾，两个好位置都占住。
+2. **一个会话只干一件事。** 换话题就开新会话，别让不相干的内容抢桌面、加深「中间的沼泽」。
+3. **感觉它变笨时，主动做一次「人工压缩」。** 让它「把目前的结论、约定和所有关键数字总结成一段」，你核对补全——尤其是数字——然后开个新会话，把这段贴在第一条。和产品偷偷做的压缩相比，你亲手核对过细节。
+4. **贴文档只贴相关部分。** 整份丢进去，既吃桌面，又淹没你真正想问的那几段。
+5. **长对话后期，对它嘴里的数字多留个心眼。** 可能来自被压缩过的摘要，回到第一篇的老规矩：要出处，再核对。
+
+<div class="nb-lab" data-nb-lab="risk">
+  <div class="nb-lab-head">
+    <span class="nb-lab-kicker">LAB 03</span>
+    <strong>该开新会话了吗？</strong>
+    <p>对照你手头那个越聊越长的对话，勾选已经出现的现象。</p>
+  </div>
+  <div class="nb-lab-stage">
+    <div class="nb-checks">
+      <label class="nb-check"><input type="checkbox" data-nb-risk="2"><span>它开始违反你最早提的要求（比如又蹦英文）</span></label>
+      <label class="nb-check"><input type="checkbox" data-nb-risk="2"><span>关键数字它说得和之前不一样了</span></label>
+      <label class="nb-check"><input type="checkbox" data-nb-risk="2"><span>你已经往里贴过两三份长文档</span></label>
+      <label class="nb-check"><input type="checkbox" data-nb-risk="1"><span>现在聊的话题和开头已经不是一件事</span></label>
+      <label class="nb-check"><input type="checkbox" data-nb-risk="1"><span>它的回答越来越泛，车轱辘话变多</span></label>
+      <label class="nb-check"><input type="checkbox" data-nb-risk="-2"><span>对话不长，而且从头到尾只聊一件事</span></label>
+    </div>
+    <div class="nb-risk-meter" data-nb-risk-meter data-level="low" data-nb-medium="2" data-nb-high="4" data-nb-label-low="还能继续" data-nb-label-medium="准备收尾" data-nb-label-high="该开新会话了" data-nb-empty="勾选你观察到的现象。一个都没有？那就放心继续聊。" data-nb-tip-low="桌面还宽裕。保持「重要设定放开头」的习惯就好。" data-nb-tip-medium="找个自然的节点，让它把目前的结论、约定和关键数字总结成一段，你核对补全后，带着这段总结开新会话。" data-nb-tip-high="别硬撑。先让它输出总结，逐条核对细节——尤其是数字，然后开新会话，把总结贴在第一条。旧会话留着当档案查。">
+      <span class="nb-risk-label">判断</span>
+      <strong class="nb-risk-level" data-nb-risk-level>还能继续</strong>
+      <span class="nb-risk-tip" data-nb-risk-tip aria-live="polite">勾选你观察到的现象。一个都没有？那就放心继续聊。</span>
+    </div>
+  </div>
+</div>
+
+## 小结
+
+回到开头那句突然蹦出来的英文。现在你知道发生了什么：
+
+- 它**没有记忆**。所谓连续对话，是每次把全部记录重新给它读一遍；「记得」只是因为记录还在桌上。
+- 桌面（上下文窗口）**大小固定**。满了就从最早的开始挤，挤出去等于彻底消失，而且不会提醒你。
+- 都在桌上也不平等：**开头和结尾记得牢，中间容易被淹没**；桌子快满时的自动压缩会保大意、丢细节。
+- 对策都很朴素：重要的话放开头、适时重复；一事一会话；感觉变笨就人工总结、开新会话。
+
+三篇连起来，新手村的地基就打完了：第一篇讲它为什么会编（没有查证，只有猜词），第二篇讲怎么让它照着念（把资料翻给它看），这一篇讲它为什么会忘（桌面有限，没有记忆）。这三件事凑在一起，几乎能解释你日常遇到的大部分「AI 犯傻」。
+
+> 想再往下走一步？[上下文窗口](/vibe-coding/terms/context-window/)术语页有图解；想看一个真实的编程 Agent 怎么写代码做压缩，[Pi 教程第三章](/pi-agent-tutorials/pi-agent-compaction/)拆了它的源码——那是本站深水区的入口。

--- a/static/media/newbie-tutorials/ctx-compaction.svg
+++ b/static/media/newbie-tutorials/ctx-compaction.svg
@@ -1,0 +1,83 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1092 640" role="img" aria-labelledby="title desc">
+  <title id="title">桌子快满时，它会偷偷做总结</title>
+  <desc id="desc">三步。第一步：原对话八条，包含具体细节——全程用中文、预算 3 万 5、主色深蓝色号 1B3A6B、周四下午 3 点评审、对接人林工。第二步：桌子快满时，这八条被压缩成一段摘要：「用户在推进官网改版，已确定预算、主色与评审安排，后续用中文沟通」，原文被替换掉。第三步清点细节存活情况：全程用中文保住了；预算数字、色号、评审时间都只剩模糊说法；对接人林工完全消失。结论：压缩保大意、丢细节，之后再问细节，它要么答不上，要么现编一个。</desc>
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0 0l10 5-10 5z" fill="#b9b9b5"/>
+    </marker>
+  </defs>
+  <style>
+    .sans{font-family:-apple-system,'PingFang SC','Noto Sans SC',system-ui,sans-serif}
+    .mono{font-family:ui-monospace,SFMono-Regular,Menlo,monospace}
+    .eyebrow{font-size:14px;letter-spacing:4px;font-weight:700;fill:#d9341c}
+    .headline{font-size:36px;font-weight:720;letter-spacing:-1px;fill:#111}
+    .num{font-size:14px;letter-spacing:2px;font-weight:650;fill:#d9341c}
+    .coltitle{font-size:21px;font-weight:700;letter-spacing:-0.3px;fill:#111}
+    .sub{font-size:13.5px;fill:#6c6c6c}
+    .msg{font-size:13.5px;fill:#333}
+    .hl{font-size:13.5px;font-weight:700;fill:#d9341c}
+    .sum{font-size:15px;font-weight:600;fill:#111}
+    .keep{font-size:14px;font-weight:650;fill:#2c8a44}
+    .lost{font-size:14px;font-weight:650;fill:#d9341c}
+    .lost-s{font-size:12.5px;fill:#6c6c6c}
+    .doc{fill:#fff;stroke:#b9b9b5;stroke-width:1.5}
+    .strip{fill:#f5f5f2;stroke:#dedede;stroke-width:1}
+    .sumcard{fill:#fff;stroke:#111;stroke-width:1.5}
+    .row{fill:#fff;stroke:#dedede;stroke-width:1}
+    .row-lost{fill:#fff0ec;stroke:#ff4d2e;stroke-width:1.2}
+    .wire{fill:none;stroke:#c6c6c2;stroke-width:2;stroke-dasharray:0.1 9;stroke-linecap:round;marker-end:url(#arrow)}
+    .note{font-size:15px;fill:#6c6c6c}
+  </style>
+  <g class="sans">
+    <text x="40" y="46" class="mono eyebrow">COMPACTION</text>
+    <text x="40" y="92" class="headline">桌子快满时，它会偷偷做总结</text>
+
+    <text x="40" y="140" class="mono num">01</text>
+    <text x="76" y="141" class="coltitle">原对话 · 细节都在</text>
+    <rect class="doc" x="40" y="160" width="310" height="392"/>
+    <rect class="strip" x="56" y="176" width="278" height="40"/><text x="66" y="201" class="msg">你：官网改版，<tspan class="hl">全程用中文</tspan></text>
+    <rect class="strip" x="56" y="222" width="278" height="40"/><text x="66" y="247" class="msg">你：预算 <tspan class="hl">3 万 5</tspan>，不能超</text>
+    <rect class="strip" x="56" y="268" width="278" height="40"/><text x="66" y="293" class="msg">它：两种方案对比是……</text>
+    <rect class="strip" x="56" y="314" width="278" height="40"/><text x="66" y="339" class="msg">你：主色深蓝，<tspan class="hl">#1B3A6B</tspan></text>
+    <rect class="strip" x="56" y="360" width="278" height="40"/><text x="66" y="385" class="msg">它：按深蓝出了三版配色……</text>
+    <rect class="strip" x="56" y="406" width="278" height="40"/><text x="66" y="431" class="msg">你：<tspan class="hl">周四下午 3 点</tspan>评审</text>
+    <rect class="strip" x="56" y="452" width="278" height="40"/><text x="66" y="477" class="msg">你：对接人是<tspan class="hl">林工</tspan></text>
+    <rect class="strip" x="56" y="498" width="278" height="40"/><text x="66" y="523" class="msg">它：都记下了……</text>
+
+    <path class="wire" d="M356 356H400"/>
+
+    <text x="406" y="140" class="mono num">02</text>
+    <text x="442" y="141" class="coltitle">压缩：一段摘要换掉原文</text>
+    <rect class="sumcard" x="406" y="200" width="300" height="200"/>
+    <text x="424" y="232" class="mono sub">SUMMARY · 约 60 token</text>
+    <text x="424" y="266" class="sum">用户在推进官网改版，</text>
+    <text x="424" y="292" class="sum">已确定预算、主色与</text>
+    <text x="424" y="318" class="sum">评审安排，后续用中文</text>
+    <text x="424" y="344" class="sum">沟通。</text>
+    <text x="424" y="380" class="sub">原来的 8 条被这段替换，桌面腾出来了</text>
+    <text x="406" y="440" class="sub">好处：不至于把最早的内容整条挤掉；</text>
+    <text x="406" y="462" class="sub">代价：总结的时候，细节没跟过来。</text>
+
+    <path class="wire" d="M712 356H756"/>
+
+    <text x="762" y="140" class="mono num">03</text>
+    <text x="798" y="141" class="coltitle">清点：细节还剩多少</text>
+    <rect class="row" x="762" y="160" width="290" height="56"/>
+    <text x="778" y="184" class="keep">✓ 全程用中文</text>
+    <text x="778" y="204" class="lost-s">摘要里保住了</text>
+    <rect class="row-lost" x="762" y="224" width="290" height="56"/>
+    <text x="778" y="248" class="lost">✗ 预算 3 万 5</text>
+    <text x="778" y="268" class="lost-s">只剩「已确定预算」，数字丢了</text>
+    <rect class="row-lost" x="762" y="288" width="290" height="56"/>
+    <text x="778" y="312" class="lost">✗ 色号 #1B3A6B</text>
+    <text x="778" y="332" class="lost-s">只剩「主色」</text>
+    <rect class="row-lost" x="762" y="352" width="290" height="56"/>
+    <text x="778" y="376" class="lost">✗ 周四下午 3 点</text>
+    <text x="778" y="396" class="lost-s">只剩「评审安排」</text>
+    <rect class="row-lost" x="762" y="416" width="290" height="56"/>
+    <text x="778" y="440" class="lost">✗ 对接人林工</text>
+    <text x="778" y="460" class="lost-s">摘要里完全没提</text>
+
+    <text x="40" y="600" class="note">压缩保大意、丢细节。之后你再问「预算多少」，它手里只有摘要——要么答不上，要么现编一个数（第一篇的老毛病）。</text>
+  </g>
+</svg>

--- a/static/media/newbie-tutorials/ctx-desk.svg
+++ b/static/media/newbie-tutorials/ctx-desk.svg
@@ -1,0 +1,104 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1092 600" role="img" aria-labelledby="title desc">
+  <title id="title">桌面只有这么大：上下文窗口</title>
+  <desc id="desc">动画分五幕：桌面代表大小固定的上下文窗口。第一幕，你的要求「全程中文、预算 3 万 5」放上桌面，占用 18%。第二幕，几轮问答加进来，34%。第三幕，你贴的十几页长合同占掉一大块，72%。第四幕，它的长回答也占地方，90%。第五幕，新消息进来，桌子满了，最早的那条要求被挤出桌面，彻底消失，而且它不会提醒你。</desc>
+  <style>
+    .sans{font-family:-apple-system,'PingFang SC','Noto Sans SC',system-ui,sans-serif}
+    .mono{font-family:ui-monospace,SFMono-Regular,Menlo,monospace}
+    .eyebrow{font-size:14px;letter-spacing:4px;font-weight:700;fill:#d9341c}
+    .headline{font-size:36px;font-weight:720;letter-spacing:-1px;fill:#111}
+    .ptitle{font-size:13.5px;letter-spacing:3px;font-weight:700;fill:#6c6c6c}
+    .blabel{font-size:17px;font-weight:650;fill:#111}
+    .bsub{font-size:12.5px;fill:#6c6c6c}
+    .cap{font-size:14px;letter-spacing:1px;font-weight:700;fill:#6c6c6c}
+    .cap-warn{font-size:14px;letter-spacing:1px;font-weight:700;fill:#d9341c}
+    .caption{font-size:16px;font-weight:600;fill:#333}
+    .caption-warn{font-size:16px;font-weight:700;fill:#d9341c}
+    .note{font-size:15px;fill:#6c6c6c}
+    .desk{fill:#f5f5f2;stroke:#b9b9b5;stroke-width:2}
+    .block{fill:#fff;stroke:#dedede;stroke-width:1.5}
+    .block-req{fill:#fff0ec;stroke:#ff4d2e;stroke-width:1.8}
+    .ghost{fill:none;stroke:#b9b9b5;stroke-width:1.5;stroke-dasharray:5 5}
+    .ghost-t{font-size:15px;font-weight:650;fill:#9c9c98}
+    .a1{animation:s1 15s linear infinite}.a2{animation:s2 15s linear infinite}
+    .a3{animation:s3 15s linear infinite}.a4{animation:s4 15s linear infinite}
+    .a5{animation:s5 15s linear infinite}
+    .b1{animation:k1 15s linear infinite}.b2{animation:k2 15s linear infinite}
+    .b3{animation:k3 15s linear infinite}.b4{animation:k4 15s linear infinite}
+    .b1,.b2,.b3,.b4,.a1,.a2,.a3,.a4{opacity:0}
+    @keyframes k1{0%,1%{opacity:0}3%,77%{opacity:1}80%,100%{opacity:0}}
+    @keyframes k2{0%,21%{opacity:0}23%,77%{opacity:1}80%,100%{opacity:0}}
+    @keyframes k3{0%,41%{opacity:0}43%,77%{opacity:1}80%,100%{opacity:0}}
+    @keyframes k4{0%,61%{opacity:0}63%,77%{opacity:1}80%,100%{opacity:0}}
+    @keyframes s1{0%,1%{opacity:0}3%,18%{opacity:1}21%,100%{opacity:0}}
+    @keyframes s2{0%,21%{opacity:0}23%,38%{opacity:1}41%,100%{opacity:0}}
+    @keyframes s3{0%,41%{opacity:0}43%,58%{opacity:1}61%,100%{opacity:0}}
+    @keyframes s4{0%,61%{opacity:0}63%,78%{opacity:1}81%,100%{opacity:0}}
+    @keyframes s5{0%,81%{opacity:0}83%,98%{opacity:1}100%{opacity:0}}
+    @media(prefers-reduced-motion:reduce){
+      .a1,.a2,.a3,.a4,.a5,.b1,.b2,.b3,.b4{animation:none}
+      .a1,.a2,.a3,.a4,.b1,.b2,.b3,.b4{opacity:0}
+      .a5{opacity:1}
+    }
+  </style>
+
+  <g class="sans">
+    <text x="40" y="46" class="mono eyebrow">CONTEXT WINDOW</text>
+    <text x="40" y="92" class="headline">每次作答，都要把一切重新摊上这张桌</text>
+
+    <rect class="desk" x="40" y="140" width="1012" height="156"/>
+    <text x="64" y="168" class="mono ptitle">桌面 = 上下文窗口 · 大小固定</text>
+    <text x="1028" y="168" text-anchor="end" class="mono cap a1">已用 18%</text>
+    <text x="1028" y="168" text-anchor="end" class="mono cap a2">已用 34%</text>
+    <text x="1028" y="168" text-anchor="end" class="mono cap a3">已用 72%</text>
+    <text x="1028" y="168" text-anchor="end" class="mono cap a4">已用 90%</text>
+    <text x="1028" y="168" text-anchor="end" class="mono cap-warn a5">满了 · 有东西掉下去了</text>
+
+    <!-- phases 1-4 layout -->
+    <g class="b1">
+      <rect class="block-req" x="60" y="182" width="170" height="94"/>
+      <text x="76" y="216" class="blabel">你的要求</text>
+      <text x="76" y="240" class="bsub">全程中文</text>
+      <text x="76" y="258" class="bsub">预算 3 万 5</text>
+    </g>
+    <g class="b2">
+      <rect class="block" x="238" y="182" width="180" height="94"/>
+      <text x="254" y="216" class="blabel">几轮问答</text>
+      <text x="254" y="240" class="bsub">方案讨论……</text>
+    </g>
+    <g class="b3">
+      <rect class="block" x="426" y="182" width="330" height="94"/>
+      <text x="442" y="216" class="blabel">你贴的长合同</text>
+      <text x="442" y="240" class="bsub">十几页，一口气占掉三分之一</text>
+    </g>
+    <g class="b4">
+      <rect class="block" x="764" y="182" width="220" height="94"/>
+      <text x="780" y="216" class="blabel">它的长回答</text>
+      <text x="780" y="240" class="bsub">它说的话也占桌面</text>
+    </g>
+
+    <!-- phase 5 layout: requirement evicted -->
+    <g class="a5">
+      <rect class="block" x="60" y="182" width="180" height="94"/>
+      <text x="76" y="216" class="blabel">几轮问答</text>
+      <rect class="block" x="248" y="182" width="330" height="94"/>
+      <text x="264" y="216" class="blabel">你贴的长合同</text>
+      <rect class="block" x="586" y="182" width="220" height="94"/>
+      <text x="602" y="216" class="blabel">它的长回答</text>
+      <rect class="block-req" x="814" y="182" width="170" height="94" style="fill:#fff;stroke:#dedede"/>
+      <text x="830" y="216" class="blabel">你的新消息</text>
+      <rect class="ghost" x="60" y="330" width="200" height="76"/>
+      <text x="78" y="362" class="ghost-t">你的要求</text>
+      <text x="78" y="386" class="bsub">全程中文 · 预算 3 万 5</text>
+      <text x="280" y="372" class="caption-warn">⚠ 被挤出桌面 = 彻底消失，它再也看不见这条</text>
+    </g>
+
+    <text x="40" y="470" class="caption a1">对话开始：你的要求最先放上桌面</text>
+    <text x="40" y="470" class="caption a2">几轮问答加进来，还很宽裕</text>
+    <text x="40" y="470" class="caption a3">你贴了一份长合同——大文件是吃桌面的大户</text>
+    <text x="40" y="470" class="caption a4">它写的长回答同样占地方，桌子快满了</text>
+    <text x="40" y="470" class="caption-warn a5">新消息进来，放不下了：最早的内容被挤出去，腾出位置</text>
+
+    <text x="40" y="530" class="note">被挤出去的内容不是「存档」了，而是对它彻底不存在——并且它不会提醒你。</text>
+    <text x="40" y="558" class="note">于是聊到后面，它开始违反你最早提的要求。它不是变笨了，是那条要求已经不在桌上。</text>
+  </g>
+</svg>

--- a/static/media/newbie-tutorials/ctx-lost-middle.svg
+++ b/static/media/newbie-tutorials/ctx-lost-middle.svg
@@ -1,0 +1,53 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1092 500" role="img" aria-labelledby="title desc">
+  <title id="title">迷失在中间：同在桌上，待遇不同</title>
+  <desc id="desc">一排十三张消息卡代表一段长对话。两端的卡片颜色深，表示开头和最近的内容模型用得最牢；中间的卡片逐渐变浅，表示埋在中间的内容容易被漏掉。你的第 3 条要求恰好在正中间，被标了警告。下方结论：重要要求放开头，聊久了再重复一遍，让它同时占住两个好位置。</desc>
+  <style>
+    .sans{font-family:-apple-system,'PingFang SC','Noto Sans SC',system-ui,sans-serif}
+    .mono{font-family:ui-monospace,SFMono-Regular,Menlo,monospace}
+    .eyebrow{font-size:14px;letter-spacing:4px;font-weight:700;fill:#d9341c}
+    .headline{font-size:36px;font-weight:720;letter-spacing:-1px;fill:#111}
+    .card{fill:#fff;stroke:#b9b9b5;stroke-width:1.5}
+    .t{font-size:13px;font-weight:650;fill:#333}
+    .needle{fill:#fff0ec;stroke:#ff4d2e;stroke-width:1.8;stroke-dasharray:5 4}
+    .needle-t{font-size:15px;font-weight:700;fill:#d9341c}
+    .zone{font-size:14px;font-weight:700;fill:#2c8a44}
+    .zone-warn{font-size:14px;font-weight:700;fill:#d9341c}
+    .brk{fill:none;stroke:#dedede;stroke-width:1.5}
+    .note{font-size:15px;fill:#6c6c6c}
+    .fix{font-size:16px;font-weight:650;fill:#111}
+    .f30{opacity:0.55}.f60{opacity:0.3}
+  </style>
+  <g class="sans">
+    <text x="40" y="46" class="mono eyebrow">LOST IN THE MIDDLE</text>
+    <text x="40" y="92" class="headline">同在桌上，待遇也不一样</text>
+
+    <text x="40" y="134" class="note">一段长对话，从最早（左）到最近（右）——颜色越深，越容易被它用上：</text>
+
+    <rect class="card" x="40" y="186" width="72" height="100"/><text x="52" y="218" class="t">最早</text>
+    <rect class="card" x="118" y="186" width="72" height="100"/>
+    <rect class="card f30" x="196" y="186" width="72" height="100"/>
+    <rect class="card f30" x="274" y="186" width="72" height="100"/>
+    <rect class="card f60" x="352" y="186" width="72" height="100"/>
+    <rect class="card f60" x="430" y="186" width="72" height="100"/>
+    <rect class="needle" x="508" y="186" width="72" height="100"/><text x="518" y="218" class="t">要求 3</text>
+    <rect class="card f60" x="586" y="186" width="72" height="100"/>
+    <rect class="card f60" x="664" y="186" width="72" height="100"/>
+    <rect class="card f30" x="742" y="186" width="72" height="100"/>
+    <rect class="card f30" x="820" y="186" width="72" height="100"/>
+    <rect class="card" x="898" y="186" width="72" height="100"/>
+    <rect class="card" x="976" y="186" width="72" height="100"/><text x="988" y="218" class="t">最近</text>
+
+    <text x="544" y="172" text-anchor="middle" class="needle-t">你的第 3 条要求埋在这里 ↓</text>
+
+    <path class="brk" d="M40 306v10h150v-10"/>
+    <text x="115" y="342" text-anchor="middle" class="zone">开头 · 记得牢</text>
+    <path class="brk" d="M352 306v10h306v-10"/>
+    <text x="505" y="342" text-anchor="middle" class="zone-warn">中间 · 容易被淹没</text>
+    <path class="brk" d="M898 306v10h150v-10"/>
+    <text x="973" y="342" text-anchor="middle" class="zone">最近 · 记得牢</text>
+
+    <text x="40" y="400" class="note">研究者把这叫「迷失在中间」：内容明明都在窗口里，开头和结尾的更容易被用上，</text>
+    <text x="40" y="426" class="note">埋在中间的细节常常被漏掉。塞得越满，中间那片沼泽就越大。</text>
+    <text x="40" y="470" class="fix">所以：重要要求放开头；聊久了，把它再说一遍——让它同时占住两个好位置。</text>
+  </g>
+</svg>


### PR DESCRIPTION
## Summary

- add the third Newbie Village tutorial explaining context limits and compaction
- add three explanatory SVG illustrations
- add interactive desk-eviction and compaction labs with route coverage

## Validation

- `PATH="$HOME/.nvm/versions/node/v22.17.0/bin:$PATH" npm run verify` in `astro/`
- `xmllint --noout` for all three SVG assets
- Playwright desktop interaction and 390px mobile checks
- browser console: 0 warnings, 0 errors