### PR TITLE
fix: stop serving stale retired collection directories

### DIFF
--- a/.github/workflows/automatic-code-release.yml
+++ b/.github/workflows/automatic-code-release.yml
@@ -82,3 +82,11 @@ jobs:
 
       - name: Request and verify production code release
         run: node scripts/request-code-release.mjs
+
+      - name: Setup Node.js for retired route verification
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.17.0
+
+      - name: Verify retired directories on ordinary public URLs
+        run: node --experimental-strip-types workers/retired-collections/verify.mjs

--- a/.github/workflows/worker-ci.yml
+++ b/.github/workflows/worker-ci.yml
@@ -28,7 +28,9 @@ jobs:
           cache: npm
 
       - name: Install dependencies
-        run: npm ci
+        run: |
+          npm ci
+          npm ci --prefix astro
 
       - name: Run Worker security tests
         run: npm run test:worker

--- a/.github/workflows/worker-ci.yml
+++ b/.github/workflows/worker-ci.yml
@@ -48,6 +48,7 @@ jobs:
           npm run admin:check
           npm run content:deployer:check
           npm run content:broker:check
+          npx wrangler deploy --dry-run --config workers/retired-collections/wrangler.toml
 
   astro-verify:
     runs-on: ubuntu-latest

--- a/workers/retired-collections/README.md
+++ b/workers/retired-collections/README.md
@@ -1,0 +1,30 @@
+# Retired collection directories
+
+The nine Chinese collection indexes live only in homepage sections. This Worker
+enforces real `404` responses on their exact former paths before the Pages asset
+cache can return an old directory. It does not redirect, render a compatibility
+directory, or intercept article subpaths. The route list is checked against the
+site's collection directory contract by the unit test.
+
+On 2026-09-11, release 774 removed the old index assets. The Pages production and
+deployment domains returned 404, while ordinary custom-domain index URLs returned
+old 200 responses with `CF-Cache-Status: DYNAMIC`, `Age`, and a one-week shared TTL.
+Adding a query parameter returned 404. A zone Purge Everything request was captured
+returning HTTP 200, `success: true`, and no errors, but the old responses persisted.
+The exact upstream cache layer was not established. This Worker is a scoped
+containment measure, not evidence that the upstream cache defect was fixed.
+
+After merging and successful CI, deploy with:
+
+```sh
+npx wrangler deploy --config workers/retired-collections/wrangler.toml
+node --experimental-strip-types workers/retired-collections/verify.mjs
+```
+
+The post-release check intentionally uses bare URLs and rejects redirects. Do not
+add cache-busting parameters. The Pages site itself still uses the content release
+pipeline; this Worker has no content, secrets, storage, or Pages deployment rights.
+
+To remove this containment after the underlying cache behavior is resolved, remove
+only this Worker's nine routes, then run the bare-URL verifier again. Do not change
+the existing daily tombstone route or DNS bindings.

--- a/workers/retired-collections/index.test.ts
+++ b/workers/retired-collections/index.test.ts
@@ -1,0 +1,43 @@
+import { readFileSync } from "node:fs";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { collectionDirectories } from "../../astro/src/lib/collectionRoutes";
+import worker from "./index";
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe("retired collection responses", () => {
+  it("returns an uncached 404 without consulting a stale origin", async () => {
+    const upstream = vi.fn(() => new Response("stale directory"));
+    vi.stubGlobal("fetch", upstream);
+    for (const path of Object.keys(collectionDirectories)) {
+      for (const suffix of ["", "?page=2"]) {
+        const response = await worker.fetch(new Request(`https://bubblenews.today${path}${suffix}`));
+        expect(response.status).toBe(404);
+        expect(response.headers.get("cache-control")).toBe("no-store");
+        expect(response.headers.get("location")).toBeNull();
+        expect(await response.text()).not.toContain("stale directory");
+      }
+    }
+    expect(upstream).not.toHaveBeenCalled();
+  });
+
+  it("preserves HEAD semantics and leaves details and English routes alone", async () => {
+    const head = await worker.fetch(new Request("https://bubblenews.today/workbuddy-tutorials/", { method: "HEAD" }));
+    expect(head.status).toBe(404);
+    expect(await head.text()).toBe("");
+    const upstream = vi.fn(() => new Response("article", { status: 200 }));
+    vi.stubGlobal("fetch", upstream);
+    for (const path of ["/", "/workbuddy-tutorials/workbuddy-feishu-workflow-guide/", "/benchmarks/aa-index/", "/en/newbie-tutorials/"]) {
+      const request = new Request(`https://bubblenews.today${path}`);
+      expect(await (await worker.fetch(request)).text()).toBe("article");
+      expect(upstream).toHaveBeenLastCalledWith(request);
+    }
+  });
+
+  it("deploys only the nine exact directory paths, without article wildcards", () => {
+    const config = readFileSync("workers/retired-collections/wrangler.toml", "utf8");
+    const paths = [...config.matchAll(/pattern = "bubblenews\.today([^"]+)"/g)].map(match => match[1]);
+    expect(paths.sort()).toEqual(Object.keys(collectionDirectories).sort());
+    expect(paths.every(path => !path.includes("*"))).toBe(true);
+  });
+});

--- a/workers/retired-collections/index.ts
+++ b/workers/retired-collections/index.ts
@@ -1,0 +1,20 @@
+import { isRetiredDirectory } from "../../astro/src/lib/collectionRoutes";
+
+// Enforce removed directories before the Pages asset cache can serve an old copy.
+// These are exact Worker routes; article subpaths remain owned by Pages.
+export default {
+  async fetch(request: Request): Promise<Response> {
+    const path = new URL(request.url).pathname;
+    if (!isRetiredDirectory(path)) return fetch(request);
+    return new Response(request.method === "HEAD" ? null :
+      '<!doctype html><html lang="zh-CN"><meta charset="utf-8"><meta name="viewport" content="width=device-width"><title>404 · Bubble\'s Brain</title><h1>404</h1><p>此页面不存在。</p><a href="/">返回首页</a></html>', {
+      status: 404,
+      headers: {
+        "Content-Type": "text/html; charset=utf-8",
+        "Cache-Control": "no-store",
+        "X-Robots-Tag": "noindex",
+        "X-Content-Type-Options": "nosniff",
+      },
+    });
+  },
+};

--- a/workers/retired-collections/verify.mjs
+++ b/workers/retired-collections/verify.mjs
@@ -1,0 +1,14 @@
+import { collectionDirectories } from "../../astro/src/lib/collectionRoutes.ts";
+
+const origins = process.argv.slice(2);
+if (!origins.length) origins.push("https://bubblenews.today", "https://ai-bubblebrain-daily-news.pages.dev");
+for (const origin of origins) {
+  for (const path of [...Object.keys(collectionDirectories), "/highlights/2025/"]) {
+    // Intentionally no cache-busting query: this must test an ordinary visitor's URL.
+    const url = new URL(path, origin);
+    const response = await fetch(url, { redirect: "manual", signal: AbortSignal.timeout(30000) });
+    await response.body?.cancel();
+    if (response.status !== 404) throw new Error(`${url}: expected 404, received ${response.status}`);
+    console.log(`404 ${url}`);
+  }
+}

--- a/workers/retired-collections/wrangler.toml
+++ b/workers/retired-collections/wrangler.toml
@@ -1,0 +1,18 @@
+name = "bubble-retired-collections"
+main = "index.ts"
+compatibility_date = "2026-09-11"
+workers_dev = false
+preview_urls = false
+
+# Exact retired paths only. Do not append wildcards: article routes belong to Pages.
+routes = [
+  { pattern = "bubblenews.today/newbie-tutorials/", zone_name = "bubblenews.today" },
+  { pattern = "bubblenews.today/codex-tutorials/", zone_name = "bubblenews.today" },
+  { pattern = "bubblenews.today/pi-agent-tutorials/", zone_name = "bubblenews.today" },
+  { pattern = "bubblenews.today/workbuddy-tutorials/", zone_name = "bubblenews.today" },
+  { pattern = "bubblenews.today/highlights/", zone_name = "bubblenews.today" },
+  { pattern = "bubblenews.today/vibe-coding/terms/", zone_name = "bubblenews.today" },
+  { pattern = "bubblenews.today/vibe-coding/skills/", zone_name = "bubblenews.today" },
+  { pattern = "bubblenews.today/vibe-coding/design/", zone_name = "bubblenews.today" },
+  { pattern = "bubblenews.today/benchmarks/", zone_name = "bubblenews.today" },
+]


### PR DESCRIPTION
Retired Chinese collection directory URLs still return stale 200 pages on the custom domain after release 774, even though both Pages origins return 404. A captured zone Purge Everything response reports success, but the bare URLs remain stale.

Return 404 with no-store through a Worker attached only to the nine exact retired directory URLs. Homepage sections remain the sole directories; article subpaths and query requests remain served by Pages. This contains the stale-response problem without redirects and does not claim to repair the unidentified upstream cache layer.

Add CI bundling and post-release verification that checks ordinary bare URLs on both production domains, with no cache-busting query and no followed redirects. The Worker is deployed separately after merge.

Validation: three focused tests pass, Wrangler dry-run passes, diff check passes. The new public verifier reproduces the existing 200 failure before deployment. Independent review confirms exact route scope and Node compatibility.
