### PR TITLE
fix: restore preview state when resuming production releases

### DIFF
--- a/.github/workflows/content-release.yml
+++ b/.github/workflows/content-release.yml
@@ -484,9 +484,14 @@ jobs:
           node "$verifier" "$PREVIEW_URL" "$EXACT_CODE_SHA" astro/dist/client/release-manifests/site-route-manifest.json
 
       - name: Record Preview evidence
-        if: ${{ steps.resume.outputs.stage != 'promote' }}
         run: |
-          evidence="$(jq -nc --arg url "$PREVIEW_URL" --arg artifact "$ARTIFACT_SHA256" --arg content "$CONTENT_ROOT_SHA256" --arg code "$EXACT_CODE_SHA" --arg contract "$RESUME_CONTRACT_VERSION" '{preview_url:$url,artifact_sha256:$artifact,content_sha256:$content,code_sha:$code,route_parity:true,resume_contract_version:($contract | if length > 0 then . else null end)}')"
+          if [[ "$SERVER_RESUME_STAGE" == "promote" ]]; then
+            # The new attempt starts in building state. Re-attest the verified
+            # checkpoint with its current fence before requesting promotion.
+            evidence="$(jq -ce '.preview_checkpoint.evidence' server-resume-plan.json)"
+          else
+            evidence="$(jq -nc --arg url "$PREVIEW_URL" --arg artifact "$ARTIFACT_SHA256" --arg content "$CONTENT_ROOT_SHA256" --arg code "$EXACT_CODE_SHA" --arg contract "$RESUME_CONTRACT_VERSION" '{preview_url:$url,artifact_sha256:$artifact,content_sha256:$content,code_sha:$code,route_parity:true,resume_contract_version:($contract | if length > 0 then . else null end)}')"
+          fi
           node "$RUNNER_TEMP/content-release-helper.mjs" callback preview_verified "$evidence"
 
       - name: Request fenced production promotion

--- a/tests/worker/contentProductionConfig.test.js
+++ b/tests/worker/contentProductionConfig.test.js
@@ -79,7 +79,7 @@ describe("content production preflight", () => {
     );
     expect(validateWranglerDocuments(configuredWranglerDocuments())).toEqual({
       files: 7,
-      maximumInconsistencyMs: 120000,
+      maximumInconsistencyMs: 240000,
       minimumExactVerifierCount: 2,
       minimumVerifierCount: 3,
       stabilityOffsetsMs: [],

--- a/tests/worker/contentReleaseWorkflow.test.js
+++ b/tests/worker/contentReleaseWorkflow.test.js
@@ -1,7 +1,47 @@
-import { readFile } from "node:fs/promises";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { execFileSync } from "node:child_process";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 
 describe("fenced content release workflow", () => {
+  it("replays the trusted preview evidence through the current attempt callback", async () => {
+    const workflow = await readFile(
+      new URL("../../.github/workflows/content-release.yml", import.meta.url),
+      "utf8",
+    );
+    const step = workflow.split("      - name: Record Preview evidence\n")[1]
+      .split("\n      - name:")[0];
+    expect(step).not.toMatch(/^\s+if:/m);
+    const shell = step.split("        run: |\n")[1]
+      .split("\n").map((line) => line.replace(/^          /, "")).join("\n");
+    const directory = await mkdtemp(join(tmpdir(), "preview-resume-"));
+    const evidence = {
+      preview_url: "https://release-769.bubble-content-preview.pages.dev",
+      artifact_sha256: "a".repeat(64),
+      content_sha256: "b".repeat(64),
+      code_sha: "c".repeat(40),
+      route_parity: true,
+      resume_contract_version: "r2-materialize-v1",
+    };
+    try {
+      await writeFile(join(directory, "server-resume-plan.json"),
+        JSON.stringify({ preview_checkpoint: { evidence } }));
+      await writeFile(join(directory, "content-release-helper.mjs"),
+        "console.log(JSON.stringify(process.argv.slice(2)));");
+      const result = execFileSync("bash", ["-e", "-c", shell], {
+        cwd: directory,
+        env: { ...process.env, SERVER_RESUME_STAGE: "promote", RUNNER_TEMP: directory },
+        encoding: "utf8",
+      });
+      expect(JSON.parse(result)).toEqual([
+        "callback", "preview_verified", JSON.stringify(evidence),
+      ]);
+    } finally {
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+
   it("derives resume stages from the deployer and materializes R2 checkpoints", async () => {
     const [workflow, deployerConfig] = await Promise.all([
       readFile(
@@ -65,7 +105,10 @@ describe("fenced content release workflow", () => {
       /- name: Verify Preview route parity and exact bytes\n\s+if: \$\{\{ steps\.resume\.outputs\.stage == 'build' \|\| \(steps\.resume\.outputs\.stage == 'preview' && steps\.preview-reuse\.outputs\.reused != 'true'\) \}\}/,
     );
     expect(workflow).toMatch(
-      /- name: Record Preview evidence\n\s+if: \$\{\{ steps\.resume\.outputs\.stage != 'promote' \}\}/,
+      /- name: Record Preview evidence\n\s+run: \|/,
+    );
+    expect(workflow).toContain(
+      "jq -ce '.preview_checkpoint.evidence' server-resume-plan.json",
     );
     expect(workflow).toContain(
       "Materialize trusted Preview verification baseline",

--- a/wrangler.content-broker.toml
+++ b/wrangler.content-broker.toml
@@ -16,7 +16,7 @@ VERIFY_MIN_EXACT_ENDPOINTS = "2"
 # From production upload start through exact multi-origin convergence. Pending
 # origins are probed in parallel until this hard limit; exceeding it restores
 # the last-known-good release while leaving the database pointer unchanged.
-MAX_PRODUCTION_INCONSISTENCY_MS = "120000"
+MAX_PRODUCTION_INCONSISTENCY_MS = "240000"
 # Knowledge-base releases are immutable static artifacts. Exact multi-origin
 # verification runs before the pointer commits, and the scheduled reconciler
 # continues checking production afterwards, so no time-based hold is needed.


### PR DESCRIPTION
A release resumed from its verified preview checkpoint was left in the new attempt’s building state, so the production broker rejected it as stale. Replay the stored preview evidence through the current fenced callback before promotion.

Allow four minutes for the complete Pages upload and multi-origin confirmation; the first BrainPod upload exceeded the prior two-minute window. All identity and byte-verification gates remain enabled.

Validation: 801 tests passed, including execution of the resumed evidence callback; production broker dry run passed.
