### PR TITLE
fix: wrap long lines in article code blocks

### DIFF
--- a/astro/src/styles/legacy-pages.css
+++ b/astro/src/styles/legacy-pages.css
@@ -673,12 +673,14 @@
 .article-content pre {
 	position: relative;
 	overflow: auto;
+	overflow-wrap: anywhere;
 	padding: 28px 22px 22px;
 	border: 1px solid var(--rule);
 	border-radius: 2px;
 	background: var(--paper-muted) !important;
 	font-size: 0.82rem;
 	line-height: 1.75;
+	white-space: pre-wrap;
 }
 
 /* Shiki stamps the language on the block — surface it as a quiet mono tag. */

--- a/astro/src/styles/migration.css
+++ b/astro/src/styles/migration.css
@@ -1073,12 +1073,14 @@ h1 {
 .legacy-content pre,
 .article-content pre {
 	overflow: auto;
+	overflow-wrap: anywhere;
 	padding: 20px;
 	border: 1px solid var(--rule);
 	background: var(--paper-muted);
 	font-family: var(--mono);
 	font-size: 0.82rem;
 	line-height: 1.7;
+	white-space: pre-wrap;
 }
 
 .legacy-content :not(pre) > code,


### PR DESCRIPTION
## Summary

- wrap long code lines within article code blocks
- preserve whitespace while allowing uninterrupted tokens to break safely

## Validation

- `npm run verify`