### PR TITLE
fix: retire the stale highlights year archive

### DIFF
--- a/workers/retired-collections/README.md
+++ b/workers/retired-collections/README.md
@@ -1,7 +1,8 @@
 # Retired collection directories
 
 The nine Chinese collection indexes live only in homepage sections. This Worker
-enforces real `404` responses on their exact former paths before the Pages asset
+enforces real `404` responses on their exact former paths and the retired 2025
+Highlights archive before the Pages asset
 cache can return an old directory. It does not redirect, render a compatibility
 directory, or intercept article subpaths. The route list is checked against the
 site's collection directory contract by the unit test.
@@ -11,6 +12,8 @@ deployment domains returned 404, while ordinary custom-domain index URLs returne
 old 200 responses with `CF-Cache-Status: DYNAMIC`, `Age`, and a one-week shared TTL.
 Adding a query parameter returned 404. A zone Purge Everything request was captured
 returning HTTP 200, `success: true`, and no errors, but the old responses persisted.
+Post-deployment checks from another connection also caught a stale 200 for
+`/highlights/2025/`, so that exact archive path is included as well.
 The exact upstream cache layer was not established. This Worker is a scoped
 containment measure, not evidence that the upstream cache defect was fixed.
 
@@ -26,5 +29,5 @@ add cache-busting parameters. The Pages site itself still uses the content relea
 pipeline; this Worker has no content, secrets, storage, or Pages deployment rights.
 
 To remove this containment after the underlying cache behavior is resolved, remove
-only this Worker's nine routes, then run the bare-URL verifier again. Do not change
+only this Worker's ten routes, then run the bare-URL verifier again. Do not change
 the existing daily tombstone route or DNS bindings.

--- a/workers/retired-collections/index.test.ts
+++ b/workers/retired-collections/index.test.ts
@@ -9,7 +9,7 @@ describe("retired collection responses", () => {
   it("returns an uncached 404 without consulting a stale origin", async () => {
     const upstream = vi.fn(() => new Response("stale directory"));
     vi.stubGlobal("fetch", upstream);
-    for (const path of Object.keys(collectionDirectories)) {
+    for (const path of [...Object.keys(collectionDirectories), "/highlights/2025/"]) {
       for (const suffix of ["", "?page=2"]) {
         const response = await worker.fetch(new Request(`https://bubblenews.today${path}${suffix}`));
         expect(response.status).toBe(404);
@@ -34,10 +34,10 @@ describe("retired collection responses", () => {
     }
   });
 
-  it("deploys only the nine exact directory paths, without article wildcards", () => {
+  it("deploys only the exact directories and retired year archive, without article wildcards", () => {
     const config = readFileSync("workers/retired-collections/wrangler.toml", "utf8");
     const paths = [...config.matchAll(/pattern = "bubblenews\.today([^"]+)"/g)].map(match => match[1]);
-    expect(paths.sort()).toEqual(Object.keys(collectionDirectories).sort());
+    expect(paths.sort()).toEqual([...Object.keys(collectionDirectories), "/highlights/2025/"].sort());
     expect(paths.every(path => !path.includes("*"))).toBe(true);
   });
 });

--- a/workers/retired-collections/wrangler.toml
+++ b/workers/retired-collections/wrangler.toml
@@ -11,6 +11,7 @@ routes = [
   { pattern = "bubblenews.today/pi-agent-tutorials/", zone_name = "bubblenews.today" },
   { pattern = "bubblenews.today/workbuddy-tutorials/", zone_name = "bubblenews.today" },
   { pattern = "bubblenews.today/highlights/", zone_name = "bubblenews.today" },
+  { pattern = "bubblenews.today/highlights/2025/", zone_name = "bubblenews.today" },
   { pattern = "bubblenews.today/vibe-coding/terms/", zone_name = "bubblenews.today" },
   { pattern = "bubblenews.today/vibe-coding/skills/", zone_name = "bubblenews.today" },
   { pattern = "bubblenews.today/vibe-coding/design/", zone_name = "bubblenews.today" },


### PR DESCRIPTION
The bare-URL production verifier caught `/highlights/2025/` still serving an old 200 response on a direct connection after the nine primary directories were fixed. This is the only former year archive generated by the removed route.

Add the exact 2025 archive path to the existing retirement Worker and route-scope tests. Article URLs remain untouched; no wildcard or redirect is added. The public verifier already includes this path.

Validation: three scoped tests pass; Wrangler dry-run and diff check pass. The failing production response was captured before this update.
