### PR TITLE
perf: replace per-object AWS CLI calls with a pooled R2 client

### DIFF
--- a/.github/workflows/content-release.yml
+++ b/.github/workflows/content-release.yml
@@ -379,7 +379,7 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_ARTIFACT_SECRET_ACCESS_KEY }}
           AWS_DEFAULT_REGION: auto
           R2_ENDPOINT: https://${{ secrets.CLOUDFLARE_ACCOUNT_ID }}.r2.cloudflarestorage.com
-          R2_UPLOAD_CONCURRENCY: "8"
+          R2_UPLOAD_CONCURRENCY: "32"
         run: |
           if [[ "$R2_INCREMENTAL_REUSE_ENABLED" == "true" ]]; then
             if jq -e '.trusted_baseline != null' server-resume-plan.json > /dev/null 2>&1; then

--- a/scripts/materialize-content-addressed-artifact.mjs
+++ b/scripts/materialize-content-addressed-artifact.mjs
@@ -2,7 +2,7 @@ import { createHash, randomUUID } from "node:crypto";
 import { mkdir, readFile, rename, rm, stat, writeFile } from "node:fs/promises";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import { AwsCliObjectStore } from "./upload-content-addressed-artifact.mjs";
+import { createObjectStore } from "./upload-content-addressed-artifact.mjs";
 
 const SHA256 = /^[a-f0-9]{64}$/;
 const SHA1 = /^[a-f0-9]{40}$/;
@@ -254,22 +254,23 @@ if (isMain) {
     ),
   );
   const descriptor = plan.artifact;
-  const store = new AwsCliObjectStore({
-    bucket: process.env.R2_ARTIFACT_BUCKET,
-    endpoint: process.env.R2_ENDPOINT,
-    aws: process.env.AWS_CLI || "aws",
-  });
-  const result = await materializeContentAddressedArtifact({
-    descriptor,
-    expectedSiteReleaseId: process.env.SITE_RELEASE_ID,
-    expectedCodeSha: process.env.EXACT_CODE_SHA,
-    expectedContentSha256: process.env.CONTENT_ROOT_SHA256,
-    targetRoot: positional[1] || "astro/dist/client",
-    store,
-    concurrency: process.env.R2_MATERIALIZE_CONCURRENCY || DEFAULT_CONCURRENCY,
-    includeFile: verificationBaseline
-      ? isPreviewVerificationBaselinePath
-      : undefined,
-  });
-  process.stdout.write(`${JSON.stringify(result)}\n`);
+  const store = createObjectStore();
+  try {
+    const result = await materializeContentAddressedArtifact({
+      descriptor,
+      expectedSiteReleaseId: process.env.SITE_RELEASE_ID,
+      expectedCodeSha: process.env.EXACT_CODE_SHA,
+      expectedContentSha256: process.env.CONTENT_ROOT_SHA256,
+      targetRoot: positional[1] || "astro/dist/client",
+      store,
+      concurrency:
+        process.env.R2_MATERIALIZE_CONCURRENCY || DEFAULT_CONCURRENCY,
+      includeFile: verificationBaseline
+        ? isPreviewVerificationBaselinePath
+        : undefined,
+    });
+    process.stdout.write(`${JSON.stringify(result)}\n`);
+  } finally {
+    await store.close();
+  }
 }

--- a/scripts/r2-object-store.mjs
+++ b/scripts/r2-object-store.mjs
@@ -1,0 +1,230 @@
+import { createHash, createHmac } from "node:crypto";
+import { Agent, fetch as undiciFetch } from "undici";
+
+const EMPTY_SHA256 =
+  "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
+const RETRYABLE_STATUSES = new Set([408, 429, 500, 502, 503, 504]);
+const DEFAULT_ATTEMPTS = 4;
+
+function sha256Hex(bytes) {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+function hmac(key, value) {
+  return createHmac("sha256", key).update(value, "utf8").digest();
+}
+
+function encodeSegment(segment) {
+  return encodeURIComponent(segment).replace(
+    /[!'()*]/g,
+    (character) => `%${character.charCodeAt(0).toString(16).toUpperCase()}`,
+  );
+}
+
+export function encodeObjectPath(bucket, key) {
+  return `/${[bucket, ...key.split("/")].map(encodeSegment).join("/")}`;
+}
+
+export function amzDate(date) {
+  return date
+    .toISOString()
+    .replace(/[-:]/g, "")
+    .replace(/\.\d{3}Z$/, "Z");
+}
+
+export function signV4({
+  method,
+  url,
+  headers,
+  payloadSha256,
+  accessKeyId,
+  secretAccessKey,
+  sessionToken,
+  region = "auto",
+  service = "s3",
+  date = new Date(),
+}) {
+  const target = new URL(url);
+  const timestamp = amzDate(date);
+  const scopeDate = timestamp.slice(0, 8);
+  const signed = new Map(
+    Object.entries(headers).map(([name, value]) => [
+      name.toLowerCase(),
+      String(value).trim().replace(/\s+/g, " "),
+    ]),
+  );
+  signed.set("host", target.host);
+  signed.set("x-amz-date", timestamp);
+  signed.set("x-amz-content-sha256", payloadSha256);
+  if (sessionToken) signed.set("x-amz-security-token", sessionToken);
+  const names = [...signed.keys()].sort();
+  const canonicalHeaders = names
+    .map((name) => `${name}:${signed.get(name)}\n`)
+    .join("");
+  const signedHeaders = names.join(";");
+  const canonicalQuery = [...target.searchParams.entries()]
+    .map(([name, value]) => [encodeSegment(name), encodeSegment(value)])
+    .sort(([left], [right]) => (left < right ? -1 : left > right ? 1 : 0))
+    .map(([name, value]) => `${name}=${value}`)
+    .join("&");
+  const canonicalRequest = [
+    method,
+    target.pathname,
+    canonicalQuery,
+    canonicalHeaders,
+    signedHeaders,
+    payloadSha256,
+  ].join("\n");
+  const scope = `${scopeDate}/${region}/${service}/aws4_request`;
+  const stringToSign = [
+    "AWS4-HMAC-SHA256",
+    timestamp,
+    scope,
+    sha256Hex(canonicalRequest),
+  ].join("\n");
+  const signingKey = hmac(
+    hmac(hmac(hmac(`AWS4${secretAccessKey}`, scopeDate), region), service),
+    "aws4_request",
+  );
+  const signature = createHmac("sha256", signingKey)
+    .update(stringToSign, "utf8")
+    .digest("hex");
+  const output = Object.fromEntries(
+    names
+      .filter((name) => name !== "host")
+      .map((name) => [name, signed.get(name)]),
+  );
+  output.authorization = `AWS4-HMAC-SHA256 Credential=${accessKeyId}/${scope}, SignedHeaders=${signedHeaders}, Signature=${signature}`;
+  return output;
+}
+
+export class R2RequestError extends Error {
+  constructor(message, { status, code, retryable }) {
+    super(message);
+    this.name = "R2RequestError";
+    this.status = status;
+    this.code = code;
+    this.retryable = retryable;
+  }
+}
+
+function errorCode(body) {
+  return body.match(/<Code>([^<]+)<\/Code>/)?.[1] || null;
+}
+
+function sleep(milliseconds) {
+  return new Promise((resolvePromise) =>
+    setTimeout(resolvePromise, milliseconds),
+  );
+}
+
+/**
+ * Minimal S3-compatible client for Cloudflare R2 that keeps one HTTP/1.1
+ * connection pool open for the whole run instead of spawning the AWS CLI for
+ * every object. It preserves the workflow's immutability contract: PUTs are
+ * conditional on `If-None-Match: *` and callers still GET-verify every object.
+ */
+export class R2ObjectStore {
+  constructor({
+    bucket,
+    endpoint,
+    accessKeyId = process.env.AWS_ACCESS_KEY_ID,
+    secretAccessKey = process.env.AWS_SECRET_ACCESS_KEY,
+    sessionToken = process.env.AWS_SESSION_TOKEN,
+    region = process.env.AWS_DEFAULT_REGION || "auto",
+    connections = 32,
+    attempts = DEFAULT_ATTEMPTS,
+    fetch = undiciFetch,
+    dispatcher,
+    now = () => new Date(),
+    allowInsecureEndpoint = false,
+  }) {
+    if (!bucket || !endpoint) {
+      throw new Error("R2 bucket and endpoint are required");
+    }
+    if (!accessKeyId || !secretAccessKey) {
+      throw new Error("R2 access key id and secret access key are required");
+    }
+    const origin = new URL(endpoint);
+    if (
+      (origin.protocol !== "https:" && !allowInsecureEndpoint) ||
+      origin.pathname !== "/" ||
+      origin.search
+    ) {
+      throw new Error("R2 endpoint must be an https origin");
+    }
+    this.bucket = bucket;
+    this.origin = origin.origin;
+    this.credentials = { accessKeyId, secretAccessKey, sessionToken, region };
+    this.attempts = attempts;
+    this.fetch = fetch;
+    this.now = now;
+    this.dispatcher =
+      dispatcher ||
+      new Agent({ connections, pipelining: 1, keepAliveTimeout: 30_000 });
+  }
+
+  async request(method, key, { body, headers = {} } = {}) {
+    const url = `${this.origin}${encodeObjectPath(this.bucket, key)}`;
+    const payloadSha256 = body ? sha256Hex(body) : EMPTY_SHA256;
+    let lastError;
+    for (let attempt = 1; attempt <= this.attempts; attempt += 1) {
+      const signedHeaders = signV4({
+        method,
+        url,
+        headers,
+        payloadSha256,
+        date: this.now(),
+        ...this.credentials,
+      });
+      let response;
+      try {
+        response = await this.fetch(url, {
+          method,
+          headers: signedHeaders,
+          body,
+          dispatcher: this.dispatcher,
+        });
+      } catch (error) {
+        lastError = new R2RequestError(
+          `R2 ${method} ${key} failed: ${error instanceof Error ? error.message : String(error)}`,
+          { status: 0, code: null, retryable: true },
+        );
+        if (attempt < this.attempts) {
+          await sleep(200 * 2 ** (attempt - 1));
+          continue;
+        }
+        throw lastError;
+      }
+      if (response.ok) return response;
+      const text = (await response.text()).slice(0, 2048);
+      const retryable = RETRYABLE_STATUSES.has(response.status);
+      lastError = new R2RequestError(
+        `R2 ${method} ${key} failed with ${response.status}${text ? `: ${text}` : ""}`,
+        { status: response.status, code: errorCode(text), retryable },
+      );
+      if (!retryable || attempt === this.attempts) throw lastError;
+      await sleep(200 * 2 ** (attempt - 1));
+    }
+    throw lastError;
+  }
+
+  async putIfAbsent(key, _localPath, bytes) {
+    if (!Buffer.isBuffer(bytes)) {
+      throw new Error("R2 putIfAbsent requires the object bytes");
+    }
+    await this.request("PUT", key, {
+      body: bytes,
+      headers: { "if-none-match": "*" },
+    });
+  }
+
+  async get(key) {
+    const response = await this.request("GET", key);
+    return Buffer.from(await response.arrayBuffer());
+  }
+
+  async close() {
+    await this.dispatcher.close();
+  }
+}

--- a/scripts/upload-content-addressed-artifact.mjs
+++ b/scripts/upload-content-addressed-artifact.mjs
@@ -3,6 +3,7 @@ import { spawn } from "node:child_process";
 import { readFile, realpath, stat } from "node:fs/promises";
 import { relative, resolve, sep } from "node:path";
 import { fileURLToPath } from "node:url";
+import { R2ObjectStore } from "./r2-object-store.mjs";
 
 const SHA256 = /^[a-f0-9]{64}$/;
 const MAX_FILES = 20_000;
@@ -161,6 +162,19 @@ function runCommand(command, args) {
   });
 }
 
+/**
+ * Selects the R2 client for release scripts. The native client keeps a
+ * connection pool open for the whole run; the AWS CLI client remains as an
+ * explicit fallback (`R2_STORE_CLIENT=aws-cli`) with identical semantics.
+ */
+export function createObjectStore(env = process.env) {
+  const options = { bucket: env.R2_ARTIFACT_BUCKET, endpoint: env.R2_ENDPOINT };
+  if (env.R2_STORE_CLIENT === "aws-cli") {
+    return new AwsCliObjectStore({ ...options, aws: env.AWS_CLI || "aws" });
+  }
+  return new R2ObjectStore(options);
+}
+
 export class AwsCliObjectStore {
   constructor({ bucket, endpoint, aws = "aws" }) {
     if (!bucket || !endpoint) {
@@ -232,6 +246,8 @@ export class AwsCliObjectStore {
     });
     return Buffer.concat(chunks);
   }
+
+  async close() {}
 }
 
 async function loadPlan(manifestPath, distRoot, expectedManifestSha256) {
@@ -412,11 +428,7 @@ const isMain =
 if (isMain) {
   const manifestPath = process.argv[2] || "content-release-artifact.json";
   const distRoot = process.argv[3] || "astro/dist/client";
-  const store = new AwsCliObjectStore({
-    bucket: process.env.R2_ARTIFACT_BUCKET,
-    endpoint: process.env.R2_ENDPOINT,
-    aws: process.env.AWS_CLI || "aws",
-  });
+  const store = createObjectStore();
   const incrementalReuseEnabled =
     process.env.R2_INCREMENTAL_REUSE_ENABLED === "true";
   let trustedBaseline = null;
@@ -432,22 +444,26 @@ if (isMain) {
       manifestBytes: await readFile(process.env.R2_TRUSTED_BASE_MANIFEST_PATH),
     };
   }
-  const result = await uploadContentAddressedArtifact({
-    manifestPath,
-    distRoot,
-    artifactObjectKey: process.env.ARTIFACT_OBJECT_KEY,
-    expectedManifestSha256: process.env.ARTIFACT_SHA256,
-    incrementalReuseEnabled,
-    trustedBaseline,
-    concurrency: process.env.R2_UPLOAD_CONCURRENCY || DEFAULT_CONCURRENCY,
-    store,
-    onProgress: ({ completed, total, disposition }) => {
-      if (completed === total || completed % 100 === 0) {
-        process.stderr.write(
-          `Verified ${completed}/${total} immutable R2 objects (${disposition})\n`,
-        );
-      }
-    },
-  });
-  process.stdout.write(`${JSON.stringify(result)}\n`);
+  try {
+    const result = await uploadContentAddressedArtifact({
+      manifestPath,
+      distRoot,
+      artifactObjectKey: process.env.ARTIFACT_OBJECT_KEY,
+      expectedManifestSha256: process.env.ARTIFACT_SHA256,
+      incrementalReuseEnabled,
+      trustedBaseline,
+      concurrency: process.env.R2_UPLOAD_CONCURRENCY || DEFAULT_CONCURRENCY,
+      store,
+      onProgress: ({ completed, total, disposition }) => {
+        if (completed === total || completed % 100 === 0) {
+          process.stderr.write(
+            `Verified ${completed}/${total} immutable R2 objects (${disposition})\n`,
+          );
+        }
+      },
+    });
+    process.stdout.write(`${JSON.stringify(result)}\n`);
+  } finally {
+    await store.close();
+  }
 }

--- a/tests/worker/r2ObjectStore.test.js
+++ b/tests/worker/r2ObjectStore.test.js
@@ -1,0 +1,191 @@
+import { createHash } from "node:crypto";
+import { createServer } from "node:http";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  R2ObjectStore,
+  encodeObjectPath,
+  signV4,
+} from "../../scripts/r2-object-store.mjs";
+
+const servers = [];
+
+afterEach(async () => {
+  await Promise.all(
+    servers
+      .splice(0)
+      .map((server) => new Promise((resolve) => server.close(resolve))),
+  );
+});
+
+function sha256(bytes) {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+describe("SigV4 signing", () => {
+  it("reproduces the AWS documented GET object signature", () => {
+    // https://docs.aws.amazon.com/AmazonS3/latest/API/sig-v4-header-based-auth.html
+    const headers = signV4({
+      method: "GET",
+      url: "https://examplebucket.s3.amazonaws.com/test.txt",
+      headers: { range: "bytes=0-9" },
+      payloadSha256: sha256(""),
+      accessKeyId: "AKIAIOSFODNN7EXAMPLE",
+      secretAccessKey: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+      region: "us-east-1",
+      date: new Date("2013-05-24T00:00:00Z"),
+    });
+    expect(headers.authorization).toBe(
+      "AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE/20130524/us-east-1/s3/aws4_request, SignedHeaders=host;range;x-amz-content-sha256;x-amz-date, Signature=f0e8bdb87c964420e857bd35b5d6ed310bd44f0170aba48dd91039c6036bdb41",
+    );
+  });
+
+  it("encodes object keys per path segment", () => {
+    expect(encodeObjectPath("bucket", "assets/sha256/ab cd*(1)")).toBe(
+      "/bucket/assets/sha256/ab%20cd%2A%281%29",
+    );
+  });
+});
+
+async function fakeR2(handler) {
+  const requests = [];
+  const server = createServer(async (request, response) => {
+    const chunks = [];
+    for await (const chunk of request) chunks.push(chunk);
+    const body = Buffer.concat(chunks);
+    requests.push({
+      method: request.method,
+      url: request.url,
+      headers: request.headers,
+      body,
+    });
+    await handler(request, response, body, requests.length);
+  });
+  servers.push(server);
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  return {
+    requests,
+    endpoint: `http://127.0.0.1:${server.address().port}`,
+  };
+}
+
+function store(endpoint, overrides = {}) {
+  return new R2ObjectStore({
+    bucket: "artifacts",
+    endpoint,
+    accessKeyId: "a".repeat(24),
+    secretAccessKey: "b".repeat(40),
+    attempts: 3,
+    allowInsecureEndpoint: true,
+    ...overrides,
+  });
+}
+
+describe("R2ObjectStore", () => {
+  it("issues a signed conditional PUT and a GET on one connection pool", async () => {
+    const objects = new Map();
+    const fake = await fakeR2((request, response, body) => {
+      const key = decodeURIComponent(request.url.replace("/artifacts/", ""));
+      if (request.method === "PUT") {
+        if (objects.has(key)) {
+          response.writeHead(412);
+          response.end("<Error><Code>PreconditionFailed</Code></Error>");
+          return;
+        }
+        objects.set(key, body);
+        response.writeHead(200);
+        response.end();
+        return;
+      }
+      const bytes = objects.get(key);
+      response.writeHead(bytes ? 200 : 404);
+      response.end(bytes);
+    });
+    const client = store(fake.endpoint);
+    const payload = Buffer.from("immutable asset");
+    const key = `assets/sha256/${sha256(payload)}`;
+    try {
+      await client.putIfAbsent(key, null, payload);
+      await expect(client.get(key)).resolves.toEqual(payload);
+      await expect(
+        client.putIfAbsent(key, null, payload),
+      ).rejects.toMatchObject({
+        status: 412,
+        code: "PreconditionFailed",
+        retryable: false,
+      });
+    } finally {
+      await client.close();
+    }
+    const [put, get] = fake.requests;
+    expect(put.headers["if-none-match"]).toBe("*");
+    expect(put.headers["x-amz-content-sha256"]).toBe(sha256(payload));
+    expect(put.headers.authorization).toMatch(
+      /^AWS4-HMAC-SHA256 Credential=a{24}\/\d{8}\/auto\/s3\/aws4_request, SignedHeaders=host;if-none-match;x-amz-content-sha256;x-amz-date, Signature=[0-9a-f]{64}$/,
+    );
+    expect(get.method).toBe("GET");
+    expect(get.headers.authorization).toContain(
+      "SignedHeaders=host;x-amz-content-sha256;x-amz-date",
+    );
+    expect(fake.requests).toHaveLength(3);
+  });
+
+  it("retries transient failures but not precondition or client errors", async () => {
+    let attempts = 0;
+    const fake = await fakeR2((request, response) => {
+      attempts += 1;
+      if (attempts === 1) {
+        response.writeHead(503);
+        response.end("<Error><Code>SlowDown</Code></Error>");
+        return;
+      }
+      response.writeHead(200);
+      response.end("ok");
+    });
+    const client = store(fake.endpoint);
+    try {
+      await expect(client.get("assets/sha256/x")).resolves.toEqual(
+        Buffer.from("ok"),
+      );
+      expect(attempts).toBe(2);
+    } finally {
+      await client.close();
+    }
+
+    const denied = await fakeR2((request, response) => {
+      response.writeHead(403);
+      response.end("<Error><Code>AccessDenied</Code></Error>");
+    });
+    const deniedClient = store(denied.endpoint);
+    try {
+      await expect(deniedClient.get("assets/sha256/x")).rejects.toMatchObject({
+        status: 403,
+        code: "AccessDenied",
+        retryable: false,
+      });
+      expect(denied.requests).toHaveLength(1);
+    } finally {
+      await deniedClient.close();
+    }
+  });
+
+  it("requires an https origin endpoint outside tests", () => {
+    expect(
+      () =>
+        new R2ObjectStore({
+          bucket: "artifacts",
+          endpoint: "http://account.r2.cloudflarestorage.com",
+          accessKeyId: "a",
+          secretAccessKey: "b",
+        }),
+    ).toThrow("https origin");
+    expect(
+      () =>
+        new R2ObjectStore({
+          bucket: "artifacts",
+          endpoint: "https://account.r2.cloudflarestorage.com/bucket",
+          accessKeyId: "a",
+          secretAccessKey: "b",
+        }),
+    ).toThrow("https origin");
+  });
+});


### PR DESCRIPTION
## Summary
- New `scripts/r2-object-store.mjs`: SigV4-signed S3 client over one `undici` connection pool (32 connections, retries on 408/429/5xx/network, never on 412/4xx).
- `upload-content-addressed-artifact.mjs` and `materialize-content-addressed-artifact.mjs` use it via `createObjectStore()`; `R2_STORE_CLIENT=aws-cli` restores the previous AWS CLI implementation unchanged.
- Verification contract is unchanged: conditional `PUT If-None-Match: *`, then full `GET` + sha256 + byte comparison for every object (`r2-full-get-sha256-indefinite-lock-v1`).
- `R2_UPLOAD_CONCURRENCY` 8 -> 32 (materialize already 32).

Evidence: run 34148686795 (after #375/#376) spent 15m22s in "Upload immutable content-addressed R2 artifact" at ~0.4s/object with 8 concurrency; earlier runs showed identical per-object cost at 32 concurrency, i.e. the bottleneck is process spawn, not R2.

#### Test plan
- [x] SigV4 reproduces the AWS-documented GET example signature
- [x] Local fake R2: signed conditional PUT, GET, 412 surfaces as non-retryable, 503 retried once, 403 not retried
- [x] `npm test` (811 passing)
- [ ] First `Exact Content Release` after merge: confirm R2 step succeeds and note duration; if it fails, set repo var / step env `R2_STORE_CLIENT=aws-cli` to fall back

Generated with [Devin](https://devin.ai)
