### PR TITLE
ci: accelerate resumed content releases

### DIFF
--- a/.github/workflows/content-release.yml
+++ b/.github/workflows/content-release.yml
@@ -286,6 +286,7 @@ jobs:
         run: node scripts/validate-content-production-config.mjs workflow-release
 
       - name: Install root locked dependencies
+        if: ${{ steps.resume.outputs.stage == 'build' }}
         run: npm ci
 
       - name: Install Astro locked dependencies
@@ -406,20 +407,63 @@ jobs:
           evidence="$(jq -nc --arg object_key "$ARTIFACT_OBJECT_KEY" --arg hash "$ARTIFACT_SHA256" --arg fingerprint "$artifact_fingerprint" --arg algorithm "$ARTIFACT_HASH_ALGORITHM" --arg code "$EXACT_CODE_SHA" --arg source_code "$SOURCE_CODE_SHA" --arg content "$CONTENT_ROOT_SHA256" --arg env "$BUILD_ENVIRONMENT_VERSION" --arg profile "r2-full-get-sha256-indefinite-lock-v1" --arg verified_at "$r2_verified_at" --arg lock "$lock_evidence_sha256" --arg contract "$RESUME_CONTRACT_VERSION" --argjson bytes "$ARTIFACT_BYTES" '{object_key:$object_key,byte_length:$bytes,artifact_sha256:$hash,artifact_fingerprint_sha256:$fingerprint,hash_algorithm:$algorithm,code_sha:$code,source_code_sha:($source_code | if length > 0 then . else null end),content_sha256:$content,build_environment_version:$env,verification_profile:$profile,r2_verified_at:$verified_at,lock_evidence_sha256:$lock,resume_contract_version:($contract | if length > 0 then . else null end)}')"
           node "$RUNNER_TEMP/content-release-helper.mjs" callback artifact_registered "$evidence"
 
-      - name: Materialize exact registered R2 artifact
+      - name: Materialize trusted Preview verification baseline
         if: ${{ steps.resume.outputs.stage == 'preview' }}
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.R2_ARTIFACT_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_ARTIFACT_SECRET_ACCESS_KEY }}
           AWS_DEFAULT_REGION: auto
           R2_ENDPOINT: https://${{ secrets.CLOUDFLARE_ACCOUNT_ID }}.r2.cloudflarestorage.com
-          R2_MATERIALIZE_CONCURRENCY: "16"
+          R2_MATERIALIZE_CONCURRENCY: "32"
         run: |
-          node scripts/materialize-content-addressed-artifact.mjs server-resume-plan.json astro/dist/client > materialize-summary.json
+          node release-control/scripts/materialize-content-addressed-artifact.mjs \
+            server-resume-plan.json astro/dist/client \
+            --preview-verification-baseline > materialize-baseline-summary.json
+          jq -e \
+            '.site_release_id == env.SITE_RELEASE_ID
+              and .artifact_sha256 == env.ARTIFACT_SHA256
+              and .materialized_file_count < .file_count' \
+            materialize-baseline-summary.json >/dev/null
+
+      - name: Reuse exact existing Pages Preview
+        id: preview-reuse
+        if: ${{ steps.resume.outputs.stage == 'preview' }}
+        shell: bash
+        run: |
+          candidate_url="https://release-$CONTENT_RELEASE_SEQUENCE.bubble-content-preview.pages.dev"
+          set +e
+          node release-control/scripts/verify-preview.mjs \
+            "$candidate_url" "$EXACT_CODE_SHA" \
+            astro/dist/client/release-manifests/site-route-manifest.json \
+            | tee preview-reuse-verification.log
+          verify_status="${PIPESTATUS[0]}"
+          set -e
+          if [[ "$verify_status" == "0" ]]; then
+            echo "reused=true" >> "$GITHUB_OUTPUT"
+            echo "PREVIEW_URL=$candidate_url" >> "$GITHUB_ENV"
+          else
+            echo "reused=false" >> "$GITHUB_OUTPUT"
+            echo "Existing exact Preview is not reusable; redeploying the registered artifact." >&2
+          fi
+
+      - name: Install Preview deployment dependencies
+        if: ${{ steps.resume.outputs.stage == 'preview' && steps.preview-reuse.outputs.reused != 'true' }}
+        run: npm ci
+
+      - name: Materialize exact registered R2 artifact
+        if: ${{ steps.resume.outputs.stage == 'preview' && steps.preview-reuse.outputs.reused != 'true' }}
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.R2_ARTIFACT_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_ARTIFACT_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: auto
+          R2_ENDPOINT: https://${{ secrets.CLOUDFLARE_ACCOUNT_ID }}.r2.cloudflarestorage.com
+          R2_MATERIALIZE_CONCURRENCY: "32"
+        run: |
+          node release-control/scripts/materialize-content-addressed-artifact.mjs server-resume-plan.json astro/dist/client > materialize-summary.json
           jq -e '.site_release_id == env.SITE_RELEASE_ID and .artifact_sha256 == env.ARTIFACT_SHA256' materialize-summary.json >/dev/null
 
       - name: Deploy exact files to Pages Preview
-        if: ${{ steps.resume.outputs.stage != 'promote' }}
+        if: ${{ steps.resume.outputs.stage == 'build' || (steps.resume.outputs.stage == 'preview' && steps.preview-reuse.outputs.reused != 'true') }}
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_PREVIEW_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
@@ -430,7 +474,7 @@ jobs:
           echo "PREVIEW_URL=$preview_url" >> "$GITHUB_ENV"
 
       - name: Verify Preview route parity and exact bytes
-        if: ${{ steps.resume.outputs.stage != 'promote' }}
+        if: ${{ steps.resume.outputs.stage == 'build' || (steps.resume.outputs.stage == 'preview' && steps.preview-reuse.outputs.reused != 'true') }}
         shell: bash
         run: |
           verifier="scripts/verify-preview.mjs"

--- a/scripts/materialize-content-addressed-artifact.mjs
+++ b/scripts/materialize-content-addressed-artifact.mjs
@@ -42,6 +42,13 @@ function positiveInteger(value) {
   return parsed;
 }
 
+export function isPreviewVerificationBaselinePath(path) {
+  return (
+    path === ROUTE_MANIFEST ||
+    /^data\/daily\/\d{4}-\d{2}-\d{2}\.json$/.test(path)
+  );
+}
+
 async function runPool(entries, concurrency, worker) {
   let cursor = 0;
   await Promise.all(
@@ -159,6 +166,7 @@ export async function materializeContentAddressedArtifact({
   targetRoot,
   store,
   concurrency = DEFAULT_CONCURRENCY,
+  includeFile,
 }) {
   validateDescriptor(descriptor, {
     siteReleaseId: expectedSiteReleaseId,
@@ -171,32 +179,36 @@ export async function materializeContentAddressedArtifact({
   const temporary = `${target}.materializing-${randomUUID()}`;
   const backup = `${target}.previous-${randomUUID()}`;
   const objectReads = new Map();
+  const selectedFiles = includeFile
+    ? manifest.files.filter((file) => includeFile(file.path))
+    : manifest.files;
+  if (!selectedFiles.some((file) => file.path === ROUTE_MANIFEST)) {
+    throw new Error(
+      "Materialized artifact selection must include the route manifest",
+    );
+  }
   let targetMoved = false;
   try {
     await mkdir(temporary, { recursive: true });
-    await runPool(
-      manifest.files,
-      positiveInteger(concurrency),
-      async (file) => {
-        let pending = objectReads.get(file.object_key);
-        if (!pending) {
-          pending = store.get(file.object_key);
-          objectReads.set(file.object_key, pending);
-        }
-        const bytes = await pending;
-        if (
-          bytes.byteLength !== file.byte_length ||
-          sha256(bytes) !== file.sha256
-        ) {
-          throw new Error(
-            `Resume artifact asset identity mismatch: ${file.path}`,
-          );
-        }
-        const destination = resolve(temporary, file.path);
-        await mkdir(dirname(destination), { recursive: true });
-        await writeFile(destination, bytes, { flag: "wx" });
-      },
-    );
+    await runPool(selectedFiles, positiveInteger(concurrency), async (file) => {
+      let pending = objectReads.get(file.object_key);
+      if (!pending) {
+        pending = store.get(file.object_key);
+        objectReads.set(file.object_key, pending);
+      }
+      const bytes = await pending;
+      if (
+        bytes.byteLength !== file.byte_length ||
+        sha256(bytes) !== file.sha256
+      ) {
+        throw new Error(
+          `Resume artifact asset identity mismatch: ${file.path}`,
+        );
+      }
+      const destination = resolve(temporary, file.path);
+      await mkdir(dirname(destination), { recursive: true });
+      await writeFile(destination, bytes, { flag: "wx" });
+    });
     const existing = await stat(target).catch(() => null);
     if (existing) {
       await rename(target, backup);
@@ -209,6 +221,7 @@ export async function materializeContentAddressedArtifact({
       artifact_sha256: descriptor.artifact_sha256,
       artifact_fingerprint_sha256: descriptor.artifact_fingerprint_sha256,
       file_count: manifest.file_count,
+      materialized_file_count: selectedFiles.length,
       total_asset_bytes: manifest.total_asset_bytes,
       unique_object_reads: objectReads.size,
       target_root: target,
@@ -227,9 +240,16 @@ const isMain =
   process.argv[1] &&
   resolve(process.argv[1]) === fileURLToPath(import.meta.url);
 if (isMain) {
+  const argumentsList = process.argv.slice(2);
+  const verificationBaseline = argumentsList.includes(
+    "--preview-verification-baseline",
+  );
+  const positional = argumentsList.filter(
+    (argument) => argument !== "--preview-verification-baseline",
+  );
   const plan = JSON.parse(
     await readFile(
-      process.argv[2] || resolve(process.cwd(), "server-resume-plan.json"),
+      positional[0] || resolve(process.cwd(), "server-resume-plan.json"),
       "utf8",
     ),
   );
@@ -244,9 +264,12 @@ if (isMain) {
     expectedSiteReleaseId: process.env.SITE_RELEASE_ID,
     expectedCodeSha: process.env.EXACT_CODE_SHA,
     expectedContentSha256: process.env.CONTENT_ROOT_SHA256,
-    targetRoot: process.argv[3] || "astro/dist/client",
+    targetRoot: positional[1] || "astro/dist/client",
     store,
     concurrency: process.env.R2_MATERIALIZE_CONCURRENCY || DEFAULT_CONCURRENCY,
+    includeFile: verificationBaseline
+      ? isPreviewVerificationBaselinePath
+      : undefined,
   });
   process.stdout.write(`${JSON.stringify(result)}\n`);
 }

--- a/scripts/preview-targeted-retry.mjs
+++ b/scripts/preview-targeted-retry.mjs
@@ -1,0 +1,27 @@
+export const DEFAULT_PREVIEW_RETRY_DELAYS_MS = Object.freeze([15_000, 30_000]);
+
+export async function verifyWithTargetedRetries(
+  records,
+  verifyBatch,
+  {
+    delays = DEFAULT_PREVIEW_RETRY_DELAYS_MS,
+    sleep = (milliseconds) =>
+      new Promise((resolve) => setTimeout(resolve, milliseconds)),
+  } = {},
+) {
+  let failures = await verifyBatch(records);
+  for (const delay of delays) {
+    const retryableRecords = records.filter(
+      (record) => failures.get(record.route)?.retryable === true,
+    );
+    if (retryableRecords.length === 0) break;
+    await sleep(delay);
+    const retryFailures = await verifyBatch(retryableRecords);
+    for (const record of retryableRecords) {
+      const failure = retryFailures.get(record.route);
+      if (failure) failures.set(record.route, failure);
+      else failures.delete(record.route);
+    }
+  }
+  return failures;
+}

--- a/scripts/verify-preview.mjs
+++ b/scripts/verify-preview.mjs
@@ -1,15 +1,8 @@
 import { createHash } from "node:crypto";
 import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
 import { dirname, resolve } from "node:path";
-import {
-  applyExternalLinkWaivers,
-  auditExternalLinks,
-  closeExternalLinkDispatchers,
-  DEFAULT_EXTERNAL_LINK_BUDGETS,
-  evaluateExternalLinkAudit,
-  probeExternalUrl,
-} from "./external-link-audit.mjs";
 import { expectedPreviewMediaType } from "./preview-media-types.mjs";
+import { verifyWithTargetedRetries } from "./preview-targeted-retry.mjs";
 import { assertRouteBuildContract } from "./content-route-build-contract.mjs";
 
 const argumentsList = process.argv.slice(2);
@@ -64,6 +57,8 @@ base.hash = "";
 function invariant(condition, message) {
   if (!condition) throw new Error(message);
 }
+
+class TransientPreviewError extends Error {}
 
 function sha256(value) {
   return createHash("sha256").update(value).digest("hex");
@@ -183,14 +178,25 @@ const canonicalOrigins = new Set(
     .filter(Boolean)
     .map((value) => new URL(value).origin),
 );
-const failures = [];
 const externalUrls = new Set();
-let cursor = 0;
 const concurrency = Math.min(12, manifest.records.length);
 
-async function verifyRecord(record) {
+async function verifyRecord(record, failures) {
   try {
-    const response = await fetchManual(record.route);
+    let response;
+    try {
+      response = await fetchManual(record.route);
+    } catch (error) {
+      throw new TransientPreviewError(
+        `${record.route}: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+    if (response.status === 429 || response.status >= 500) {
+      await response.body?.cancel();
+      throw new TransientPreviewError(
+        `expected ${record.status}, received ${response.status}`,
+      );
+    }
     invariant(
       response.status === record.status,
       `${record.route}: expected ${record.status}, received ${response.status}`,
@@ -299,21 +305,36 @@ async function verifyRecord(record) {
       }
     }
   } catch (error) {
-    failures.push(
-      `${record.route}: ${error instanceof Error ? error.message : String(error)}`,
-    );
+    failures.set(record.route, {
+      message: `${record.route}: ${error instanceof Error ? error.message : String(error)}`,
+      retryable: error instanceof TransientPreviewError,
+    });
   }
 }
 
-async function routeWorker() {
-  while (true) {
-    const index = cursor++;
-    if (index >= manifest.records.length) return;
-    await verifyRecord(manifest.records[index]);
+async function verifyRecords(records) {
+  const failures = new Map();
+  let cursor = 0;
+  async function routeWorker() {
+    while (true) {
+      const index = cursor++;
+      if (index >= records.length) return;
+      await verifyRecord(records[index], failures);
+    }
   }
+  await Promise.all(
+    Array.from({ length: Math.min(concurrency, records.length) }, () =>
+      routeWorker(),
+    ),
+  );
+  return failures;
 }
 
-await Promise.all(Array.from({ length: concurrency }, () => routeWorker()));
+const routeFailures = await verifyWithTargetedRetries(
+  manifest.records,
+  verifyRecords,
+);
+const failures = [...routeFailures.values()].map((failure) => failure.message);
 
 const missingRoute = `/.well-known/phase4-missing-${Date.now()}`;
 const missingResponse = await fetchManual(missingRoute);
@@ -351,6 +372,14 @@ invariant(
 
 let externalEvaluation = null;
 if (checkExternal) {
+  const {
+    applyExternalLinkWaivers,
+    auditExternalLinks,
+    closeExternalLinkDispatchers,
+    DEFAULT_EXTERNAL_LINK_BUDGETS,
+    evaluateExternalLinkAudit,
+    probeExternalUrl,
+  } = await import("./external-link-audit.mjs");
   const urls = [...externalUrls].sort();
   const startedAt = new Date().toISOString();
   const waiverPolicyText = await readFile(externalWaiversPath, "utf8");

--- a/tests/worker/contentArtifactMaterialize.test.js
+++ b/tests/worker/contentArtifactMaterialize.test.js
@@ -4,7 +4,10 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { createContentAddressedArtifact } from "../../scripts/create-content-addressed-artifact.mjs";
-import { materializeContentAddressedArtifact } from "../../scripts/materialize-content-addressed-artifact.mjs";
+import {
+  isPreviewVerificationBaselinePath,
+  materializeContentAddressedArtifact,
+} from "../../scripts/materialize-content-addressed-artifact.mjs";
 
 const RELEASE_ID = "22222222-2222-4222-8222-222222222222";
 const CODE_SHA = "b".repeat(40);
@@ -32,11 +35,18 @@ async function fixture() {
   temporaryDirectories.push(root);
   const source = join(root, "source");
   await mkdir(join(source, "release-manifests"), { recursive: true });
+  await mkdir(join(source, "data/daily"), { recursive: true });
   const page = Buffer.from("<h1>release</h1>\n");
+  const daily = Buffer.from('{"date":"2026-09-04"}\n');
   await writeFile(join(source, "index.html"), page);
-  const fingerprint = sha256(
-    Buffer.from(`index.html\0${sha256(page)}\n`, "utf8"),
-  );
+  await writeFile(join(source, "data/daily/2026-09-04.json"), daily);
+  const fingerprintSource = [
+    ["data/daily/2026-09-04.json", daily],
+    ["index.html", page],
+  ]
+    .map(([path, bytes]) => `${path}\0${sha256(bytes)}\n`)
+    .join("");
+  const fingerprint = sha256(Buffer.from(fingerprintSource, "utf8"));
   await writeFile(
     join(source, "release-manifests/site-route-manifest.json"),
     `${JSON.stringify({
@@ -99,12 +109,42 @@ describe("content-addressed artifact materialization", () => {
     expect(result).toMatchObject({
       site_release_id: RELEASE_ID,
       artifact_sha256: value.artifact.artifact_sha256,
-      file_count: 2,
-      unique_object_reads: 2,
+      file_count: 3,
+      unique_object_reads: 3,
     });
     expect(await readFile(join(value.target, "index.html"), "utf8")).toBe(
       "<h1>release</h1>\n",
     );
+    expect(value.store.reads).toHaveLength(4);
+  });
+
+  it("can materialize only the trusted Preview verification baseline", async () => {
+    const value = await fixture();
+    const result = await materializeContentAddressedArtifact({
+      descriptor: value.descriptor,
+      expectedSiteReleaseId: RELEASE_ID,
+      expectedCodeSha: CODE_SHA,
+      expectedContentSha256: CONTENT_SHA,
+      targetRoot: value.target,
+      store: value.store,
+      includeFile: isPreviewVerificationBaselinePath,
+    });
+
+    expect(result).toMatchObject({
+      file_count: 3,
+      materialized_file_count: 2,
+      unique_object_reads: 2,
+    });
+    await expect(readFile(join(value.target, "index.html"))).rejects.toThrow();
+    expect(
+      await readFile(
+        join(value.target, "release-manifests/site-route-manifest.json"),
+        "utf8",
+      ),
+    ).toContain(RELEASE_ID);
+    expect(
+      await readFile(join(value.target, "data/daily/2026-09-04.json"), "utf8"),
+    ).toBe('{"date":"2026-09-04"}\n');
     expect(value.store.reads).toHaveLength(3);
   });
 

--- a/tests/worker/contentReleaseWorkflow.test.js
+++ b/tests/worker/contentReleaseWorkflow.test.js
@@ -42,7 +42,7 @@ describe("fenced content release workflow", () => {
       workflow.indexOf("Create immutable fenced release helper"),
     ).toBeLessThan(workflow.indexOf("Checkout exact code SHA"));
     expect(workflow).toContain(
-      "node scripts/materialize-content-addressed-artifact.mjs server-resume-plan.json astro/dist/client",
+      "node release-control/scripts/materialize-content-addressed-artifact.mjs server-resume-plan.json astro/dist/client",
     );
     expect(workflow).toMatch(
       /- name: Checkout protected release controls for resumed artifacts\n\s+if: \$\{\{ steps\.resume\.outputs\.stage == 'preview' \}\}/,
@@ -56,18 +56,27 @@ describe("fenced content release workflow", () => {
       'git -C release-control merge-base --is-ancestor "$EXACT_CODE_SHA" "$TRUSTED_RELEASE_CONTROL_SHA"',
     );
     expect(workflow).toMatch(
-      /- name: Materialize exact registered R2 artifact\n\s+if: \$\{\{ steps\.resume\.outputs\.stage == 'preview' \}\}/,
+      /- name: Materialize exact registered R2 artifact\n\s+if: \$\{\{ steps\.resume\.outputs\.stage == 'preview' && steps\.preview-reuse\.outputs\.reused != 'true' \}\}/,
     );
     expect(workflow).toContain(
       "if: ${{ steps.resume.outputs.stage == 'build' }}",
     );
     expect(workflow).toMatch(
-      /- name: Verify Preview route parity and exact bytes\n\s+if: \$\{\{ steps\.resume\.outputs\.stage != 'promote' \}\}/,
+      /- name: Verify Preview route parity and exact bytes\n\s+if: \$\{\{ steps\.resume\.outputs\.stage == 'build' \|\| \(steps\.resume\.outputs\.stage == 'preview' && steps\.preview-reuse\.outputs\.reused != 'true'\) \}\}/,
     );
     expect(workflow).toMatch(
       /- name: Record Preview evidence\n\s+if: \$\{\{ steps\.resume\.outputs\.stage != 'promote' \}\}/,
     );
-    expect(workflow).toContain('R2_MATERIALIZE_CONCURRENCY: "16"');
+    expect(workflow).toContain(
+      "Materialize trusted Preview verification baseline",
+    );
+    expect(workflow).toContain("--preview-verification-baseline");
+    expect(workflow).toContain("Reuse exact existing Pages Preview");
+    expect(workflow).toContain(
+      "https://release-$CONTENT_RELEASE_SEQUENCE.bubble-content-preview.pages.dev",
+    );
+    expect(workflow).toContain("steps.preview-reuse.outputs.reused != 'true'");
+    expect(workflow).toContain('R2_MATERIALIZE_CONCURRENCY: "32"');
     expect(workflow).toContain(
       'verifier="release-control/scripts/verify-preview.mjs"',
     );

--- a/tests/worker/previewTargetedRetry.test.js
+++ b/tests/worker/previewTargetedRetry.test.js
@@ -1,0 +1,68 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { verifyWithTargetedRetries } from "../../scripts/preview-targeted-retry.mjs";
+
+describe("targeted Preview retries", () => {
+  it("rechecks only transiently failing routes", async () => {
+    const records = [{ route: "/ok" }, { route: "/temporary.avif" }];
+    const verifyBatch = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Map([
+          ["/temporary.avif", { message: "received 500", retryable: true }],
+        ]),
+      )
+      .mockResolvedValueOnce(new Map());
+    const sleep = vi.fn().mockResolvedValue(undefined);
+
+    const failures = await verifyWithTargetedRetries(records, verifyBatch, {
+      delays: [15],
+      sleep,
+    });
+
+    expect(failures.size).toBe(0);
+    expect(verifyBatch).toHaveBeenNthCalledWith(2, [
+      { route: "/temporary.avif" },
+    ]);
+    expect(sleep).toHaveBeenCalledWith(15);
+  });
+
+  it("does not retry deterministic contract failures", async () => {
+    const records = [{ route: "/wrong-type" }];
+    const verifyBatch = vi
+      .fn()
+      .mockResolvedValue(
+        new Map([
+          ["/wrong-type", { message: "wrong content type", retryable: false }],
+        ]),
+      );
+    const sleep = vi.fn();
+
+    const failures = await verifyWithTargetedRetries(records, verifyBatch, {
+      delays: [15, 30],
+      sleep,
+    });
+
+    expect(failures.size).toBe(1);
+    expect(verifyBatch).toHaveBeenCalledTimes(1);
+    expect(sleep).not.toHaveBeenCalled();
+  });
+
+  it("keeps a transient failure after exhausting targeted retries", async () => {
+    const records = [{ route: "/temporary.avif" }];
+    const transientFailure = new Map([
+      ["/temporary.avif", { message: "received 500", retryable: true }],
+    ]);
+    const verifyBatch = vi.fn().mockResolvedValue(transientFailure);
+    const sleep = vi.fn().mockResolvedValue(undefined);
+
+    const failures = await verifyWithTargetedRetries(records, verifyBatch, {
+      delays: [15, 30],
+      sleep,
+    });
+
+    expect(failures).toEqual(transientFailure);
+    expect(verifyBatch).toHaveBeenCalledTimes(3);
+    expect(sleep.mock.calls).toEqual([[15], [30]]);
+  });
+});


### PR DESCRIPTION
## Summary
- verify and reuse an existing deterministic Pages Preview before reinstalling or redeploying
- materialize only the trusted route/JSON verification baseline for resumed releases, with 32-way R2 concurrency on fallback
- retry only transiently failing Preview routes and defer external-audit dependencies until requested

## Verification
- `npm test` (53 files, 799 tests)
- targeted release tests (9 tests)
- Prettier and `git diff --check`
- live full-route verification of sequence 648 Preview (2279 routes, 720 AVIF assets)