### PR TITLE
ci: allow time for release artifact build

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -14,7 +14,7 @@ jobs:
   build-and-deploy:
     name: build-and-deploy
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 30
     env:
       PUBLIC_COMMENTS_WRITE_UI_ENABLED: ${{ vars.PUBLIC_COMMENTS_WRITE_UI_ENABLED || 'false' }}
 


### PR DESCRIPTION
## Summary
- increase the main site build timeout from 20 to 30 minutes
- accommodate the longer cold-install and responsive-image generation path

## Evidence
- main Build and Verify Site run 33853087511 passed dependency installation and Worker/data contract checks
- the job was canceled only because it exceeded the existing 20-minute limit while generating the final Astro artifact