### PR TITLE
feat: show unread dots per article and shorten the first-visit window

### DIFF
--- a/astro/src/components/BrainPodCollectionHome.astro
+++ b/astro/src/components/BrainPodCollectionHome.astro
@@ -125,7 +125,17 @@ const previewLimit = 5;
 													target={item.external ? '_blank' : undefined}
 													rel={item.external ? 'noopener noreferrer' : undefined}
 												>
-													<span>{item.title}</span>
+													<span>
+														{item.title}
+														<span
+															class="reading-update-dot"
+															data-update-item={item.key}
+															role="img"
+															aria-label="未读更新"
+															title="未读更新"
+															hidden
+														/>
+													</span>
 													<i class="ph ph-arrow-up-right" aria-hidden="true" />
 												</a>
 											</li>

--- a/astro/src/lib/readingUpdates.test.ts
+++ b/astro/src/lib/readingUpdates.test.ts
@@ -54,11 +54,12 @@ describe('reading updates', () => {
 		expect(updates[0].item.date).toBe('2020-01-01');
 		expect(buildReadingUpdates([a], [])).toEqual([]);
 	});
-	it('shows the first seven days, keeps unread items across visits, and hides read or future updates', () => {
+	it('shows the first three days, keeps unread items across visits, and hides read or future updates', () => {
 		const history = initialReadingHistory(now);
+		expect(history.since).toBe('2026-09-04');
 		const updates = [
 			{ item: a, recordedAt: '2026-09-06' },
-			{ item: b, recordedAt: '2026-08-20' },
+			{ item: b, recordedAt: '2026-09-03' },
 			{ item: item('/future/'), recordedAt: '2026-09-08' },
 		];
 		expect(unreadReadingUpdates(updates, history, now).map((u) => u.item.key)).toEqual(['/a/']);

--- a/astro/src/lib/readingUpdates.ts
+++ b/astro/src/lib/readingUpdates.ts
@@ -35,7 +35,7 @@ export interface ReadingHistory {
 }
 
 export function initialReadingHistory(now = new Date()): ReadingHistory {
-	return { since: new Date(now.getTime() - 7 * 86400000).toISOString().slice(0, 10), read: {} };
+	return { since: new Date(now.getTime() - 3 * 86400000).toISOString().slice(0, 10), read: {} };
 }
 
 export function unreadReadingUpdates(

--- a/astro/src/scripts/brainpod.ts
+++ b/astro/src/scripts/brainpod.ts
@@ -241,7 +241,7 @@ export function mountBrainPod(root: HTMLElement): () => void {
 						.slice(start, start + 5)
 						.map(
 							(r, i) =>
-								`<button class="lcd-row" data-row="${i + start}" aria-current="${i + start === p.selected}" title="${escapeHTML(r.title)}"><span>${escapeHTML(r.title)}</span>${isCollection(r) ? `<span class="row-count">${r.items.length}</span>` : ''}<span class="row-chevron">›</span></button>`,
+								`<button class="lcd-row" data-row="${i + start}" aria-current="${i + start === p.selected}" title="${escapeHTML(r.title)}"><span>${escapeHTML(r.title)}</span>${isCollection(r) ? `<span class="row-count">${r.items.length}</span>` : `<span class="reading-update-dot" data-update-item="${escapeHTML(r.key)}" role="img" aria-label="未读更新" hidden></span>`}<span class="row-chevron">›</span></button>`,
 						)
 						.join('')
 				: '<div class="lcd-detail"><p>这里的内容正在整理中。</p></div>';
@@ -261,6 +261,7 @@ export function mountBrainPod(root: HTMLElement): () => void {
 						? '确认阅读 · MENU 返回'
 						: '中央键查看';
 		updateSelectButton();
+		refreshReadingIndicators();
 		if (entry) {
 			if (!isCollection(entry) || entry.id !== 'recent-updates')
 				root.dataset.brainpodCollection = isCollection(entry) ? entry.id : entry.section;

--- a/astro/src/scripts/readingUpdates.ts
+++ b/astro/src/scripts/readingUpdates.ts
@@ -47,6 +47,9 @@ export function refreshReadingIndicators() {
 		const sections = dot.dataset.updateSections?.split(' ') ?? [];
 		dot.hidden = !unread.some((update) => sections.includes(update.item.section));
 	}
+	for (const dot of document.querySelectorAll<HTMLElement>('[data-update-item]')) {
+		dot.hidden = !unread.some((update) => update.item.key === dot.dataset.updateItem);
+	}
 }
 
 function init() {
@@ -69,7 +72,9 @@ document.addEventListener('click', (event) => {
 	if (!payload?.textContent) return;
 	try {
 		const updates: ReadingUpdate[] = JSON.parse(payload.textContent).updates ?? [];
-		const update = updates.find((update) => update.item.external && update.item.href === link.href);
+		const update = updates.find(
+			(update) => new URL(update.item.href, location.origin).href === link.href,
+		);
 		if (update) markReadingUpdateSeen(update.item.key);
 	} catch {
 		/* Invalid optional metadata must not interrupt navigation. */

--- a/astro/src/styles/brainpod.css
+++ b/astro/src/styles/brainpod.css
@@ -1619,6 +1619,17 @@
 	text-align: right;
 	font-variant-numeric: tabular-nums;
 }
+.brainpod .lcd-row .reading-update-dot {
+	display: inline-block;
+	width: 6px;
+	height: 6px;
+	flex-shrink: 0;
+	border-radius: 50%;
+	background: #2162cc;
+}
+.brainpod .lcd-row[aria-current='true'] .reading-update-dot {
+	background: #fff;
+}
 .brainpod .lcd-row .row-chevron {
 	font-size: 24px;
 	font-weight: 400;


### PR DESCRIPTION
## Summary
- Article rows in the collection browser (`BrainPodCollectionHome.astro`) and iPod LCD rows (`brainpod.ts`) get a `.reading-update-dot[data-update-item]` bound to the article key; `refreshReadingIndicators` toggles them alongside the existing section dots.
- Clicking any link whose href matches an updated article marks it read at once (previously only external links and article page load did), so the dot is gone when you navigate back.
- `initialReadingHistory` window: 7 days -> 3 days.

#### Test plan
- [x] `readingUpdates.test.ts` updated for the 3-day window
- [x] `astro check`, `eslint`, `build`, `verify:csp`, `verify:site`
- [x] Manual in `astro preview`: fresh localStorage shows dots on the two 2026-09-06 highlights only; opening one and going back clears its dot, section dot persists while another remains unread; iPod list rows show the same state
- Note: dots depend on the library payload, which only exists on the home page; "查看全部" list pages are unchanged.

Generated with [Devin](https://devin.ai)
