### PR TITLE
fix: allow committed responsive image assets in automatic code releases

### DIFF
--- a/workers/content/deployer/index.test.ts
+++ b/workers/content/deployer/index.test.ts
@@ -909,6 +909,14 @@ describe("automatic code release boundary", () => {
             status: "added",
           },
           {
+            filename: "static/_responsive/media/workbuddy-tutorials/guide-640.avif",
+            status: "added",
+          },
+          {
+            filename: "astro/responsive-images.lock.json",
+            status: "modified",
+          },
+          {
             filename: "design-reference/knowledge-base.png",
             status: "added",
           },
@@ -935,7 +943,7 @@ describe("automatic code release boundary", () => {
           structuredCutoverDate: "2026-07-16",
         },
       ),
-    ).toHaveLength(11);
+    ).toHaveLength(13);
   });
 
   it("accepts BrainPod models, reading assets, and their source documentation", () => {

--- a/workers/content/deployer/index.ts
+++ b/workers/content/deployer/index.ts
@@ -437,9 +437,11 @@ function classifyCodeReleasePath(
       "content/workbuddy-tutorials/",
       "static/fonts/",
       "static/media/",
+      "static/_responsive/",
       "static/images/highlights/research-acceleration/",
     ].some((prefix) => path.startsWith(prefix)) ||
     [
+      "astro/responsive-images.lock.json",
       "astro/src/content.config.ts",
       "astro/src/data/changelog.ts",
       "astro/src/data/brainpodModel.json",


### PR DESCRIPTION
## Summary
- `Automatic Code Release` for 9b0d3aa was rejected with `unsafe_code_release: astro/responsive-images.lock.json`.
- Classify `static/_responsive/` and `astro/responsive-images.lock.json` as publishable in the deployer path allowlist, matching `static/media/`.

#### Test plan
- [x] `npx vitest run workers/content/deployer/index.test.ts` (53 passing, change-set test extended)
- [x] `npm run content:deployer:check`
- [ ] Redeploy deployer and re-dispatch Automatic Code Release for current main

Generated with [Devin](https://devin.ai)
