### PR TITLE
fix: retry production attempts rejected before authorization

### DIFF
--- a/workers/content/broker/index.test.ts
+++ b/workers/content/broker/index.test.ts
@@ -379,6 +379,60 @@ describe("production coordinator", () => {
       attempts: 0,
     });
   });
+  it.each(["authorize_attempt", "verify_deployment", "commit_promotion"])("only rechecks failures before authorization: %s", async (stage) => {
+    const { state, values } = fakeCoordinatorState();
+    const attemptToken = "123e4567-e89b-42d3-a456-426614174088";
+    const payload = {
+      attempt_token: attemptToken,
+      execution_generation: 3,
+      site_release_id: "123e4567-e89b-42d3-a456-426614174001",
+    };
+    values.set(`production-operation:${attemptToken}`, {
+      id: attemptToken,
+      kind: "promote",
+      payload,
+      status: "completed",
+      attempts: 1,
+      created_at: "2026-01-01T00:00:00.000Z",
+      updated_at: new Date().toISOString(),
+      completed_at: new Date().toISOString(),
+      response_status: 503,
+      response_body: JSON.stringify({ error: "promotion_failed", stage, diagnostics: { errorMessage: "Stale production deployment attempt" } }),
+    });
+    values.set("production-operation-completed", [
+      {
+        id: attemptToken,
+        completed_at: new Date().toISOString(),
+      },
+    ]);
+    const coordinator = new ProductionCoordinator(
+      state,
+      {} as never,
+      vi.fn() as never,
+    );
+
+    const response = await coordinator.fetch(
+      new Request("https://coordinator.internal/internal/enqueue", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ kind: "promote", payload }),
+      }),
+    );
+
+    expect(response.status).toBe(202);
+    const retryable = stage === "authorize_attempt";
+    await expect(response.json()).resolves.toMatchObject({
+      operation_id: attemptToken,
+      deduplicated: !retryable,
+    });
+    expect(values.get("production-operation-queue")).toEqual(retryable ? [attemptToken] : undefined);
+    expect(values.get(`production-operation:${attemptToken}`)).toMatchObject({
+      id: attemptToken,
+      status: retryable ? "queued" : "completed",
+      attempts: retryable ? 0 : 1,
+    });
+  });
+
 });
 
 describe("asynchronous production promotion protocol", () => {

--- a/workers/content/broker/index.ts
+++ b/workers/content/broker/index.ts
@@ -2231,9 +2231,34 @@ export class ProductionCoordinator {
               idempotencyConflict = true;
               return;
             }
-            acceptedId = existing.id;
-            deduplicated = true;
-            return;
+            let failedBeforeAuthorization = false;
+            if (existing.status === "completed" && existing.response_status === 503) {
+              try {
+                const failure = JSON.parse(existing.response_body || "null");
+                failedBeforeAuthorization =
+                  failure?.error === "promotion_failed" &&
+                  failure?.stage === "authorize_attempt" &&
+                  failure?.diagnostics?.errorMessage === "Stale production deployment attempt";
+              } catch {
+                // An unknown result must retain its idempotency protection.
+              }
+            }
+            if (!failedBeforeAuthorization) {
+              acceptedId = existing.id;
+              deduplicated = true;
+              return;
+            }
+            // No promotion was authorized and no Pages write happened. A
+            // resumed workflow may now have restored preview_verified; let
+            // the database re-check this exact payload's current fence.
+            const completed =
+              (await transaction.get<CompletedCoordinatorOperation[]>(
+                COORDINATOR_COMPLETED_KEY,
+              )) || [];
+            await transaction.put(
+              COORDINATOR_COMPLETED_KEY,
+              completed.filter((item) => item.id !== id),
+            );
           }
         }
         if (kind === "reconcile") {


### PR DESCRIPTION
A resumed release could retain a cached stale-attempt rejection after its preview state was restored. Allow an identical signed promotion to re-enter authorization only when its prior result failed before authorization with that exact stale-attempt error. The database rechecks the current fence; successful operations, identity conflicts, and failures after authorization remain deduplicated.

Validation: 51 broker tests passed, including pre-authorization retry and post-authorization deduplication. The deployed fix completed production release 769; both APIs and both site origins converged on code 0e65d0599953dd043b69937967136f18d5dcdf84.
