### PR TITLE
fix: classify scripts/r2-object-store.mjs as an inert release script

### DIFF
--- a/workers/content/deployer/index.ts
+++ b/workers/content/deployer/index.ts
@@ -269,6 +269,7 @@ const INERT_ROOT_SCRIPTS = new Set([
   "scripts/materialize-content-addressed-artifact.mjs",
   "scripts/preview-media-types.mjs",
   "scripts/pull-daily-content.sh",
+  "scripts/r2-object-store.mjs",
   "scripts/request-code-release.mjs",
   "scripts/request-content-release-plan.mjs",
   "scripts/request-production-promotion.mjs",


### PR DESCRIPTION
Automatic Code Release for c1dae53 was rejected: unknown path scripts/r2-object-store.mjs. It is a workflow-only helper like the other release scripts, so it is inert for the site build.

Generated with [Devin](https://devin.ai)